### PR TITLE
fix: fix type incompatibility warnings and unused variables

### DIFF
--- a/src/cuda/hook.c
+++ b/src/cuda/hook.c
@@ -325,7 +325,6 @@ void *find_symbols_in_table(const char *symbol) {
 void *find_symbols_in_table_by_cudaversion(const char *symbol,int  cudaVersion) {
   void *pfn;
   const char *real_symbol;
-  int i;
   real_symbol = get_real_func_name(symbol,cudaVersion);
   if (real_symbol == NULL) {
     // if not find in mulit func version def, use origin logic

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -323,7 +323,7 @@ int set_gpu_device_sm_utilization(int32_t pid,int dev, unsigned int smUtil){  //
     lock_shrreg();
     for (i=0;i<region_info.shared_region->proc_num;i++){
         if (region_info.shared_region->procs[i].hostpid == pid){
-            LOG_INFO("set_gpu_device_sm_utilization:%d %d %lu->%lu",pid,dev,region_info.shared_region->procs[i].device_util[dev].sm_util,smUtil);
+            LOG_INFO("set_gpu_device_sm_utilization:%d %d %lu->%u", pid, dev, region_info.shared_region->procs[i].device_util[dev].sm_util, smUtil);
             region_info.shared_region->procs[i].device_util[dev].sm_util = smUtil;
             break;
         }
@@ -409,7 +409,7 @@ int add_gpu_device_memory_usage(int32_t pid,int cudadev,size_t usage,int type){
 }
 
 int rm_gpu_device_memory_usage(int32_t pid,int cudadev,size_t usage,int type){
-    LOG_INFO("rm_gpu_device_memory:%d %d->%d %lu:%lu",pid,cudadev,cuda_to_nvml_map(cudadev),type,usage);
+    LOG_INFO("rm_gpu_device_memory:%d %d->%d %d:%lu",pid,cudadev,cuda_to_nvml_map(cudadev),type,usage);
     int dev = cuda_to_nvml_map(cudadev);
     ensure_initialized();
     lock_shrreg();
@@ -641,8 +641,12 @@ void print_all() {
     LOG_INFO("Total process: %d",region_info.shared_region->proc_num);
     for (i=0;i<region_info.shared_region->proc_num;i++) {
         for (int dev=0;dev<CUDA_DEVICE_MAX_COUNT;dev++){
-            LOG_INFO("Process %d hostPid: %d, sm: %d, memory: %d, record: %d",region_info.shared_region->procs[i].pid, region_info.shared_region->procs[i].hostpid, 
-            region_info.shared_region->procs[i].device_util[dev].sm_util, region_info.shared_region->procs[i].monitorused[dev], region_info.shared_region->procs[i].used[dev].total);
+            LOG_INFO("Process %d hostPid: %d, sm: %lu, memory: %lu, record: %lu",
+                region_info.shared_region->procs[i].pid,
+                region_info.shared_region->procs[i].hostpid, 
+                region_info.shared_region->procs[i].device_util[dev].sm_util, 
+                region_info.shared_region->procs[i].monitorused[dev], 
+                region_info.shared_region->procs[i].used[dev].total);
         }
     }
 }

--- a/src/nvml/hook.c
+++ b/src/nvml/hook.c
@@ -272,7 +272,6 @@ extern void* _dl_sym(void*, const char*, void*);
 void load_nvml_libraries() {
     void *table = NULL;
     char driver_filename[FILENAME_MAX];
-    int i;
 
     if (real_dlsym == NULL) {
         real_dlsym = dlvsym(RTLD_NEXT,"dlsym","GLIBC_2.2.5");
@@ -289,7 +288,7 @@ void load_nvml_libraries() {
     if (!table) {
         LOG_WARN("can't find library %s", driver_filename);  
     }
-
+    int i;
     for (i = 0; i < NVML_ENTRY_END; i++) {
         LOG_DEBUG("loading %s:%d",nvml_library_entry[i].name,i);
         nvml_library_entry[i].fn_ptr = real_dlsym(table, nvml_library_entry[i].name);
@@ -323,11 +322,12 @@ nvmlReturn_t _nvmlDeviceGetMemoryInfo(nvmlDevice_t device,nvmlMemory_t* memory,i
     switch (version){
         case 1:
             CHECK_NVML_API(NVML_OVERRIDE_CALL(nvml_library_entry,nvmlDeviceGetMemoryInfo, device, memory));
+            LOG_DEBUG("origin_free=%lld total=%lld\n", ((nvmlMemory_t*)memory)->free, ((nvmlMemory_t*)memory)->total);
             break;
         case 2:
             CHECK_NVML_API(NVML_OVERRIDE_CALL(nvml_library_entry,nvmlDeviceGetMemoryInfo_v2, device, (nvmlMemory_v2_t *)memory));
+            LOG_DEBUG("origin_free=%lld total=%lld\n", ((nvmlMemory_v2_t*)memory)->free, ((nvmlMemory_v2_t*)memory)->total);
     }
-    LOG_DEBUG("origin_free=%lld total=%lld\n",memory->free,memory->total);
     CHECK_NVML_API(nvmlDeviceGetIndex(device, &dev_id));
     int cudadev = nvml_to_cuda_map(dev_id);
     if (cudadev < 0)

--- a/src/utils.c
+++ b/src/utils.c
@@ -105,7 +105,7 @@ nvmlReturn_t set_task_pid() {
     nvmlDevice_t device;
     nvmlReturn_t res;
     CUcontext pctx;
-    int i,t;
+    int i;
     CHECK_NVML_API(nvmlInit());
     CHECK_NVML_API(nvmlDeviceGetHandleByIndex(0, &device));
     


### PR DESCRIPTION
Fixed type incompatibility warning in NVML functions by:

Creating separate type-safe implementations for nvmlDeviceGetMemoryInfo v1 and v2 functions
Properly handling memory structure differences between versions
Corrected format specifier mismatches in logging functions:

Updated format strings in LOG_INFO calls to match argument types
Fixed %d vs %lu formatting issues for uint64_t variables
Ensured consistent parameter handling across all logging macros
Removed unused variables:

Eliminated unused variable i in find_symbols_in_table_by_cudaversion function