### PR TITLE
Fix cost calculation for the kernel

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -34,7 +34,7 @@ int cuda_to_nvml_map_array[CUDA_DEVICE_MAX_COUNT];
 void rate_limiter(int grids, int blocks) {
   long before_cuda_cores = 0;
   long after_cuda_cores = 0;
-  long kernel_size = grids;
+  long kernel_size = (long)grids * (long)blocks;
 
   while (get_recent_kernel()<0) {
     sleep(1);


### PR DESCRIPTION
It looks like the "cost" of kernel is determined by the `grid` size, however, the real cost should account for both `gridDim` (number of Blocks) and `blockDim` (number of Threads).

### Observation
When I ran my sample code below to determine the impact of setting `CUDA_DEVICE_SM_LIMIT`, I didn't observe expected slowdown in the process that was given 1/3 of the quota as the other process. 

Sample Code:
```py
import torch
import time
import argparse

def granular_load(duration_sec=10, size=128, batch_size=100):
    if not torch.cuda.is_available():
        print("CUDA not available")
        return

    print(f"Starting granular compute load for {duration_sec} seconds...")
    print(f"Matrix size: {size}x{size}, Batch size: {batch_size}")
    input("Press Enter to start...")

    start_time = time.time()

    # Create smaller random matrices
    a = torch.randn(size, size, device='cuda')
    b = torch.randn(size, size, device='cuda')

    iters = 0
    while time.time() - start_time < duration_sec:
        # Launch a batch of kernels
        for _ in range(batch_size):
            c = torch.matmul(a, b)

        # Force synchronization periodically
        torch.cuda.synchronize()
        iters += batch_size

        if iters % 10000 == 0:
            print(f"Completed {iters} iterations...")

    print(f"Finished. Total iterations: {iters}")
    print(f"Throughput: {iters / duration_sec:.2f} kernels/sec")

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--duration", type=int, default=10)
    parser.add_argument("--size", type=int, default=128)
    args = parser.parse_args()
    granular_load(args.duration, args.size)
```