### PR TITLE
fix: change return type of nvml_to_cuda_map to int for consistency

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -176,7 +176,7 @@ void print_all();
 int load_env_from_file(char *filename);
 int comparelwr(const char *s1,char *s2);
 int put_device_info();
-unsigned int nvml_to_cuda_map(unsigned int nvmldev);
+int nvml_to_cuda_map(unsigned int nvmldev);
 unsigned int cuda_to_nvml_map(unsigned int cudadev);
 
 int clear_proc_slot_nolock(int);

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -177,7 +177,7 @@ int load_env_from_file(char *filename);
 int comparelwr(const char *s1,char *s2);
 int put_device_info();
 int nvml_to_cuda_map(unsigned int nvmldev);
-unsigned int cuda_to_nvml_map(unsigned int cudadev);
+int cuda_to_nvml_map(unsigned int cudadev);
 
 int clear_proc_slot_nolock(int);
 #endif  // __MULTIPROCESS_MEMORY_LIMIT_H__

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -105,7 +105,7 @@ int nvml_to_cuda_map(unsigned int nvmldev){
     return -1;
 }
 
-unsigned int cuda_to_nvml_map(unsigned int cudadev){
+int cuda_to_nvml_map(unsigned int cudadev){
     return cuda_to_nvml_map_array[cudadev];
 }
 

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -95,13 +95,12 @@ long delta(int up_limit, int user_current, long share) {
   return share;
 }
 
-unsigned int nvml_to_cuda_map(unsigned int nvmldev){
+int nvml_to_cuda_map(unsigned int nvmldev){
     unsigned int devcount;
     CHECK_NVML_API(nvmlDeviceGetCount_v2(&devcount));
-    int i=0;
-    for (i=0;i<devcount;i++){
+    for (unsigned int i = 0; i < devcount; i++){
         if (cuda_to_nvml_map(i)==nvmldev)
-          return i;
+          return (int)i;
     }
     return -1;
 }

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -99,7 +99,8 @@ int nvml_to_cuda_map(unsigned int nvmldev){
     unsigned int devcount;
     CHECK_NVML_API(nvmlDeviceGetCount_v2(&devcount));
     for (unsigned int i = 0; i < devcount; i++){
-        if (cuda_to_nvml_map(i)==nvmldev)
+        int mapped = cuda_to_nvml_map(i);
+        if ((mapped >= 0) && (mapped == (int)nvmldev))
           return (int)i;
     }
     return -1;


### PR DESCRIPTION
 ### Summary

  - change nvml_to_cuda_map to return int so it can safely signal failure with -1
  - update the function declaration and callers to rely on the signed return value

  This removes the implementation-defined behavior where an unsigned -1 could be interpreted as a huge positive index, bypassing the <0 guard and leading to out-of-bounds access when NVML devices are not
  visible to CUDA (e.g., under CUDA_VISIBLE_DEVICES remapping).
