### PR TITLE
fix: make build.sh resilient to missing git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
 cmake-build-debug
+.idea
+.vscode
+.claude

--- a/build.sh
+++ b/build.sh
@@ -28,10 +28,7 @@ if [ -z "$CI_COMMIT_BRANCH" ]; then
     CI_COMMIT_BRANCH=${BRANCH_NAME:-"unknown"}
 fi
 if [ -z "$CI_COMMIT_SHA" ]; then
-    CI_COMMIT_SHA=$(git describe --abbrev=100 --always)
-    if [ $? -ne 0 ]; then
-        CI_COMMIT_SHA="unknown"
-    fi
+    CI_COMMIT_SHA=$(git describe --abbrev=100 --always 2>/dev/null || echo "unknown")
 fi
 
 echo "CI_COMMIT_BRANCH:${CI_COMMIT_BRANCH}"


### PR DESCRIPTION
## Summary
- `build.sh` used `set -e` with `$(git describe ...)` and a `$?` check that was never reached when git is unavailable
- This was discovered during a HAMi Docker build, where the `nvbuild` stage only installs `cmake` (not `git`), causing `build.sh` to fail immediately with "git: command not found"
- Replaced with a single `|| echo "unknown"` fallback that works correctly under `set -e`
- Also added `.idea`, `.vscode`, `.claude` to `.gitignore`

## Test plan
- [x] Script still works normally when git is available
- [x] Script falls back to `"unknown"` when git is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)