### PR TITLE
Fix the lock release issue

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -173,7 +173,6 @@ int get_used_gpu_utilization(int *userutil,int *sysprocnum) {
       if (sum < 0)
         sum = 0;
       userutil[cudadev] = sum;
-      unlock_shrreg();
     }
     unlock_shrreg();
     return 0;


### PR DESCRIPTION
There is a locking issue in the get_used_gpu_utilization() function.

Signed-off-by: Lei Jiang <helloppx@gmail.com>