### PR TITLE
fix: call nvmlDeviceGetUUID with nvmlConstant

### DIFF
--- a/src/include/log_utils.h
+++ b/src/include/log_utils.h
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-FILE *fp1;
+extern FILE *fp1;
 
 #ifdef FILEDEBUG 
 #define LOG_DEBUG(msg, ...) { \

--- a/src/include/nvml-subset.h
+++ b/src/include/nvml-subset.h
@@ -1136,9 +1136,14 @@ typedef struct nvmlFBCStats_st {
 } nvmlFBCStats_t;
 
 /**
- * Buffer size guaranteed to be large enough for \ref nvmlDeviceGetUUID
+ * Buffer size guaranteed to be large enough for storing GPU identifiers.
  */
 #define NVML_DEVICE_UUID_BUFFER_SIZE 80
+
+/**
+ * Buffer size guaranteed to be large enough for \ref nvmlDeviceGetUUID
+ */
+#define NVML_DEVICE_UUID_V2_BUFFER_SIZE 96
 
 /**
  * Blacklist GPU device information

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -126,7 +126,7 @@ int init_device_info() {
     nvmlDevice_t dev;
     for(i=0;i<nvmlDevicesCount;i++){
         CHECK_NVML_API(nvmlDeviceGetHandleByIndex(i, &dev));
-        CHECK_NVML_API(nvmlDeviceGetUUID(dev,region_info.shared_region->uuids[i],96));
+        CHECK_NVML_API(nvmlDeviceGetUUID(dev,region_info.shared_region->uuids[i],NVML_DEVICE_UUID_V2_BUFFER_SIZE);
     }
     LOG_INFO("put_device_info finished %d",nvmlDevicesCount);
     return 0;


### PR DESCRIPTION
According to the [NVML API Reference Guide](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g84dca2d06974131ccec1651428596191) about `nvmlDeviceGetUUID` API, it suggest using `NVML_DEVICE_UUID_V2_BUFFER_SIZE` constant when calling this API.
BTW, the comment about `NVML_DEVICE_UUID_BUFFER_SIZE` and `NVML_DEVICE_UUID_V2_BUFFER_SIZE` should be updated.