### PR TITLE
fix multiprocess_utilization_watcher

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -93,7 +93,7 @@ typedef struct {
     int32_t sm_init_flag;
     size_t owner_pid;
     sem_t sem;
-    uint64_t num;
+    uint64_t device_num;
     uuid uuids[CUDA_DEVICE_MAX_COUNT];
     uint64_t limit[CUDA_DEVICE_MAX_COUNT];
     uint64_t sm_limit[CUDA_DEVICE_MAX_COUNT];
@@ -143,7 +143,7 @@ int set_env_utilization_switch();
 
 int set_gpu_device_memory_monitor(int32_t pid,int dev,size_t monitor);
 int set_gpu_device_sm_utilization(int32_t pid,int dev, unsigned int smUtil);
-int init_gpu_device_sm_utilization();
+int init_gpu_device_utilization();
 int add_gpu_device_memory_usage(int32_t pid,int dev,size_t usage,int type);
 int rm_gpu_device_memory_usage(int32_t pid,int dev,size_t usage,int type);
 
@@ -172,6 +172,7 @@ void suspend_all();
 void resume_all();
 int wait_status_self(int status);
 int wait_status_all(int status);
+void print_all();
 
 int load_env_from_file(char *filename);
 int comparelwr(const char *s1,char *s2);

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -120,70 +120,58 @@ int get_used_gpu_utilization(int *userutil,int *sysprocnum) {
 
     int i,sum=0;
     unsigned int infcount;
-    size_t summonitor=0;
     nvmlProcessInfo_v1_t infos[SHARED_REGION_MAX_PROCESS_NUM];
 
     unsigned int nvmlCounts;
     CHECK_NVML_API(nvmlDeviceGetCount(&nvmlCounts));
 
+    lock_shrreg();
+
     int devi,cudadev;
     for (devi=0;devi<nvmlCounts;devi++){
       sum=0;
-      summonitor=0;
+      infcount = SHARED_REGION_MAX_PROCESS_NUM;
       shrreg_proc_slot_t *proc;
       cudadev = nvml_to_cuda_map((unsigned int)(devi));
       if (cudadev<0)
         continue;
       nvmlDevice_t device;
-      char uuid[NVML_DEVICE_UUID_BUFFER_SIZE];
       CHECK_NVML_API(nvmlDeviceGetHandleByIndex(cudadev, &device));
-        // Get device UUID
-     CHECK_NVML_API(nvmlDeviceGetUUID(device, uuid, NVML_DEVICE_UUID_BUFFER_SIZE));
+
+      // Get Memory for container
       nvmlReturn_t res = nvmlDeviceGetComputeRunningProcesses(device,&infcount,infos);
-      if (res==NVML_ERROR_INSUFFICIENT_SIZE){
-        continue;
+      if (res == NVML_SUCCESS) {
+        for (i=0; i<infcount; i++){
+          proc = find_proc_by_hostpid(infos[i].pid);
+          if (proc != NULL){
+              LOG_DEBUG("pid=%u monitor=%lld\n", infos[i].pid, infos[i].usedGpuMemory);
+              proc->monitorused[cudadev] += infos[i].usedGpuMemory;
+          }
+        }
       }
+
+      // Get SM util for container
       gettimeofday(&cur,NULL);
       microsec = (cur.tv_sec - 1) * 1000UL * 1000UL + cur.tv_usec;
       nvmlProcessUtilizationSample_t processes_sample[SHARED_REGION_MAX_PROCESS_NUM];
       unsigned int processes_num = SHARED_REGION_MAX_PROCESS_NUM;
       res = nvmlDeviceGetProcessUtilization(device,processes_sample,&processes_num,microsec);
-      LOG_DEBUG("processes_num=%d\n",processes_num);
-      LOG_DEBUG("Device UUID: %s\n", uuid);
-      if ((res==NVML_ERROR_INSUFFICIENT_SIZE) || (res==NVML_ERROR_NOT_FOUND)){
-        userutil[cudadev] = 0;
-        for (i=0; i<infcount; i++){
-          proc = find_proc_by_hostpid(infos[i].pid);
-          if (proc != NULL){
-              LOG_DEBUG("pid=%u monitor=%lld\n",infos[i].pid,infos[i].usedGpuMemory);
-              summonitor += infos[i].usedGpuMemory;
-          }
-          set_gpu_device_memory_monitor(infos[i].pid,cudadev,summonitor);
-          set_gpu_device_sm_utilization(infos[i].pid,cudadev,0);
-        } 
-        continue;
-      }
-      for (i=0; i<processes_num; i++){
-          //if (processes_sample[i].timeStamp >= microsec){
+      if (res == NVML_SUCCESS) {
+        for (i=0; i<processes_num; i++){
           proc = find_proc_by_hostpid(processes_sample[i].pid);
           if (proc != NULL){
-              //LOG_WARN("pid=%u num=%d\n",processes_sample[i].pid,processes_num);
-              //proc = find_proc_by_hostpid(processes_sample[i].pid);
-              //if (proc!=NULL) {
-              //    printf("inner pid=%u\n",proc->pid);
               sum += processes_sample[i].smUtil;
-              summonitor += infos[i].usedGpuMemory;
-              //LOG_WARN("monitorused=%lld %d %d %d",infos[i].usedGpuMemory,proc->hostpid,proc->pid,pidfound);
-              //LOG_WARN("smutil=%d %d %lu %u %u %u\n",virtual_map[devi],devi,summonitor,processes_sample[i].smUtil,processes_sample[i].encUtil,processes_sample[i].decUtil);
-              //}
+              LOG_DEBUG("pid=%u smUtil=%d\n", processes_sample[i].pid, processes_sample[i].smUtil);
+              proc->device_util[cudadev].sm_util += processes_sample[i].smUtil;
           }
-          set_gpu_device_memory_monitor(processes_sample[i].pid,cudadev,summonitor);
-          set_gpu_device_sm_utilization(processes_sample[i].pid,cudadev,processes_sample[i].smUtil);
+        }
       }
+      
       if (sum < 0)
         sum = 0;
       userutil[cudadev] = sum;
     }
+    unlock_shrreg();
     return 0;
 }
 
@@ -193,6 +181,8 @@ void* utilization_watcher() {
     int sysprocnum;
     int share = 0;
     int upper_limit = get_current_device_sm_limit(0);
+
+    ensure_initialized();
     LOG_DEBUG("upper_limit=%d\n",upper_limit);
     while (1){
         nanosleep(&g_wait, NULL);
@@ -201,7 +191,7 @@ void* utilization_watcher() {
           if (pidfound==0)
             continue;
         }
-        init_gpu_device_sm_utilization();
+        init_gpu_device_utilization();
         get_used_gpu_utilization(userutil,&sysprocnum);
         //if (sysprocnum == 1 &&
         //    userutil < upper_limit / 10) {

--- a/src/multiprocess/shrreg_tool.c
+++ b/src/multiprocess/shrreg_tool.c
@@ -25,6 +25,12 @@ void create_new() {
 }
 
 
+void print_shared_region(){
+    ensure_initialized();
+    print_all();
+}
+
+
 void send_stop_signal(){
     ensure_initialized();
     suspend_all();
@@ -64,6 +70,9 @@ int main(int argc, char* argv[]) {
         }
         if (strcmp(arg, "--resume") == 0){
             send_resume_signal();
+        }
+        if (strcmp(arg, "--print") == 0){
+            print_shared_region();
         }
         if (strcmp(arg, "--version") == 0){
             printf("shrreg size: %ld, version %d.%d\n", 


### PR DESCRIPTION
Fix multiprocess_utilization_watcher;
In pre version,  summonitor is sum of all process's memory in one container, that will cause the all process's memory except the first one value wrong.