### PR TITLE
feat: multi-GPU independent token pool for rate limiting

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <semaphore.h>
 #include <unistd.h>
 #include <time.h>
@@ -26,8 +27,8 @@
 
 static int g_sm_num[CUDA_DEVICE_MAX_COUNT];
 static int g_max_thread_per_sm[CUDA_DEVICE_MAX_COUNT];
-static volatile long g_cur_cuda_cores[CUDA_DEVICE_MAX_COUNT] = {0};
-static volatile long g_total_cuda_cores[CUDA_DEVICE_MAX_COUNT] = {0};
+static volatile int64_t g_cur_cuda_cores[CUDA_DEVICE_MAX_COUNT] = {0};
+static volatile int64_t g_total_cuda_cores[CUDA_DEVICE_MAX_COUNT] = {0};
 extern int pidfound;
 int cuda_to_nvml_map_array[CUDA_DEVICE_MAX_COUNT];
 
@@ -40,9 +41,9 @@ void rate_limiter(int grids, int blocks) {
   CUresult res = cuCtxGetDevice(&current_device);
   int device_id = (res == CUDA_SUCCESS) ? (int)current_device : 0;
 
-  long before_cuda_cores = 0;
-  long after_cuda_cores = 0;
-  long kernel_size = grids;
+  int64_t before_cuda_cores = 0;
+  int64_t after_cuda_cores = 0;
+  int64_t kernel_size = grids;
 
   /* Fast exit using cached values — no shared memory access needed */
   if (cached_sm_limit[device_id] >= 100 || cached_sm_limit[device_id] == 0) {
@@ -66,11 +67,10 @@ CHECK:
       }
       after_cuda_cores = before_cuda_cores - kernel_size;
   } while (!CAS(&g_cur_cuda_cores[device_id], before_cuda_cores, after_cuda_cores));
-
 }
 
-static void change_token(long delta, int device_id) {
-  long cuda_cores_before = 0, cuda_cores_after = 0;
+static void change_token(int64_t delta, int device_id) {
+  int64_t cuda_cores_before = 0, cuda_cores_after = 0;
 
   LOG_DEBUG("device %d: delta: %ld, curr: %ld", device_id, delta, g_cur_cuda_cores[device_id]);
   do {
@@ -83,12 +83,12 @@ static void change_token(long delta, int device_id) {
   } while (!CAS(&g_cur_cuda_cores[device_id], cuda_cores_before, cuda_cores_after));
 }
 
-static long delta(int up_limit, int user_current, long share, int device_id) {
+static int64_t delta(int up_limit, int user_current, int64_t share, int device_id) {
   int utilization_diff =
       abs(up_limit - user_current) < 5 ? 5 : abs(up_limit - user_current);
-  long increment =
-      (long)g_sm_num[device_id] * (long)g_sm_num[device_id] *
-      (long)g_max_thread_per_sm[device_id] * (long)utilization_diff / 2560;
+  int64_t increment =
+      (int64_t)g_sm_num[device_id] * (int64_t)g_sm_num[device_id] *
+      (int64_t)g_max_thread_per_sm[device_id] * (int64_t)utilization_diff / 2560;
 
   /* Accelerate cuda cores allocation when utilization vary widely */
   if (utilization_diff > up_limit / 2) {
@@ -218,7 +218,7 @@ void* utilization_watcher() {
         return;
     }
 
-    long share[CUDA_DEVICE_MAX_COUNT] = {0};
+    int64_t share[CUDA_DEVICE_MAX_COUNT] = {0};
 
     ensure_initialized();
 
@@ -238,12 +238,12 @@ void* utilization_watcher() {
                 continue;
             }
 
-            if ((share[dev]==g_total_cuda_cores[dev]) && (g_cur_cuda_cores[dev]<0)) {
+            if ((share[dev] == g_total_cuda_cores[dev]) && (g_cur_cuda_cores[dev] < 0)) {
               g_total_cuda_cores[dev] *= 2;
               share[dev] = g_total_cuda_cores[dev];
             }
 
-            if ((userutil[dev]<=100) && (userutil[dev]>=0)){
+            if ((userutil[dev] <= 100) && (userutil[dev] >= 0)) {
               share[dev] = delta(cached_sm_limit[dev], userutil[dev], share[dev], dev);
               change_token(share[dev], dev);
             }

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -24,66 +24,71 @@
 #include "include/nvml_override.h"
 
 
-static int g_sm_num;
-static int g_max_thread_per_sm;
-static volatile long g_cur_cuda_cores = 0;
-static volatile long g_total_cuda_cores = 0;
+static int g_sm_num[CUDA_DEVICE_MAX_COUNT];
+static int g_max_thread_per_sm[CUDA_DEVICE_MAX_COUNT];
+static volatile long g_cur_cuda_cores[CUDA_DEVICE_MAX_COUNT] = {0};
+static volatile long g_total_cuda_cores[CUDA_DEVICE_MAX_COUNT] = {0};
 extern int pidfound;
 int cuda_to_nvml_map_array[CUDA_DEVICE_MAX_COUNT];
 
 /* Cached at init — these values do not change at runtime */
-static int cached_sm_limit = 0;
+static int cached_sm_limit[CUDA_DEVICE_MAX_COUNT] = {0};
 static int cached_util_switch = 0;
 
 void rate_limiter(int grids, int blocks) {
+  CUdevice current_device;
+  CUresult res = cuCtxGetDevice(&current_device);
+  int device_id = (res == CUDA_SUCCESS) ? (int)current_device : 0;
+
   long before_cuda_cores = 0;
   long after_cuda_cores = 0;
   long kernel_size = grids;
 
   /* Fast exit using cached values — no shared memory access needed */
-  if (cached_sm_limit >= 100 || cached_sm_limit == 0)
+  if (cached_sm_limit[device_id] >= 100 || cached_sm_limit[device_id] == 0) {
       return;
-  if (cached_util_switch == 0)
+  }
+  if (cached_util_switch == 0) {
       return;
+  }
 
   while (get_recent_kernel()<0) {
     sleep(1);
   }
   set_recent_kernel(2);
 
-  LOG_DEBUG("grid: %d, blocks: %d", grids, blocks);
-  LOG_DEBUG("launch kernel %ld, curr core: %ld", kernel_size, g_cur_cuda_cores);
   do {
 CHECK:
-      before_cuda_cores = g_cur_cuda_cores;
-      LOG_DEBUG("current core: %ld", g_cur_cuda_cores);
+      before_cuda_cores = g_cur_cuda_cores[device_id];
       if (before_cuda_cores < 0) {
         nanosleep(&g_cycle, NULL);
         goto CHECK;
       }
       after_cuda_cores = before_cuda_cores - kernel_size;
-  } while (!CAS(&g_cur_cuda_cores, before_cuda_cores, after_cuda_cores));
+  } while (!CAS(&g_cur_cuda_cores[device_id], before_cuda_cores, after_cuda_cores));
+
 }
 
-static void change_token(long delta) {
-  int cuda_cores_before = 0, cuda_cores_after = 0;
+static void change_token(long delta, int device_id) {
+  long cuda_cores_before = 0, cuda_cores_after = 0;
 
-  LOG_DEBUG("delta: %ld, curr: %ld", delta, g_cur_cuda_cores);
+  LOG_DEBUG("device %d: delta: %ld, curr: %ld", device_id, delta, g_cur_cuda_cores[device_id]);
   do {
-    cuda_cores_before = g_cur_cuda_cores;
+    cuda_cores_before = g_cur_cuda_cores[device_id];
     cuda_cores_after = cuda_cores_before + delta;
 
-    if (cuda_cores_after > g_total_cuda_cores) {
-      cuda_cores_after = g_total_cuda_cores;
+    if (cuda_cores_after > g_total_cuda_cores[device_id]) {
+      cuda_cores_after = g_total_cuda_cores[device_id];
     }
-  } while (!CAS(&g_cur_cuda_cores, cuda_cores_before, cuda_cores_after));
+  } while (!CAS(&g_cur_cuda_cores[device_id], cuda_cores_before, cuda_cores_after));
 }
 
-long delta(int up_limit, int user_current, long share) {
+static long delta(int up_limit, int user_current, long share, int device_id) {
   int utilization_diff =
       abs(up_limit - user_current) < 5 ? 5 : abs(up_limit - user_current);
   long increment =
-      (long)g_sm_num * (long)g_sm_num * (long)g_max_thread_per_sm * (long)utilization_diff / 2560;
+      (long)g_sm_num[device_id] * (long)g_sm_num[device_id] *
+      (long)g_max_thread_per_sm[device_id] * (long)utilization_diff / 2560;
 
   /* Accelerate cuda cores allocation when utilization vary widely */
   if (utilization_diff > up_limit / 2) {
@@ -91,8 +96,9 @@ long delta(int up_limit, int user_current, long share) {
   }
 
   if (user_current <= up_limit) {
-    share = (share + increment) > g_total_cuda_cores ? g_total_cuda_cores
-                                                   : (share + increment);
+    share = (share + increment) > g_total_cuda_cores[device_id]
+            ? g_total_cuda_cores[device_id]
+            : (share + increment);
   } else {
     share = (share - increment) < 0 ? 0 : (share - increment);
   }
@@ -116,10 +122,22 @@ unsigned int cuda_to_nvml_map(unsigned int cudadev){
 }
 
 int setspec() {
+    unsigned int device_count;
+
     CHECK_NVML_API(nvmlInit());
-    CHECK_CU_RESULT(cuDeviceGetAttribute(&g_sm_num,CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,0));
-    CHECK_CU_RESULT(cuDeviceGetAttribute(&g_max_thread_per_sm,CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,0));
-    g_total_cuda_cores = g_max_thread_per_sm * g_sm_num * FACTOR;
+    CHECK_NVML_API(nvmlDeviceGetCount(&device_count));
+
+    for (unsigned int dev = 0; dev < device_count && dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+        CUdevice cu_dev;
+        CHECK_CU_RESULT(cuDeviceGet(&cu_dev, dev));
+        CHECK_CU_RESULT(cuDeviceGetAttribute(&g_sm_num[dev],
+            CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, cu_dev));
+        CHECK_CU_RESULT(cuDeviceGetAttribute(&g_max_thread_per_sm[dev],
+            CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR, cu_dev));
+        g_total_cuda_cores[dev] = g_max_thread_per_sm[dev] * g_sm_num[dev] * FACTOR;
+        LOG_INFO("setspec: device %d sm_num=%d max_threads_per_sm=%d total_cores=%ld FACTOR=%d",
+                 dev, g_sm_num[dev], g_max_thread_per_sm[dev], g_total_cuda_cores[dev], FACTOR);
+    }
     return 0;
 }
 
@@ -194,10 +212,16 @@ void* utilization_watcher() {
     nvmlInit();
     int userutil[CUDA_DEVICE_MAX_COUNT];
     int sysprocnum;
-    long share = 0;
-    int upper_limit = get_current_device_sm_limit(0);
+
+    unsigned int device_count;
+    if (nvmlDeviceGetCount(&device_count) != NVML_SUCCESS) {
+        return;
+    }
+
+    long share[CUDA_DEVICE_MAX_COUNT] = {0};
+
     ensure_initialized();
-    LOG_DEBUG("upper_limit=%d\n",upper_limit);
+
     while (1){
         nanosleep(&g_wait, NULL);
         if (pidfound==0) {
@@ -207,31 +231,54 @@ void* utilization_watcher() {
         }
         init_gpu_device_utilization();
         get_used_gpu_utilization(userutil,&sysprocnum);
-        //if (sysprocnum == 1 &&
-        //    userutil < upper_limit / 10) {
-        //    g_cur_cuda_cores =
-        //        delta(upper_limit, userutil, share);
-        //    continue;
-        //}
-        if ((share==g_total_cuda_cores) && (g_cur_cuda_cores<0)) {
-          g_total_cuda_cores *= 2;
-          share = g_total_cuda_cores;
+
+        // Calculate independently for each device
+        for (unsigned int dev = 0; dev < device_count && dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+            if (cached_sm_limit[dev] <= 0 || cached_sm_limit[dev] >= 100) {
+                continue;
+            }
+
+            if ((share[dev]==g_total_cuda_cores[dev]) && (g_cur_cuda_cores[dev]<0)) {
+              g_total_cuda_cores[dev] *= 2;
+              share[dev] = g_total_cuda_cores[dev];
+            }
+
+            if ((userutil[dev]<=100) && (userutil[dev]>=0)){
+              share[dev] = delta(cached_sm_limit[dev], userutil[dev], share[dev], dev);
+              change_token(share[dev], dev);
+            }
+
+            LOG_INFO("device %d: userutil=%d currentcores=%ld total=%ld limit=%d share=%ld\n",
+                     dev, userutil[dev], g_cur_cuda_cores[dev], g_total_cuda_cores[dev],
+                     cached_sm_limit[dev], share[dev]);
         }
-        if ((userutil[0]<=100) && (userutil[0]>=0)){
-          share = delta(upper_limit, userutil[0], share);
-          change_token(share);
-        }
-        LOG_INFO("userutil1=%d currentcores=%ld total=%ld limit=%d share=%ld\n",userutil[0],g_cur_cuda_cores,g_total_cuda_cores,upper_limit,share);
     }
 }
 
 void init_utilization_watcher() {
-    cached_sm_limit = get_current_device_sm_limit(0);
     cached_util_switch = get_utilization_switch();
-    LOG_INFO("set core utilization limit to  %d", cached_sm_limit);
+    LOG_INFO("init_utilization_watcher: util_switch=%d", cached_util_switch);
+
+    unsigned int device_count;
+    if (nvmlDeviceGetCount(&device_count) != NVML_SUCCESS) {
+        LOG_WARN("nvmlDeviceGetCount failed");
+        return;
+    }
+
     setspec();
+
+    // Initialize cached_sm_limit for each device
+    int has_limit = 0;
+    for (unsigned int dev = 0; dev < device_count && dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+        cached_sm_limit[dev] = get_current_device_sm_limit(dev);
+        LOG_INFO("device %d: core utilization limit = %d", dev, cached_sm_limit[dev]);
+        if (cached_sm_limit[dev] > 0 && cached_sm_limit[dev] <= 100) {
+            has_limit = 1;
+        }
+    }
+
     pthread_t tid;
-    if ((cached_sm_limit <= 100) && (cached_sm_limit > 0)) {
+    if (has_limit && cached_util_switch == 1) {
         pthread_create(&tid, NULL, utilization_watcher, NULL);
     }
     return;

--- a/test/test_multi_gpu_utilization.cu
+++ b/test/test_multi_gpu_utilization.cu
@@ -1,0 +1,206 @@
+/**
+ * test_multi_gpu_utilization.cu
+ *
+ * Test for multi-GPU independent token pool functionality.
+ *
+ * This test verifies that GPU utilization limiting works independently
+ * for each GPU device, which is essential for VLLM TP>1 scenarios.
+ *
+ * Test Scenarios:
+ *   1. Both GPUs run IDENTICAL workload with SAME SM limit
+ *   2. If token pools are SHARED , GPUs will block each other
+ *   3. If token pools are INDEPENDENT (correct), both complete normally
+ *
+ * Usage:
+ *   rm -f /tmp/cudevshr.cache
+ *   export CUDA_DEVICE_SM_LIMIT=25
+ *   export GPU_CORE_UTILIZATION_POLICY=FORCE
+ *   LD_PRELOAD=./build/libvgpu.so ./build/test/test_multi_gpu_utilization
+ *
+ * Expected behavior:
+ *   - Each GPU should have its own token pool
+ *   - Both GPUs should complete in similar time (not blocking each other)
+ *   - If GPU1 waits for GPU0, it indicates SHARED token pool
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <cuda_runtime.h>
+#include <unistd.h>
+#include <time.h>
+
+#define CHECK_CUDA(call) \
+    do { \
+        cudaError_t err = call; \
+        if (err != cudaSuccess) { \
+            fprintf(stderr, "CUDA error at %s:%d: %s\n", \
+                    __FILE__, __LINE__, cudaGetErrorString(err)); \
+            exit(1); \
+        } \
+    } while(0)
+
+// Busy kernel that consumes GPU resources
+__global__ void busyKernel(double* data, int N, int iterations) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid < N) {
+        double sum = 0.0;
+        for (int i = 0; i < iterations; i++) {
+            sum += sin(data[tid] * 0.001) * cos(data[tid] * 0.001);
+            data[tid] = sum;
+        }
+    }
+}
+
+// Thread argument structure
+typedef struct {
+    int device_id;
+    int num_kernels;
+    int iterations;
+    double elapsed_time;
+    int completed;
+} ThreadArg;
+
+// Thread function to run kernels on a specific GPU
+void* runOnDevice(void* arg) {
+    ThreadArg* ta = (ThreadArg*)arg;
+    struct timespec start, end;
+
+    CHECK_CUDA(cudaSetDevice(ta->device_id));
+
+    // Allocate memory
+    int N = 1 << 24;  // ~16M elements
+    double* d_data;
+    CHECK_CUDA(cudaMalloc(&d_data, N * sizeof(double)));
+    CHECK_CUDA(cudaMemset(d_data, 0, N * sizeof(double)));
+
+    int threadsPerBlock = 256;
+    int blocks = (N + threadsPerBlock - 1) / threadsPerBlock;
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    // Launch multiple kernels
+    for (int i = 0; i < ta->num_kernels; i++) {
+        busyKernel<<<blocks, threadsPerBlock>>>(d_data, N, ta->iterations);
+        CHECK_CUDA(cudaGetLastError());
+    }
+
+    CHECK_CUDA(cudaDeviceSynchronize());
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    ta->elapsed_time = (end.tv_sec - start.tv_sec) +
+                       (end.tv_nsec - start.tv_nsec) / 1e9;
+    ta->completed = 1;
+
+    CHECK_CUDA(cudaFree(d_data));
+
+    printf("[GPU %d] Completed %d kernels (%d iterations each) in %.2f seconds\n",
+           ta->device_id, ta->num_kernels, ta->iterations, ta->elapsed_time);
+
+    return NULL;
+}
+
+int main(int argc, char** argv) {
+    int deviceCount;
+    CHECK_CUDA(cudaGetDeviceCount(&deviceCount));
+
+    printf("========================================\n");
+    printf("Multi-GPU Token Pool Isolation Test\n");
+    printf("========================================\n");
+    printf("Found %d GPU(s)\n", deviceCount);
+
+    if (deviceCount < 2) {
+        printf("\n[WARNING] This test requires at least 2 GPUs.\n");
+        printf("Current system only has %d GPU(s).\n", deviceCount);
+        printf("The test will run in single-GPU mode for basic validation.\n\n");
+
+        // Fall back to single GPU test
+        pthread_t thread;
+        ThreadArg arg = {0, 5, 2000, 0.0, 0};
+
+        printf("Running single-GPU test...\n");
+        pthread_create(&thread, NULL, runOnDevice, &arg);
+        pthread_join(thread, NULL);
+
+        printf("\n[RESULT] Single-GPU test completed in %.2f seconds.\n", arg.elapsed_time);
+        return 0;
+    }
+
+    // Multi-GPU test: IDENTICAL workload on both GPUs
+    printf("\nTest: Both GPUs run IDENTICAL workload\n");
+    printf("If token pools are SHARED, GPUs will BLOCK each other\n");
+    printf("If token pools are INDEPENDENT, both complete normally\n\n");
+
+    pthread_t threads[2];
+    ThreadArg args[2];
+
+    // IDENTICAL workload for both GPUs
+    int num_kernels = 5;
+    int iterations = 2000;
+
+    // GPU0
+    args[0].device_id = 0;
+    args[0].num_kernels = num_kernels;
+    args[0].iterations = iterations;
+    args[0].elapsed_time = 0.0;
+    args[0].completed = 0;
+
+    // GPU1 - SAME workload as GPU0
+    args[1].device_id = 1;
+    args[1].num_kernels = num_kernels;
+    args[1].iterations = iterations;
+    args[1].elapsed_time = 0.0;
+    args[1].completed = 0;
+
+    struct timespec total_start, total_end;
+    clock_gettime(CLOCK_MONOTONIC, &total_start);
+
+    // Start both threads simultaneously
+    pthread_create(&threads[0], NULL, runOnDevice, &args[0]);
+    pthread_create(&threads[1], NULL, runOnDevice, &args[1]);
+
+    // Wait for both to complete
+    pthread_join(threads[0], NULL);
+    pthread_join(threads[1], NULL);
+
+    clock_gettime(CLOCK_MONOTONIC, &total_end);
+    double total_time = (total_end.tv_sec - total_start.tv_sec) +
+                        (total_end.tv_nsec - total_start.tv_nsec) / 1e9;
+
+    printf("\n========================================\n");
+    printf("RESULTS:\n");
+    printf("========================================\n");
+    printf("GPU0: %.2f seconds\n", args[0].elapsed_time);
+    printf("GPU1: %.2f seconds\n", args[1].elapsed_time);
+    printf("Total: %.2f seconds\n", total_time);
+    printf("Time difference: %.2f seconds (%.1f%%)\n",
+           fabs(args[0].elapsed_time - args[1].elapsed_time),
+           fabs(args[0].elapsed_time - args[1].elapsed_time) /
+           ((args[0].elapsed_time + args[1].elapsed_time) / 2) * 100);
+    printf("\n");
+
+    // Analysis
+    double max_time = args[0].elapsed_time > args[1].elapsed_time ?
+                      args[0].elapsed_time : args[1].elapsed_time;
+    double min_time = args[0].elapsed_time < args[1].elapsed_time ?
+                      args[0].elapsed_time : args[1].elapsed_time;
+    double ratio = max_time / min_time;
+
+    if (ratio < 1.2) {
+        printf("[PASS] Both GPUs completed in similar time (ratio=%.2fx)\n", ratio);
+        printf("       This indicates per-GPU token pools are INDEPENDENT.\n");
+        printf("       No blocking between GPUs detected.\n");
+    } else {
+        printf("[FAIL] Significant time difference (ratio=%.2fx)\n", ratio);
+        printf("       One GPU may have been BLOCKED by the other.\n");
+        printf("       This could indicate SHARED token pool.\n");
+    }
+
+    printf("\n[NOTE] Test prerequisites:\n");
+    printf("       rm -f /tmp/cudevshr.cache\n");
+    printf("       export CUDA_DEVICE_SM_LIMIT=25\n");
+    printf("       export GPU_CORE_UTILIZATION_POLICY=FORCE\n");
+
+    return 0;
+}

--- a/test/test_multi_gpu_utilization.cu
+++ b/test/test_multi_gpu_utilization.cu
@@ -38,7 +38,7 @@
                     __FILE__, __LINE__, cudaGetErrorString(err)); \
             exit(1); \
         } \
-    } while(0)
+    } while (0)
 
 // Busy kernel that consumes GPU resources
 __global__ void busyKernel(double* data, int N, int iterations) {


### PR DESCRIPTION
Problem:
#142 
- All GPUs in a pod share a single global token pool (g_cur_cuda_cores)
- GPU1 tasks blocked by GPU0 utilization in VLLM TP>1 scenarios

Solution:
- Per-device token pools: g_cur_cuda_cores[device_id]
- rate_limiter() detects current device via cuCtxGetDevice()
- utilization_watcher() iterates all devices independently

Key changes:
- Global variables changed to per-device arrays
- rate_limiter() uses cuCtxGetDevice() for transparent device detection

Test:
- test/test_multi_gpu_utilization.cu verifies GPU independence
Using the same workload, compare the execution time on GPU0 and GPU1.

before:
<img width="537" height="354" alt="image" src="https://github.com/user-attachments/assets/dd5b9ec3-9eb4-407e-aafc-ff71dc6e5ea2" />
after:
<img width="493" height="369" alt="image" src="https://github.com/user-attachments/assets/e5caabf6-236f-4d06-98d5-d570a63402e7" />
