### PR TITLE
fix: build error if branch contains `/`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,11 @@ else()
 endif()
 
 if(GIT_FOUND)
+    message(STATUS "Git original branch is ${GIT_BRANCH}")
     #string(REPLACE "." "_" GIT_BRANCH ${GIT_BRANCH})
-    #string(REPLACE "-" "_" GIT_BRANCH ${GIT_BRANCH})
-    #message(STATUS "Git branch is ${GIT_BRANCH}")
+    string(REPLACE "-" "_" GIT_BRANCH ${GIT_BRANCH})
+    string(REPLACE "/" "_" GIT_BRANCH ${GIT_BRANCH})
+    message(STATUS "Git formated branch is ${GIT_BRANCH}")
 endif()
 
 # Generate the static config header file


### PR DESCRIPTION
build.sh run failed if the branch contains invalid char in c variable name
`In file included from /HAMi-core/src/multiprocess/multiprocess_memory_limit.h:21,
                 from /HAMi-core/src/cuda/context.c:2:
/HAMi-core/build/config/static_config.h:8:29: error: expected '=', ',', ';', 'asm' or '__attribute__' before '/' token
    8 | extern size_t GIT_BRANCH_fix/build_error;
      |                             ^
In file included from /HAMi-core/src/multiprocess/multiprocess_memory_limit.h:21,
                 from /HAMi-core/src/allocator/allocator.c:4:
/HAMi-core/build/config/static_config.h:8:29: error: expected '=', ',', ';', 'asm' or '__attribute__' before '/' token
    8 | extern size_t GIT_BRANCH_fix/build_error;
`