### PR TITLE
 LOG for nil ptr in hijack table

### DIFF
--- a/src/include/libcuda_hook.h
+++ b/src/include/libcuda_hook.h
@@ -34,6 +34,9 @@ typedef CUresult (*cuda_sym_t)();
   ({    \
     LOG_DEBUG("Hijacking %s", #sym);                                           \
     cuda_sym_t _entry = (cuda_sym_t)CUDA_FIND_ENTRY(table, sym);               \
+    if (_entry == NULL) {                                                      \
+      LOG_ERROR("Hijack failed: %s is NULL", #sym);                            \
+    }                                                                          \
     _entry(__VA_ARGS__);                                                       \
   })
 


### PR DESCRIPTION
如果 hijack table 中fn_ptr 是NULL，会导致程序段错误，如果检查到NULL 并且先输出日志，比较好定位问题。

自测的日志如下：
<img width="1515" height="269" alt="image" src="https://github.com/user-attachments/assets/cdb2f8fd-462e-4147-8e41-9b3597334650" />


关联的 pr https://github.com/Project-HAMi/HAMi-core/pull/136