### PR TITLE
fix: segfault in cuMemCreate hook when cuCtxGetDevice fails

### DIFF
--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -160,7 +160,7 @@ CUresult cuMemAllocManaged(CUdeviceptr* dptr, size_t bytesize, unsigned int flag
     LOG_DEBUG("cuMemAllocManaged dptr=%p bytesize=%ld",dptr,bytesize);
     ENSURE_RUNNING();
     CUdevice dev;
-    CUDA_OVERRIDE_CALL(cuda_library_entry,cuCtxGetDevice,&dev);
+    CHECK_DRV_API(cuCtxGetDevice(&dev));
     if (oom_check(dev,bytesize)){
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
@@ -178,7 +178,7 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInByt
     size_t bytesize = guess_pitch * Height;
     ENSURE_RUNNING();
     CUdevice dev;
-    CUDA_OVERRIDE_CALL(cuda_library_entry,cuCtxGetDevice,&dev);
+    CHECK_DRV_API(cuCtxGetDevice(&dev));
     if (oom_check(dev,bytesize)){
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
@@ -588,8 +588,11 @@ CUresult cuMemCreate ( CUmemGenericAllocationHandle* handle, size_t size, const 
     LOG_INFO("cuMemCreate:%lld:%d", size, prop->location.id);
     ENSURE_RUNNING();
     CUdevice dev;
-    CUDA_OVERRIDE_CALL(cuda_library_entry, cuCtxGetDevice, &dev);
-    if (oom_check(dev, size)) {
+    int do_oom_check = (prop->location.type == CU_MEM_LOCATION_TYPE_DEVICE);
+    if (do_oom_check && cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
+        dev = prop->location.id;
+    }
+    if (do_oom_check && oom_check(dev, size)) {
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,

--- a/test/test_mem_create.c
+++ b/test/test_mem_create.c
@@ -1,0 +1,77 @@
+#include <stdio.h>
+#include <cuda.h>
+#include <pthread.h>
+
+#include "test_utils.h"
+
+#define NUM_THREADS 4
+#define ALLOC_SIZE  (64 * 1024 * 1024)
+
+static CUdevice g_device;
+
+void *thread_func(void *arg) {
+    int tid = *(int *)arg;
+
+    CUmemAllocationProp prop = {0};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = g_device;
+
+    size_t granularity = 0;
+    CUresult res = cuMemGetAllocationGranularity(&granularity, &prop,
+                                                  CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+    if (res != CUDA_SUCCESS) {
+        fprintf(stderr, "thread %d: cuMemGetAllocationGranularity failed: %d\n", tid, res);
+        return NULL;
+    }
+
+    size_t size = ((ALLOC_SIZE + granularity - 1) / granularity) * granularity;
+
+    CUmemGenericAllocationHandle handle;
+    res = cuMemCreate(&handle, size, &prop, 0);
+    printf("thread %d: cuMemCreate returned %d (size=%zu)\n", tid, res, size);
+
+    if (res == CUDA_SUCCESS) {
+        cuMemRelease(handle);
+        return (void *)1;
+    }
+
+    return NULL;
+}
+
+int main() {
+    CHECK_DRV_API(cuInit(0));
+
+    CHECK_DRV_API(cuDeviceGet(&g_device, TEST_DEVICE_ID));
+
+    CUcontext ctx;
+    CHECK_DRV_API(cuCtxCreate(&ctx, 0, g_device));
+
+    pthread_t threads[NUM_THREADS];
+    int tids[NUM_THREADS];
+    int i;
+
+    for (i = 0; i < NUM_THREADS; i++) {
+        tids[i] = i;
+        pthread_create(&threads[i], NULL, thread_func, &tids[i]);
+    }
+
+    int success_count = 0;
+    for (i = 0; i < NUM_THREADS; i++) {
+        void *ret = NULL;
+        pthread_join(threads[i], &ret);
+        if (ret != NULL)
+            success_count++;
+    }
+
+    printf("%d/%d threads succeeded\n", success_count, NUM_THREADS);
+
+    if (success_count != NUM_THREADS) {
+        fprintf(stderr, "expected all threads to succeed\n");
+        return 1;
+    }
+
+    CHECK_NVML_API(nvmlShutdown());
+    CHECK_DRV_API(cuCtxDestroy(ctx));
+    return 0;
+}


### PR DESCRIPTION
## Problem

We ran into a segfault when loading models with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`. This setting makes PyTorch use `cuMemCreate`/`cuMemMap` (VMM APIs) instead of `cuMemAlloc`.

In our case, `transformers` loads weights using a `ThreadPoolExecutor`. On worker threads where the CUDA context hasn't been established yet, `cuCtxGetDevice` can return `CUDA_ERROR_INVALID_CONTEXT` (201). The current `cuMemCreate` hook calls `cuCtxGetDevice` via `CUDA_OVERRIDE_CALL` which discards the return value, so the `dev` variable stays uninitialized. This garbage value gets passed into `oom_check` → `get_current_device_memory_limit`, leading to an out-of-bounds access and segfault.

We confirmed `cuCtxGetDevice` returns 201 on worker threads:

```
=== Main thread (after torch.cuda.init) ===
  cuCtxGetDevice ret=0, dev=0       ← OK

=== Worker threads (before any CUDA op) ===
  thread 0: cuCtxGetDevice ret=201, dev=-999  ← CUDA_ERROR_INVALID_CONTEXT
  thread 1: cuCtxGetDevice ret=201, dev=-999
  thread 2: cuCtxGetDevice ret=201, dev=-999
  thread 3: cuCtxGetDevice ret=201, dev=-999
```

This appears to be the same issue reported in #169.

## Proposed fix

```diff
     CUdevice dev;
-    CUDA_OVERRIDE_CALL(cuda_library_entry, cuCtxGetDevice, &dev);
-    if (oom_check(dev, size)) {
+    int do_oom_check = (prop->location.type == CU_MEM_LOCATION_TYPE_DEVICE);
+    if (do_oom_check && cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
+        dev = prop->location.id;
+    }
+    if (do_oom_check && oom_check(dev, size)) {
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
```

- Check `cuCtxGetDevice` return value. When it fails, fall back to `prop->location.id` (the target device from the allocation request) so the OOM check still works correctly.
- Only run OOM check for `CU_MEM_LOCATION_TYPE_DEVICE` allocations, since GPU memory limits don't apply to other location types.

Happy to adjust the approach if maintainers have a different preference.

## Test

Added `test/test_mem_create.c` — spawns 4 threads that call `cuMemCreate`. Without the fix this segfaults; with the fix all threads complete normally.

## Verification

Tested on H100 80GB with HAMI v2.7.1 (HAMi-core ec8979d):

| Test | Before fix | After fix |
|------|-----------|-----------|
| Python + `expandable_segments:True` | Segfault (exit 139) | OK (exit 0) |
| Python without `expandable_segments` | OK | OK |
| `test_mem_create` (C, 4 threads, no context) | Segfault | OK, all threads pass |
| `test_alloc` | OK | OK |
| `test_alloc_managed` | OK | OK |
| `test_alloc_pitch` | OK | OK |

## Reproducer (Python, optional)

<details>
<summary>Click to expand</summary>

```python
# pip install torch transformers safetensors
# Crashes:  PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python repro.py
# Works:    python repro.py
import argparse, json, os, tempfile, torch
from safetensors.torch import save_file

BERT_CONFIG = {
    "architectures": ["BertModel"], "model_type": "bert",
    "hidden_size": 4096, "intermediate_size": 16384,
    "num_hidden_layers": 20, "num_attention_heads": 32,
    "max_position_embeddings": 512, "vocab_size": 30522,
    "type_vocab_size": 2, "hidden_act": "gelu",
    "layer_norm_eps": 1e-12, "hidden_dropout_prob": 0.1,
    "attention_probs_dropout_prob": 0.1,
}

def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("--single-thread", action="store_true")
    args = parser.parse_args()
    print(f"PyTorch {torch.__version__}, CUDA {torch.version.cuda}")
    print(f"PYTORCH_CUDA_ALLOC_CONF={os.environ.get('PYTORCH_CUDA_ALLOC_CONF', '(unset)')}")
    if args.single_thread:
        import transformers.core_model_loading as cml
        cml.GLOBAL_WORKERS = 0
    with tempfile.TemporaryDirectory() as d:
        with open(os.path.join(d, "config.json"), "w") as f:
            json.dump(BERT_CONFIG, f)
        from transformers import AutoModel, AutoConfig
        model = AutoModel.from_config(AutoConfig.for_model(**BERT_CONFIG))
        save_file(model.state_dict(), os.path.join(d, "model.safetensors"))
        del model
        AutoModel.from_pretrained(d, device_map="cuda")
        print("OK")

if __name__ == "__main__":
    main()
```

</details>

## Environment

- HAMI v2.7.1 (HAMi-core ec8979d)
- NVIDIA H100 80GB HBM3, Driver 570.x, CUDA 12.8
- PyTorch 2.9.1+cu128, transformers 4.52.4