### PR TITLE
remove duplicate --print arg check in shrreg_tool

### DIFF
--- a/src/multiprocess/shrreg_tool.c
+++ b/src/multiprocess/shrreg_tool.c
@@ -74,9 +74,6 @@ int main(int argc, char* argv[]) {
         if (strcmp(arg, "--resume") == 0){
             send_resume_signal();
         }
-        if (strcmp(arg, "--print") == 0){
-            print_shared_region();
-        }
         if (strcmp(arg, "--version") == 0){
             printf("shrreg size: %ld, version %d.%d\n", 
                     sizeof(shared_region_t),


### PR DESCRIPTION
The --print case was checked twice in the arg loop inside shrreg_tool.c.
This caused print_shared_region() to run twice when --print was passed.

Removed the second duplicate block. No behavior change for other args.