### PR TITLE
fix: null point of proc in get_used_gpu_utilization

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -171,8 +171,10 @@ int get_used_gpu_utilization(int *userutil,int *sysprocnum) {
         sum = 0;
       if (usedGpuMemory < 0)
         usedGpuMemory = 0;
-      proc->device_util[cudadev].sm_util = sum;
-      proc->monitorused[cudadev] = usedGpuMemory;
+      if (proc != NULL) {
+        proc->device_util[cudadev].sm_util = sum;
+        proc->monitorused[cudadev] = usedGpuMemory;
+      }
       userutil[cudadev] = sum;
     }
     unlock_shrreg();


### PR DESCRIPTION
### Description
I have encountered coredump when running a testing script with `cupy`.  After analyzing the coredump file, i found that the `proc` in the following code is `NULL` which was introduced by #97 
```bash
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/x86_64-linux-gnu/libthread_db.so.1".
--Type <RET> for more, q to quit, c to continue without paging--c
Core was generated by `python3 test.py'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f227fbaf50e in get_used_gpu_utilization (userutil=0x7f216dffedd0, sysprocnum=0x7f216dffedc4) at /opt/hami-core/src/multiprocess/multiprocess_utilization_watcher.c:174
174	      proc->device_util[cudadev].sm_util = sum;
[Current thread is 1 (Thread 0x7f216dfff640 (LWP 1199))]
(gdb) list
169	      }
170	      if (sum < 0)
171	        sum = 0;
172	      if (usedGpuMemory < 0)
173	        usedGpuMemory = 0;
174	      proc->device_util[cudadev].sm_util = sum;
175	      proc->monitorused[cudadev] = usedGpuMemory;
176	      userutil[cudadev] = sum;
177	    }
178	    unlock_shrreg();
(gdb) print proc
$1 = (shrreg_proc_slot_t *) 0x0
```