### PR TITLE
Fix multiple definition of fp1

### DIFF
--- a/src/include/fp1_global.h
+++ b/src/include/fp1_global.h
@@ -1,0 +1,10 @@
+
+#ifndef FP1_GLOBAL_H
+#define FP1_GLOBAL_H
+
+#include <stdio.h>
+
+extern FILE *fp1;
+
+#endif
+

--- a/src/include/log_utils.h
+++ b/src/include/log_utils.h
@@ -7,8 +7,8 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "fp1_global.h"
 
-FILE *fp1;
 
 #ifdef FILEDEBUG 
 #define LOG_DEBUG(msg, ...) { \


### PR DESCRIPTION
## Summary

This PR fixes the multiple definition of the global `fp1` used for logging, which caused linking errors when building modules like `shrreg-tool` and `libvgpu.so`.

## Changes
- Created `fp1_global.h` to declare `extern FILE *fp1;`
- Replaced all `FILE *fp1;` in headers or multiple source files with `#include "fp1_global.h"`
- Defined `FILE *fp1 = NULL;` only once in `libvgpu.c`

## Related
Fixes #75
