### PR TITLE
build: upgrade compile image from cuda 12.9.1 ubuntu20.04 to cuda 13.3.0 ubi8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,10 @@ build-in-docker:
 	docker run -i --rm \
 		-v $(current_dir):/libvgpu \
 		-w /libvgpu \
-		-e DEBIAN_FRONTEND=noninteractive \
-		nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04 \
-		sh -c "apt-get -y update && \
-           apt-get -y install cmake git && \
+		nvidia/cuda:13.3.0-cudnn-devel-ubi8 \
+		sh -c "dnf install -y cmake git && \
            git config --global --add safe.directory /libvgpu && \
+           rm -rf /libvgpu/build && \
            bash ./build.sh"
 .PHONY: build-in-docker
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,12 +1,9 @@
-FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM nvidia/cuda:13.3.0-cudnn-devel-ubi8
 
 WORKDIR /libvgpu
 COPY . /libvgpu
 
-RUN apt-get update && \
-    apt-get install -y cmake git && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y cmake git && \
+    dnf clean all
 
 RUN bash ./build.sh

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -215,7 +215,7 @@ void* utilization_watcher() {
 
     unsigned int device_count;
     if (nvmlDeviceGetCount(&device_count) != NVML_SUCCESS) {
-        return;
+        return NULL;
     }
 
     int64_t share[CUDA_DEVICE_MAX_COUNT] = {0};

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,6 +3,7 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <time.h>
+#include <sys/file.h>
 #include "include/utils.h"
 #include "include/log_utils.h"
 #include "include/nvml_prefix.h"


### PR DESCRIPTION
## What this PR does

Upgrade the compile base image from `nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04` to `nvidia/cuda:13.3.0-cudnn-devel-ubi8` (RHEL UBI8).

## Changes

### Build image (`Makefile` / `dockerfiles/Dockerfile`)
- Bump CUDA version: `12.9.1` → `13.3.0`
- Switch distro: Ubuntu 20.04 → RHEL UBI8
- Switch package manager: `apt-get` → `dnf`; remove Ubuntu-specific `DEBIAN_FRONTEND` env var
- Add `rm -rf /libvgpu/build` before `build.sh` to avoid stale CMake cache from a different distro causing linker errors (e.g. missing `/usr/lib/aarch64-linux-gnu/librt.a`)

### Bug fixes (exposed by newer GCC in ubi8)
- `src/multiprocess/multiprocess_utilization_watcher.c`: fix `-Wreturn-mismatch` — change bare `return;` to `return NULL;` in `void*` function `utilization_watcher()`
- `src/utils.c`: add missing `#include <sys/file.h>` required by `flock()`

## How to test

```bash
make build-in-docker
```