### PR TITLE
fix(mem): correct GPU memory accounting (host vs container) and memory limits accordingly

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -42,7 +42,9 @@ int oom_check(const int dev, size_t addon) {
     else
         d=dev;
     uint64_t limit = get_current_device_memory_limit(d);
-    size_t _usage = get_gpu_memory_usage(d);
+    // Use real NVML-reported memory usage instead of internally tracked value
+    // This ensures OOM is triggered based on actual GPU memory consumption
+    size_t _usage = get_gpu_memory_real_usage(d);
 
     if (limit == 0) {
         return 0;

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -133,6 +133,7 @@ int set_host_pid(int hostpid);
 uint64_t get_current_device_memory_monitor(const int dev);
 uint64_t get_current_device_memory_usage(const int dev);
 size_t get_gpu_memory_usage(const int dev);
+size_t get_gpu_memory_real_usage(const int dev);
 
 // Priority-related
 int get_current_priority();

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -210,9 +210,72 @@ void* utilization_watcher() {
     }
 }
 
+// update_monitorused queries NVML for per-process GPU memory and writes
+// results into procs[].monitorused[]. This runs unconditionally so that
+// the monitor can always read real NVML memory from the shared region.
+static void update_monitorused() {
+    unsigned int nvmlCounts;
+    nvmlReturn_t ret = nvmlDeviceGetCount(&nvmlCounts);
+    if (ret != NVML_SUCCESS) {
+        LOG_ERROR("update_monitorused: nvmlDeviceGetCount failed: %s", nvmlErrorString(ret));
+        return;
+    }
+    lock_shrreg();
+    int devi, cudadev, i;
+    for (devi = 0; devi < nvmlCounts; devi++) {
+        unsigned int infcount = SHARED_REGION_MAX_PROCESS_NUM;
+        nvmlProcessInfo_v1_t infos[SHARED_REGION_MAX_PROCESS_NUM];
+        shrreg_proc_slot_t *proc;
+        cudadev = nvml_to_cuda_map((unsigned int)(devi));
+        if (cudadev < 0)
+            continue;
+        nvmlDevice_t device;
+        nvmlReturn_t r = nvmlDeviceGetHandleByIndex(cudadev, &device);
+        if (r != NVML_SUCCESS)
+            continue;
+        r = nvmlDeviceGetComputeRunningProcesses(device, &infcount, infos);
+        if (r == NVML_SUCCESS) {
+            for (i = 0; i < infcount; i++) {
+                proc = find_proc_by_hostpid(infos[i].pid);
+                if (proc != NULL) {
+                    proc->monitorused[cudadev] = infos[i].usedGpuMemory;
+                }
+            }
+        }
+    }
+    unlock_shrreg();
+}
+
+// memory_monitor_watcher is a lightweight thread that periodically queries
+// NVML for per-process GPU memory and writes it into monitorused[].
+// It runs every 1 second regardless of whether SM limits are configured.
+static void* memory_monitor_watcher(void *arg) {
+    (void)arg;
+    nvmlInit();
+    ensure_initialized();
+    struct timespec sleep_interval = { .tv_sec = 1, .tv_nsec = 0 };
+    while (1) {
+        nanosleep(&sleep_interval, NULL);
+        if (pidfound == 0) {
+            update_host_pid();
+            if (pidfound == 0)
+                continue;
+        }
+        update_monitorused();
+    }
+    return NULL;
+}
+
 void init_utilization_watcher() {
     LOG_INFO("set core utilization limit to  %d",get_current_device_sm_limit(0));
     setspec();
+
+    // Always start the memory monitor watcher to populate monitorused[]
+    // so the external monitor can read real NVML memory from shared region.
+    pthread_t mem_tid;
+    pthread_create(&mem_tid, NULL, memory_monitor_watcher, NULL);
+    LOG_INFO("Started memory_monitor_watcher thread for NVML memory tracking");
+
     pthread_t tid;
     if ((get_current_device_sm_limit(0)<=100) && (get_current_device_sm_limit(0)>0)){
         pthread_create(&tid, NULL, utilization_watcher, NULL);

--- a/src/nvml/hook.c
+++ b/src/nvml/hook.c
@@ -338,10 +338,10 @@ nvmlReturn_t _nvmlDeviceGetMemoryInfo(nvmlDevice_t device,void* memory,int versi
     if (cudadev < 0) {
         return NVML_SUCCESS;
     }
+    // get_current_device_memory_usage now returns real NVML-reported usage
     size_t usage = get_current_device_memory_usage(cudadev);
-    size_t monitor = get_current_device_memory_monitor(cudadev);
     size_t limit = get_current_device_memory_limit(cudadev);
-    LOG_DEBUG("usage=%ld limit=%ld monitor=%ld", usage, limit, monitor);
+    LOG_DEBUG("usage=%ld limit=%ld", usage, limit);
     if (limit == 0) {
         switch (version) {
         case 1:
@@ -354,12 +354,12 @@ nvmlReturn_t _nvmlDeviceGetMemoryInfo(nvmlDevice_t device,void* memory,int versi
     } else {
         switch (version) {
         case 1:
-             ((nvmlMemory_t*)memory)->free = (limit-usage);
+             ((nvmlMemory_t*)memory)->free = (limit > usage) ? (limit - usage) : 0;
              ((nvmlMemory_t*)memory)->total = limit;
              ((nvmlMemory_t*)memory)->used = usage;
             return NVML_SUCCESS;
         case 2:
-            ((nvmlMemory_v2_t *)memory)->free = (limit-usage);
+            ((nvmlMemory_v2_t *)memory)->free = (limit > usage) ? (limit - usage) : 0;
             ((nvmlMemory_v2_t *)memory)->total = limit;
             ((nvmlMemory_v2_t *)memory)->used = usage;
             return NVML_SUCCESS;

--- a/src/nvml/hook.c
+++ b/src/nvml/hook.c
@@ -340,8 +340,9 @@ nvmlReturn_t _nvmlDeviceGetMemoryInfo(nvmlDevice_t device,void* memory,int versi
     }
     // get_current_device_memory_usage now returns real NVML-reported usage
     size_t usage = get_current_device_memory_usage(cudadev);
+    size_t monitor = get_current_device_memory_monitor(cudadev);
     size_t limit = get_current_device_memory_limit(cudadev);
-    LOG_DEBUG("usage=%ld limit=%ld", usage, limit);
+    LOG_DEBUG("usage=%ld limit=%ld monitor=%ld", usage, limit, monitor);
     if (limit == 0) {
         switch (version) {
         case 1:


### PR DESCRIPTION
- Fixes incorrect GPU memory reporting inside the container vs. on the host (as shown by `nvidia-smi`).
- Enforces GPU memory limits using the **corrected container-visible memory**, preventing incorrect OOM enforcement.

## GPU Memory Usage

### In container

Command: `nvidia-smi`  
<img width="827" height="445" alt="image" src="https://github.com/user-attachments/assets/9bdab7d1-c250-476b-ae8b-a17252788456" />

Command: `nvidia-smi -a`
```
    FB Memory Usage
        Total                             : 3072 MiB
        Reserved                          : 274 MiB
        Used                              : 2584 MiB
        Free                              : 488 MiB
```

### On host

Command: `nvidia-smi`
<img width="745" height="561" alt="image" src="https://github.com/user-attachments/assets/81589f7b-d0a4-46e4-8a1a-da6b6e025bda" />

Command: `nvidia-smi -a`
```
    FB Memory Usage
        Total                             : 32768 MiB
        Reserved                          : 274 MiB
        Used                              : 2588 MiB
        Free                              : 29907 MiB
```

## GPU Memory Limit Enforcement (OOM scenario)
I run the same pod, which requires ~2588 MiB GPU memory. However, in this test, the ResourceClaim requests only 2GiB (2048 MiB) GPU memory, so the pod hits GPU OOM.

Pod log showing the OOM:
<img width="935" height="313" alt="image" src="https://github.com/user-attachments/assets/3d3d5a46-b4da-415c-a4b1-8bab19ba2fc6" />
