### PR TITLE
Fix SIGUSR1/SIGUSR2 handler clobbering breaking JVM processes

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <signal.h>
+#include <string.h>
 
 #include <assert.h>
 #include <cuda.h>
@@ -73,12 +74,21 @@ void set_current_gpu_status(int status){
     }
 }
 
+static struct sigaction old_sigusr1_sa;
+static struct sigaction old_sigusr2_sa;
+
 void sig_restore_stub(int signo){
     set_current_gpu_status(1);
+    // Chain to previous handler so JVM (and other runtimes) can process SIGUSR1
+    if (old_sigusr1_sa.sa_handler != SIG_DFL && old_sigusr1_sa.sa_handler != SIG_IGN)
+        old_sigusr1_sa.sa_handler(signo);
 }
 
 void sig_swap_stub(int signo){
     set_current_gpu_status(2);
+    // Chain to previous handler so JVM (and other runtimes) can process SIGUSR2
+    if (old_sigusr2_sa.sa_handler != SIG_DFL && old_sigusr2_sa.sa_handler != SIG_IGN)
+        old_sigusr2_sa.sa_handler(signo);
 }
 
 
@@ -689,8 +699,16 @@ void init_proc_slot_withlock() {
     if (proc_num >= SHARED_REGION_MAX_PROCESS_NUM) {
         exit_withlock(-1);
     }
-    signal(SIGUSR2,sig_swap_stub);
-    signal(SIGUSR1,sig_restore_stub);
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+
+    sa.sa_handler = sig_swap_stub;
+    sigaction(SIGUSR2, &sa, &old_sigusr2_sa);
+
+    sa.sa_handler = sig_restore_stub;
+    sigaction(SIGUSR1, &sa, &old_sigusr1_sa);
 
     // If, by any means a pid of itself is found in region->process, then it is probably caused by crashloop
     // we need to reset it.


### PR DESCRIPTION
## Problem

`libvgpu.so` registers signal handlers for `SIGUSR1` and `SIGUSR2` using `signal()`, which overwrites any previously installed handlers without saving them. This causes JVM processes to crash with `SIGSEGV` in `Monitor::wait()` because the JVM uses `SIGUSR1`/`SIGUSR2` internally for GC safepoints and thread management.

Observed on HAMi volcano-vgpu nodes (hami-core mode) when running PyTorch jobs with a JVM component — the crash occurs at startup before CUDA initializes.

Additional risks from the current implementation:
- `libvgpu.so` intercepts `dlsym()`, which the JVM also uses for native library loading
- The `ENSURE_RUNNING()` spin loop can cause a deadlock if a Java thread holding a JVM monitor gets suspended

## Fix

Replace `signal()` calls in `init_proc_slot_withlock()` with `sigaction()`, saving the previous handlers into static `struct sigaction` variables and chaining to them in `sig_swap_stub` / `sig_restore_stub`. This ensures other runtimes (JVM, Python, etc.) can still process `SIGUSR1`/`SIGUSR2` correctly.

## Changes

- `src/multiprocess/multiprocess_memory_limit.c`: Replace `signal()` with `sigaction()`, chain to previous handlers

## Testing

- Verified JVM workloads no longer crash with `SIGSEGV` in `Monitor::wait()` when running under `libvgpu.so` injection on HAMi volcano-vgpu nodes (prod-ltx1-k8s-1, prod-ltx1-k8s-2)

Closes #161
