### PR TITLE
add Makefile and support compiling libvgpu.so in docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := build
+
+current_dir := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
+
+build:
+	sh ./build.sh
+.PHONY: build
+
+build-in-docker:
+	docker run -it --rm \
+		-v $(current_dir):/libvgpu \
+		-w /libvgpu \
+		-e DEBIAN_FRONTEND=noninteractive \
+		nvidia/cuda:12.2.0-devel-ubuntu20.04 \
+		sh -c "apt-get -y update; apt-get -y install cmake; bash ./build.sh"
+.PHONY: build-in-docker

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ HAMi-core operates by Hijacking the API-call between CUDA-Runtime(libcudart.so) 
 ## Build
 
 ```bash
-sh build.sh
+make
 ```
 
 ## Build in Docker
 
 ```bash
-docker build . -f dockerfiles/Dockerfile
+make build-in-docker
 ```
 
 ## Usage


### PR DESCRIPTION
- add Makefile
- `make build-in-docker`: compile code in docker container and output the results to the local `build` folder.
