### PR TITLE
fix cuMemcreate cause core dump and get memory usage 0 after allocate twice

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -108,7 +108,7 @@ int add_chunk(CUdeviceptr *address, size_t size) {
         return CUDA_ERROR_OUT_OF_MEMORY;
     
     allocated_list_entry *e;
-    INIT_ALLOCATED_LIST_ENTRY(e,addr,size);
+    INIT_ALLOCATED_LIST_ENTRY(e, addr, size, dev);
     if (size <= IPCSIZE)
         res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAlloc_v2,&e->entry->address,size);
     else{
@@ -128,23 +128,20 @@ int add_chunk(CUdeviceptr *address, size_t size) {
     return 0;
 }
 
-int add_chunk_only(CUdeviceptr address, size_t size) {
+int add_chunk_only(CUdeviceptr address, size_t size, CUdevice dev) {
     pthread_mutex_lock(&mutex);
     size_t addr=0;
     size_t allocsize;
-    CUdevice dev;
-    cuCtxGetDevice(&dev);
     if (oom_check(dev,size)){
         pthread_mutex_unlock(&mutex);
         return -1;
     }
     allocated_list_entry *e;
-    INIT_ALLOCATED_LIST_ENTRY(e,addr,size);
+    INIT_ALLOCATED_LIST_ENTRY(e, addr, size, dev);
     LIST_ADD(device_overallocated,e);
     //uint64_t t_size;
     e->entry->address=address;
     allocsize = size;
-    cuCtxGetDevice(&dev);
     add_gpu_device_memory_usage(getpid(), dev, allocsize, 2);
     pthread_mutex_unlock(&mutex);
     return 0;
@@ -183,6 +180,7 @@ int remove_chunk(allocated_list *a_list, CUdeviceptr dptr) {
 int remove_chunk_only(CUdeviceptr dptr) {
     allocated_list *a_list = device_overallocated;
     size_t t_size;
+    CUdevice t_dev;
     if (a_list->length == 0) {
         return -1;
     }
@@ -190,10 +188,9 @@ int remove_chunk_only(CUdeviceptr dptr) {
     for (val = a_list->head; val != NULL; val = val->next) {
         if (val->entry->address == dptr) {
             t_size = val->entry->length;
+            t_dev = val->entry->dev;
             LIST_REMOVE(a_list, val);
-            CUdevice dev;
-            cuCtxGetDevice(&dev);
-            rm_gpu_device_memory_usage(getpid(), dev, t_size, 2);
+            rm_gpu_device_memory_usage(getpid(), t_dev, t_size, 2);
             return 0;
         }
     }
@@ -254,7 +251,7 @@ int add_chunk_async(CUdeviceptr *address, size_t size, CUstream hStream) {
         return -1;
 
     allocated_list_entry *e;
-    INIT_ALLOCATED_LIST_ENTRY(e,addr,size);
+    INIT_ALLOCATED_LIST_ENTRY(e, addr, size, dev);
     res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAllocAsync,&e->entry->address,size,hStream);
     if (res != CUDA_SUCCESS) {
         LOG_ERROR("cuMemoryAllocate failed res=%d",res);

--- a/src/allocator/allocator.h
+++ b/src/allocator/allocator.h
@@ -14,6 +14,7 @@ struct allocated_device_memory_struct{
     CUdeviceptr address;
     size_t length;
     CUcontext ctx;
+    CUdevice dev;
     CUmemGenericAllocationHandle *allocHandle;
 };
 typedef struct allocated_device_memory_struct allocated_device_memory;
@@ -90,7 +91,7 @@ extern pthread_mutex_t mutex;
     list->length--;                         \
 }   
 
-#define INIT_ALLOCATED_LIST_ENTRY(__list_entry,__address,__size) {             \
+#define INIT_ALLOCATED_LIST_ENTRY(__list_entry, __address, __size, __dev) {             \
     CUcontext __ctx;                                                           \
     CUresult __res=cuCtxGetCurrent(&__ctx);                                    \
     if (__res!=CUDA_SUCCESS) QUIT_WITH_ERROR("cuCtxGetCurrent failed");        \
@@ -100,6 +101,7 @@ extern pthread_mutex_t mutex;
     if (__list_entry->entry == NULL) QUIT_WITH_ERROR("malloc failed");         \
     __list_entry->entry->address=__address;                                    \
     __list_entry->entry->length=__size;                                        \
+    __list_entry->entry->dev = __dev;                                            \
     __list_entry->entry->allocHandle=malloc(sizeof(CUmemGenericAllocationHandle)); \
     __list_entry->entry->ctx=__ctx;                                            \
     __list_entry->next=NULL;                                                   \
@@ -157,7 +159,7 @@ int oom_check(const int dev,size_t addon);
 // Allocate and free device memory
 int allocate_raw(CUdeviceptr *dptr, size_t size);
 int free_raw(CUdeviceptr dptr);
-int add_chunk_only(CUdeviceptr address,size_t size);
+int add_chunk_only(CUdeviceptr address, size_t size, CUdevice dev);
 int remove_chunk_only(CUdeviceptr address);
 int allocate_async_raw(CUdeviceptr *dptr, size_t size, CUstream hStream);
 int free_raw_async(CUdeviceptr dptr, CUstream hStream);

--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -166,7 +166,7 @@ CUresult cuMemAllocManaged(CUdeviceptr* dptr, size_t bytesize, unsigned int flag
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAllocManaged, dptr, bytesize, flags);
     if (res == CUDA_SUCCESS) {
-        add_chunk_only(*dptr,bytesize);
+        add_chunk_only(*dptr, bytesize, dev);
     }
     return res;
 }
@@ -184,7 +184,7 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInByt
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAllocPitch_v2, dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
     if (res == CUDA_SUCCESS) {
-        add_chunk_only(*dptr,bytesize);
+        add_chunk_only(*dptr, bytesize, dev);
     }
     return res;
 }
@@ -598,7 +598,7 @@ CUresult cuMemCreate ( CUmemGenericAllocationHandle* handle, size_t size, const 
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,
         cuMemCreate, handle, size, prop, flags);
     if (res == CUDA_SUCCESS) {
-        add_chunk_only(*handle, size);
+        add_chunk_only(*handle, size, dev);
     }
     return res;
 }

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -650,6 +650,45 @@ void exit_withlock(int exitcode) {
     exit(exitcode);
 }
 
+/**
+ * Atomically copy proc slot members from src to dst.
+ * Direct struct assignment on a struct with _Atomic members is non-atomic
+ * and can lead to torn reads/data corruption. This function copies each
+ * member individually using atomic loads and stores.
+ */
+static inline void copy_proc_slot_atomic(shrreg_proc_slot_t* dst, shrreg_proc_slot_t* src) {
+    atomic_store_explicit(&dst->pid,
+        atomic_load_explicit(&src->pid, memory_order_relaxed), memory_order_relaxed);
+    atomic_store_explicit(&dst->hostpid,
+        atomic_load_explicit(&src->hostpid, memory_order_relaxed), memory_order_relaxed);
+    atomic_store_explicit(&dst->seqlock,
+        atomic_load_explicit(&src->seqlock, memory_order_relaxed), memory_order_relaxed);
+    atomic_store_explicit(&dst->status,
+        atomic_load_explicit(&src->status, memory_order_relaxed), memory_order_relaxed);
+
+    for (int dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+        atomic_store_explicit(&dst->used[dev].total,
+            atomic_load_explicit(&src->used[dev].total, memory_order_relaxed), memory_order_relaxed);
+        atomic_store_explicit(&dst->used[dev].context_size,
+            atomic_load_explicit(&src->used[dev].context_size, memory_order_relaxed), memory_order_relaxed);
+        atomic_store_explicit(&dst->used[dev].module_size,
+            atomic_load_explicit(&src->used[dev].module_size, memory_order_relaxed), memory_order_relaxed);
+        atomic_store_explicit(&dst->used[dev].data_size,
+            atomic_load_explicit(&src->used[dev].data_size, memory_order_relaxed), memory_order_relaxed);
+        atomic_store_explicit(&dst->used[dev].offset,
+            atomic_load_explicit(&src->used[dev].offset, memory_order_relaxed), memory_order_relaxed);
+
+        atomic_store_explicit(&dst->monitorused[dev],
+            atomic_load_explicit(&src->monitorused[dev], memory_order_relaxed), memory_order_relaxed);
+
+        atomic_store_explicit(&dst->device_util[dev].dec_util,
+            atomic_load_explicit(&src->device_util[dev].dec_util, memory_order_relaxed), memory_order_relaxed);
+        atomic_store_explicit(&dst->device_util[dev].enc_util,
+            atomic_load_explicit(&src->device_util[dev].enc_util, memory_order_relaxed), memory_order_relaxed);
+        atomic_store_explicit(&dst->device_util[dev].sm_util,
+            atomic_load_explicit(&src->device_util[dev].sm_util, memory_order_relaxed), memory_order_relaxed);
+    }
+}
 
 void exit_handler() {
     if (region_info.init_status == PTHREAD_ONCE_INIT) {
@@ -839,7 +878,27 @@ int clear_proc_slot_nolock(int do_clear) {
             cleaned_pid_zero++;
             res=1;
             region->proc_num--;
-            region->procs[slot] = region->procs[region->proc_num];
+            copy_proc_slot_atomic(&region->procs[slot], &region->procs[region->proc_num]);
+            if (region_info.my_slot != NULL && region_info.my_slot == &region->procs[region->proc_num]) {
+                region_info.my_slot = &region->procs[slot];
+                atomic_store_explicit(&region->procs[region->proc_num].seqlock, 0, memory_order_relaxed);
+                atomic_store_explicit(&region->procs[region->proc_num].pid, 0, memory_order_release);
+                atomic_store_explicit(&region->procs[region->proc_num].hostpid, 0, memory_order_relaxed);
+                atomic_store_explicit(&region->procs[region->proc_num].status, 0, memory_order_release);
+
+                for (int dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+                    atomic_store_explicit(&region->procs[region->proc_num].used[dev].total, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].used[dev].context_size, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].used[dev].module_size, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].used[dev].data_size, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].device_util[dev].sm_util, 0, memory_order_relaxed);
+                    atomic_store_explicit(&region->procs[region->proc_num].monitorused[dev], 0, memory_order_relaxed);
+                }
+            }
             __sync_synchronize();
 
             // Don't increment slot - check the moved element
@@ -853,7 +912,27 @@ int clear_proc_slot_nolock(int do_clear) {
             cleaned_dead++;
             res = 1;
             region->proc_num--;
-            region->procs[slot] = region->procs[region->proc_num];
+            copy_proc_slot_atomic(&region->procs[slot], &region->procs[region->proc_num]);
+            if (region_info.my_slot != NULL && region_info.my_slot == &region->procs[region->proc_num]) {
+                region_info.my_slot = &region->procs[slot];
+                atomic_store_explicit(&region->procs[region->proc_num].seqlock, 0, memory_order_relaxed);
+                atomic_store_explicit(&region->procs[region->proc_num].pid, 0, memory_order_release);
+                atomic_store_explicit(&region->procs[region->proc_num].hostpid, 0, memory_order_relaxed);
+                atomic_store_explicit(&region->procs[region->proc_num].status, 0, memory_order_release);
+
+                for (int dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+                    atomic_store_explicit(&region->procs[region->proc_num].used[dev].total, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].used[dev].context_size, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].used[dev].module_size, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].used[dev].data_size, 0, memory_order_relaxed);
+                    atomic_store_explicit(
+                        &region->procs[region->proc_num].device_util[dev].sm_util, 0, memory_order_relaxed);
+                    atomic_store_explicit(&region->procs[region->proc_num].monitorused[dev], 0, memory_order_relaxed);
+                }
+            }
             __sync_synchronize();
             // Don't increment slot - check the moved element
             continue;


### PR DESCRIPTION
 **Summary**                                                                                                                                                                                                            
                                                                                                                                                                                                                     
  Fix two bugs introduced by prior refactoring: cuMemCreate causes a core dump due to improper CUDA context handling, and memory usage reporting always shows 0 when allocating more than once.                      
                                                                                                                                                                                                                     
  Changes                                                                                                                                                                                                            
                  
  1. **Fix core dump in cuMemCreate and other allocation paths**                                                                                                                                                         
                  
  add_chunk_only and remove_chunk_only were internally calling cuCtxGetDevice to determine the current device, but this call can fail or return incorrect results when the CUDA context is in certain states (e.g.,  
  after cuMemCreate, which may not have a bound context). This caused a core dump on cuMemCreate.
                                                                                                                                                                                                                     
  Fix: Pass CUdevice dev as a parameter from the caller instead of querying it internally.                                                                                                                           
  
  - add_chunk_only now takes a CUdevice dev parameter — all callers (cuMemAllocManaged, cuMemAllocPitch_v2, cuMemCreate) pass the device they already know                                                           
  - remove_chunk_only now reads the device from the stored allocated_device_memory_struct.dev field, which is populated at allocation time by the INIT_ALLOCATED_LIST_ENTRY macro
                                                                                                                                                                                                                     
  2. **Fix memory usage always showing 0 after the second allocation**                                                                                                                                                   
                                                                                                                                                                                                                     
  INIT_ALLOCATED_LIST_ENTRY previously did not store the CUdevice in the entry. When remove_chunk_only ran (e.g., on the second free), it called cuCtxGetDevice which could return a stale or incorrect device,      
  causing rm_gpu_device_memory_usage to decrement the wrong counter — leaving the real counter non-zero and causing subsequent get_memory_usage calls to show 0.
                                                                                                                                                                                                                     
  Fix: Added CUdevice dev field to allocated_device_memory_struct and set it in INIT_ALLOCATED_LIST_ENTRY. remove_chunk_only uses val->entry->dev instead of querying the context.                                   
  
  3. Atomic safety in clear_proc_slot_nolock                                                                                                                                                                         
                  
  Direct struct assignment on shared region process slots with _Atomic members is non-atomic and can cause torn reads.                                                                                               
                  
  Fix: Added copy_proc_slot_atomic — copies each member individually using atomic loads/stores. When compacting the slot array and the moved slot is my_slot, the pointer is updated and the vacated slot is zeroed  
  out atomically to prevent use-after-free by concurrent readers.