### PR TITLE
fix(test): test_mem_create failing due to uninitialized NVML shutdown

### DIFF
--- a/test/test_mem_create.c
+++ b/test/test_mem_create.c
@@ -71,7 +71,6 @@ int main() {
         return 1;
     }
 
-    CHECK_NVML_API(nvmlShutdown());
     CHECK_DRV_API(cuCtxDestroy(ctx));
     return 0;
 }

--- a/test/test_runtime_launch.cu
+++ b/test/test_runtime_launch.cu
@@ -46,7 +46,6 @@ int main() {
 
     cudaFree(d_data);
 
-    sleep(100);
-    printf("completed");
+    printf("completed\n");
     return 0;
 }


### PR DESCRIPTION
test_mem_create was calling nvmlShutdown() at the end of main() without ever initializing NVML.
Also removing unnecessary sleep in test_runtime_launch