### PR TITLE
Add support for `cuLaunchKernelEx`

### DIFF
--- a/src/cuda/hook.c
+++ b/src/cuda/hook.c
@@ -111,6 +111,7 @@ cuda_entry_t cuda_library_entry[] = {
     {.name = "cuFuncGetAttribute"},
     {.name = "cuFuncSetAttribute"},
     {.name = "cuLaunchKernel"},
+    {.name = "cuLaunchKernelEx"},
     {.name = "cuLaunchCooperativeKernel"},
     /* cuEvent Part */
     {.name = "cuEventCreate"},

--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -553,6 +553,16 @@ CUresult cuLaunchKernel ( CUfunction f, unsigned int  gridDimX, unsigned int  gr
     return res;
 }
 
+CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f, void **kernelParams, void **extra) {
+    ENSURE_RUNNING();
+    pre_launch_kernel();
+    if (pidfound==1){
+        rate_limiter(config->gridDimX * config->gridDimY * config->gridDimZ,
+                   config->blockDimX * config->blockDimY * config->blockDimZ);
+    }
+    CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuLaunchKernelEx,config,f,kernelParams,extra);
+    return res;
+}
 
 CUresult cuLaunchCooperativeKernel ( CUfunction f, unsigned int  gridDimX, unsigned int  gridDimY, unsigned int  gridDimZ, unsigned int  blockDimX, unsigned int  blockDimY, unsigned int  blockDimZ, unsigned int  sharedMemBytes, CUstream hStream, void** kernelParams ){
     ENSURE_RUNNING();

--- a/src/include/libcuda_hook.h
+++ b/src/include/libcuda_hook.h
@@ -145,6 +145,7 @@ typedef enum {
     CUDA_OVERRIDE_ENUM(cuFuncGetAttribute),
     CUDA_OVERRIDE_ENUM(cuFuncSetAttribute),
     CUDA_OVERRIDE_ENUM(cuLaunchKernel),
+    CUDA_OVERRIDE_ENUM(cuLaunchKernelEx),
     CUDA_OVERRIDE_ENUM(cuLaunchCooperativeKernel),
     /* cuEvent Part */
     CUDA_OVERRIDE_ENUM(cuEventCreate),

--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -203,6 +203,7 @@ void* __dlsym_hook_section(void* handle, const char* symbol) {
     DLSYM_HOOK_FUNC(cuFuncGetAttribute);
     DLSYM_HOOK_FUNC(cuFuncSetAttribute);
     DLSYM_HOOK_FUNC(cuLaunchKernel);
+    DLSYM_HOOK_FUNC(cuLaunchKernelEx);
     DLSYM_HOOK_FUNC(cuLaunchCooperativeKernel);
     DLSYM_HOOK_FUNC(cuIpcOpenMemHandle_v2);
     DLSYM_HOOK_FUNC(cuIpcGetMemHandle);


### PR DESCRIPTION
I was testing a simple program during my experimentation and didn't see any impact of setting `CUDA_DEVICE_SM_LIMIT`, on further debugging realized that the kernel launch was not being rate limited due to missing hook

Program:
```
import torch
import time

def compute_load(duration_sec=10):
    if not torch.cuda.is_available():
        print("CUDA not available")
        return


    print(f"Starting compute load for {duration_sec} seconds...")
    input("Press Enter to start...")
    start_time = time.time()

    # Create random matrices
    N = 4096
    a = torch.randn(N, N, device='cuda')
    b = torch.randn(N, N, device='cuda')

    iters = 0
    while time.time() - start_time < duration_sec:
        # Perform heavy matrix multiplication
        c = torch.matmul(a, b)
        # Force synchronization to ensure GPU is actually working
        torch.cuda.synchronize()
        iters += 1
        if iters % 100 == 0:
            print(f"Completed {iters} iterations...")

    print(f"Finished. Total iterations: {iters}")

if __name__ == "__main__":
    compute_load()
```

Before:
```
(hami-experiments) ankit@h100_node $ LIBCUDA_LOG_LEVEL=4 GPU_CORE_UTILIZATION_POLICY=force CUDA_OVERSUBSCRIBE=false CUDA_DEVICE_MEMORY_SHARED_CACHE=/tmp/cache_2.cache CUDA_VISIBLE_DEVICES=0 LD_PRELOAD=/usr/local/vgpu/libvgpu.so.v2.7.1 CUDA_DEVICE_SM_LIMIT=75 CUDA_DEVICE_MEMORY_LIMIT=2G python3 compute_load.py  2>&1 | grep 'cuLaunchKernel'
[HAMI-core Debug(2522545:124059449684928:hook.c:256)]: LOADING cuLaunchKernel 95
[HAMI-core Debug(2522545:124059449684928:libvgpu.c:74)]: into dlsym cuLaunchKernel
[HAMI-core Debug(2522545:124059449684928:libvgpu.c:74)]: into dlsym cuLaunchKernelEx
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:4000
[HAMI-core Debug(2522545:124059449684928:hook.c:403)]: found symbol cuLaunchKernel
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:7000
[HAMI-core Debug(2522545:124059449684928:hook.c:403)]: found symbol cuLaunchKernel
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522545:124059449684928:memory.c:552)]: Hijacking cuLaunchKernel
[HAMI-core Debug(2522545:124059449684928:memory.c:552)]: Hijacking cuLaunchKernel
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:4000
[HAMI-core Debug(2522545:124059449684928:hook.c:403)]: found symbol cuLaunchKernel
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:7000
[HAMI-core Debug(2522545:124059449684928:hook.c:403)]: found symbol cuLaunchKernel
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:4000
[HAMI-core Debug(2522545:124059449684928:hook.c:403)]: found symbol cuLaunchKernel
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:7000
[HAMI-core Debug(2522545:124059449684928:hook.c:403)]: found symbol cuLaunchKernel
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Info(2522545:124059449684928:hook.c:389)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522545:124059449684928:libvgpu.c:74)]: into dlsym cuLaunchKernel
[HAMI-core Debug(2522545:124059449684928:libvgpu.c:74)]: into dlsym cuLaunchKernelEx
[HAMI-core Debug(2522545:124059449684928:libvgpu.c:74)]: into dlsym cuLaunchKernel
[HAMI-core Debug(2522545:124059449684928:libvgpu.c:74)]: into dlsym cuLaunchKernelEx
```

After:
```
(hami-experiments) ankit@h100_node $ LIBCUDA_LOG_LEVEL=4 GPU_CORE_UTILIZATION_POLICY=force CUDA_OVERSUBSCRIBE=false CUDA_DEVICE_MEMORY_SHARED_CACHE=/tmp/cache_2.cache CUDA_VISIBLE_DEVICES=0 LD_PRELOAD=/tmp/libvgpu.so CUDA_DEVICE_SM_LIMIT=75 CUDA_DEVICE_MEMORY_LIMIT=2G python3 compute_load.py 2>&1 | grep 'cuLaunchKernel'
[HAMI-core Debug(2522872:130531239220160:hook.c:257)]: LOADING cuLaunchKernel 95
[HAMI-core Debug(2522872:130531239220160:hook.c:257)]: LOADING cuLaunchKernelEx 96
[HAMI-core Debug(2522872:130531239220160:libvgpu.c:74)]: into dlsym cuLaunchKernel
[HAMI-core Debug(2522872:130531239220160:libvgpu.c:74)]: into dlsym cuLaunchKernelEx
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:4000
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernel
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:7000
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernel
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernelEx
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:638)]: Hijacking cuLaunchKernel
[HAMI-core Debug(2522872:130531239220160:memory.c:638)]: Hijacking cuLaunchKernel
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:4000
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernel
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:7000
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernel
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernelEx
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernelEx
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:4000
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernel
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernel:7000
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernel
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernelEx
[HAMI-core Info(2522872:130531239220160:hook.c:390)]: into cuGetProcAddress_v2 symbol=cuLaunchKernelEx:11060
[HAMI-core Debug(2522872:130531239220160:hook.c:404)]: found symbol cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:libvgpu.c:74)]: into dlsym cuLaunchKernel
[HAMI-core Debug(2522872:130531239220160:libvgpu.c:74)]: into dlsym cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:libvgpu.c:74)]: into dlsym cuLaunchKernel
[HAMI-core Debug(2522872:130531239220160:libvgpu.c:74)]: into dlsym cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
[HAMI-core Debug(2522872:130531239220160:memory.c:652)]: Hijacking cuLaunchKernelEx
```