### PR TITLE
Fix container SM utilization metrics

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -34,7 +34,6 @@ int cuda_to_nvml_map_array[CUDA_DEVICE_MAX_COUNT];
 
 /* Cached at init — these values do not change at runtime */
 static int cached_sm_limit[CUDA_DEVICE_MAX_COUNT] = {0};
-static int cached_util_switch = 0;
 
 void rate_limiter(int grids, int blocks) {
   CUdevice current_device;
@@ -49,7 +48,7 @@ void rate_limiter(int grids, int blocks) {
   if (cached_sm_limit[device_id] >= 100 || cached_sm_limit[device_id] == 0) {
       return;
   }
-  if (cached_util_switch == 0) {
+  if (get_utilization_switch() == 0) {
       return;
   }
 
@@ -256,8 +255,7 @@ void* utilization_watcher() {
 }
 
 void init_utilization_watcher() {
-    cached_util_switch = get_utilization_switch();
-    LOG_INFO("init_utilization_watcher: util_switch=%d", cached_util_switch);
+    LOG_INFO("init_utilization_watcher: util_switch=%d", get_utilization_switch());
 
     unsigned int device_count;
     if (nvmlDeviceGetCount(&device_count) != NVML_SUCCESS) {
@@ -278,7 +276,7 @@ void init_utilization_watcher() {
     }
 
     pthread_t tid;
-    if (has_limit && cached_util_switch == 1) {
+    if (has_limit) {
         pthread_create(&tid, NULL, utilization_watcher, NULL);
     }
     return;


### PR DESCRIPTION
## Summary
- Always start the utilization watcher when a container has a configured SM/core limit.
- Read `utilization_switch` dynamically in the rate limiter instead of caching the startup value.
- Keep the switch controlling throttling behavior without preventing SM utilization metric collection.

## Bug
`Device_utilization_desc_of_container` can stay at `0` even while the container is actively using the GPU. We reproduced this with vLLM inference workloads: `nvidia-smi` reported GPU utilization around 12-15%, while HAMi continued to export `Device_utilization_desc_of_container` as `0`.

The root cause is that HAMi-core only creates the `utilization_watcher` thread when `utilization_switch` is already enabled during process initialization. If the switch starts as `0`, the watcher thread is never created. Later changes made through shared memory by vGPUmonitor cannot start the missing thread, so per-process SM utilization is never written to shared memory.

This also creates a feedback-loop issue: the watcher is responsible for updating SM utilization and related runtime state, but the watcher startup itself depends on a switch that may only be enabled after runtime activity is observed.

## Fix
The watcher is now started whenever at least one device has a configured SM/core limit. The rate limiter still checks `get_utilization_switch()` dynamically before applying throttling, so the switch continues to control throttling while metric collection remains available.

## Validation
- `make check-cuda-hook-consistency` passed.
- `make build` could not complete locally because CUDA is not configured on this macOS environment (`Specify CUDA_TOOLKIT_ROOT_DIR`).
- Verified in a cluster using a HAMi image built with this change:
  - old image: repeated inference requests showed `nvidia-smi` GPU utilization around 12-15%, but `Device_utilization_desc_of_container` stayed `0`.
  - fixed image: repeated inference requests showed HAMi SM utilization values around 11-15, matching `nvidia-smi` during active inference.

Signed-off-by: luohua13 <jcwang@alauda.io>