### PR TITLE
fix: 用可移植的 dlopen 方案替换内部 _dl_sym 符号，修复 GLIBC_PRIVATE 错误

### DIFF
--- a/src/include/libvgpu.h
+++ b/src/include/libvgpu.h
@@ -29,8 +29,6 @@ extern void load_cuda_libraries();
 
 #define FUNC_OVERRIDE_NAME(fname) overrided_##fname
 
-extern void* _dl_sym(void*, const char*, void*);
-
 #if defined(DLSYM_HOOK_DEBUG)
 #define DLSYM_HOOK_FUNC(f)                                       \
     if (0 == strcmp(symbol, #f)) {                               \

--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -99,9 +99,12 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
         }
         if (real_dlsym == NULL) {
             LOG_ERROR("real dlsym not found");
-            real_dlsym = _dl_sym(RTLD_NEXT, "dlsym", dlsym);
+            void *libc_handle = dlopen("libc.so.6", RTLD_LAZY);
+            if (libc_handle) {
+                real_dlsym = dlsym(libc_handle, "dlsym");
+            }
             if (real_dlsym == NULL)
-                LOG_ERROR("real dlsym not found");
+                LOG_ERROR("real dlsym not found after trying libc.so.6");
         }
     }
     if (handle == RTLD_NEXT) {
@@ -858,9 +861,12 @@ void preInit(){
         real_dlsym = dlvsym(RTLD_NEXT,"dlsym","GLIBC_2.2.5");
         if (real_dlsym == NULL) {
             LOG_ERROR("real dlsym not found");
-            real_dlsym = _dl_sym(RTLD_NEXT, "dlsym", dlsym);
-            if (real_dlsym == NULL)
+            void *libc_handle = dlopen("libc.so.6", RTLD_LAZY);
+            if (libc_handle) {
+                real_dlsym = dlsym(libc_handle, "dlsym");
+            } else {
                 LOG_ERROR("real dlsym not found");
+            }
         }
     }
     real_realpath = NULL;

--- a/src/nvml/hook.c
+++ b/src/nvml/hook.c
@@ -267,8 +267,6 @@ nvmlReturn_t nvmlDeviceGetIndex(nvmlDevice_t device, unsigned int *index) {
 }
 
 
-extern void* _dl_sym(void*, const char*, void*);
-
 void load_nvml_libraries() {
     void *table = NULL;
     char driver_filename[FILENAME_MAX];
@@ -276,7 +274,10 @@ void load_nvml_libraries() {
     if (real_dlsym == NULL) {
         real_dlsym = dlvsym(RTLD_NEXT,"dlsym","GLIBC_2.2.5");
         if (real_dlsym == NULL) {
-            real_dlsym = _dl_sym(RTLD_NEXT, "dlsym", dlsym);
+            void *libc_handle = dlopen("libc.so.6", RTLD_LAZY);
+            if (libc_handle) {
+                real_dlsym = dlsym(libc_handle, "dlsym");
+            }
             if (real_dlsym == NULL)
                 LOG_ERROR("real dlsym not found");
         }


### PR DESCRIPTION
### 概述
本 PR 修复了在容器环境中运行 HAMi-core 时出现的 undefined symbol: _dl_sym, version GLIBC_PRIVATE 运行时错误。

### 问题
代码之前使用了 _dl_sym ，这是 glibc 的内部符号（GLIBC_PRIVATE 版本标签）。该符号不属于公共 API，并非在所有 glibc 版本中都可用，导致库在容器环境中无法加载。

错误信息：

```
./Service/ symbol lookup error: /usr/
local/vgpu/libvgpu.so: undefined symbol: 
_dl_sym, version GLIBC_PRIVATE
```
### 解决方案
将所有 _dl_sym 的使用替换为使用 dlopen("libc.so.6") + dlsym() 的可移植方案：

```
// 修改前
real_dlsym = _dl_sym(RTLD_NEXT, "dlsym", 
dlsym);

// 修改后
void *libc_handle = dlopen("libc.so.6", 
RTLD_LAZY);
if (libc_handle) {
    real_dlsym = dlsym(libc_handle, 
    "dlsym");
}
```
### 修改内容
文件 修改内容 src/libvgpu.c 替换 dlsym() 和 preInit() 函数中的 _dl_sym src/nvml/hook.c 替换 load_nvml_libraries() 函数中的 _dl_sym src/include/libvgpu.h 移除 extern void* _dl_sym(...) 声明


### 影响
- ✅ 修复不同 glibc 版本间的兼容性问题
- ✅ 解决容器环境中的运行时崩溃
- ✅ 仅使用公共 POSIX API，不依赖内部符号
- ✅ 对现有功能无破坏性变更

### 相关问题
修复： [ undefined symbol: _dl_sym, version GLIBC_PRIVATE 运行时错误](https://github.com/Project-HAMi/HAMi-core/issues/174)