### PR TITLE
fix different PID not loading environment that go wrong

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -38,6 +38,10 @@
 #define CUDA_DEVICE_MAX_COUNT 16
 #endif
 
+#ifndef BUFFER_SIZE
+#define BUFFER_SIZE 8192
+#endif
+
 int pidfound;
 
 int ctx_activate[32];
@@ -680,8 +684,33 @@ int set_env_utilization_switch() {
     return 0;
 }
 
+void load_environ() {
+    FILE *file = fopen("/proc/1/environ", "r");
+    if (!file) {
+        return;
+    }
+    char buffer[BUFFER_SIZE];
+    size_t bytesRead = fread(buffer, 1, sizeof(buffer) - 1, file);
+    if (bytesRead == 0) {
+        fclose(file);
+        return;
+    }
+    buffer[bytesRead] = '\0';
+    size_t i = 0;
+    while (i < bytesRead) {
+        char *line = &buffer[i];
+        size_t len = strlen(line);
+        if (len > 0) {
+            putenv(strdup(line));
+        }
+        i += len + 1;
+    }
+    fclose(file);
+}
+
 void try_create_shrreg() {
     LOG_DEBUG("Try create shrreg")
+    load_environ();
     if (region_info.fd == -1) {
         // use .fd to indicate whether a reinit after fork happen
         // no need to register exit handler after fork


### PR DESCRIPTION
for information, peek at this[ issue.](https://github.com/Project-HAMi/HAMi/issues/1112)

When new PID born, container can't read its env by default, so the show info go wrong.
```shell
root@test:/workspace# nvidia-smi
Fri Aug  1 10:48:00 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A100-SXM4-80GB          Off |   00000000:38:00.0 Off |                    0 |
| N/A   50C    P0             68W /  400W |       0MiB /   8192MiB |     19%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
+-----------------------------------------------------------------------------------------+
root@test:/workspace# ssh localhost
root@localhost's password: 
root@test:~# nvidia-smi
[HAMI-core Msg(2011:139706544437056:libvgpu.c:837)]: Initializing.....
Fri Aug  1 10:47:29 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A100-SXM4-80GB          Off |   00000000:38:00.0 Off |                    0 |
| N/A   52C    P0             83W /  400W |       0MiB /  81920MiB |     57%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
+-----------------------------------------------------------------------------------------+
[HAMI-core Msg(2011:139706544437056:multiprocess_memory_limit.c:498)]: Calling exit handler 2011
```
I changed the part that get the env vars from PID 1. If there is no such env, just return and go next step; if exists then read it and use the injected default env vars. After thinking, i not pick single env var to load, cuz later code maybe add new env var.
```shell
root@ct-1400911962493157376:/workspace# nvidia-smi
Fri Aug  1 10:56:50 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A100-SXM4-80GB          Off |   00000000:38:00.0 Off |                    0 |
| N/A   49C    P0             71W /  400W |       0MiB /   8192MiB |      7%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
+-----------------------------------------------------------------------------------------+
root@test:/workspace# ssh localhost
root@localhost's password: 
root@test:~# nvidia-smi
Fri Aug  1 10:58:05 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A100-SXM4-80GB          Off |   00000000:38:00.0 Off |                    0 |
| N/A   53C    P0            250W /  400W |       0MiB /   8192MiB |     76%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
+-----------------------------------------------------------------------------------------+
```