### PR TITLE
replace strcpy/strcat with snprintf in hook and memory limit

### DIFF
--- a/src/cuda/hook.c
+++ b/src/cuda/hook.c
@@ -1,5 +1,6 @@
-#include "include/libcuda_hook.h"
+#include <stdio.h>
 #include <string.h>
+#include "include/libcuda_hook.h"
 #include "include/libvgpu.h"
 #include "include/multi_func_hook.h"
 
@@ -269,8 +270,7 @@ void load_cuda_libraries() {
             cuda_library_entry[i].fn_ptr=real_dlsym(RTLD_NEXT,cuda_library_entry[i].name);
             if (!cuda_library_entry[i].fn_ptr){
                 LOG_INFO("can't find function %s in %s", cuda_library_entry[i].name,cuda_filename);
-                memset(tmpfunc,0,500);
-                strcpy(tmpfunc,cuda_library_entry[i].name);
+                snprintf(tmpfunc, sizeof(tmpfunc), "%s", cuda_library_entry[i].name);
                 while (prior_function(tmpfunc)) {
                     cuda_library_entry[i].fn_ptr=real_dlsym(RTLD_NEXT,tmpfunc);
                     if (cuda_library_entry[i].fn_ptr) {
@@ -321,22 +321,13 @@ void *find_symbols_in_table(const char *symbol) {
     if (strncmp(symbol, "cuGraph", 7) == 0) {
         return NULL;
     }
-    strcpy(symbol_v,symbol);
-    strcat(symbol_v,"_v3");
-    pfn = __dlsym_hook_section(NULL,symbol_v);
-    if (pfn!=NULL) {
+    snprintf(symbol_v, sizeof(symbol_v), "%s_v3", symbol);
+    if ((pfn = __dlsym_hook_section(NULL, symbol_v)) != NULL)
         return pfn;
-    }
     symbol_v[strlen(symbol_v)-1]='2';
-    pfn = __dlsym_hook_section(NULL,symbol_v);
-    if (pfn!=NULL) {
+    if ((pfn = __dlsym_hook_section(NULL, symbol_v)) != NULL)
         return pfn;
-    }
-    pfn = __dlsym_hook_section(NULL,symbol);
-    if (pfn!=NULL) {
-        return pfn;
-    }
-    return NULL;
+    return __dlsym_hook_section(NULL, symbol);
 }
 
 void *find_symbols_in_table_by_cudaversion(const char *symbol,int  cudaVersion) {

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -177,10 +177,8 @@ void do_init_device_memory_limits(uint64_t* arr, int len) {
     size_t fallback_limit = get_limit_from_env(CUDA_DEVICE_MEMORY_LIMIT);
     int i;
     for (i = 0; i < len; ++i) {
-        char env_name[CUDA_DEVICE_MEMORY_LIMIT_KEY_LENGTH] = CUDA_DEVICE_MEMORY_LIMIT;
-        char index_name[8];
-        snprintf(index_name, 8, "_%d", i);
-        strcat(env_name, index_name);
+        char env_name[CUDA_DEVICE_MEMORY_LIMIT_KEY_LENGTH];
+        snprintf(env_name, sizeof(env_name), "%s_%d", CUDA_DEVICE_MEMORY_LIMIT, i);
         size_t cur_limit = get_limit_from_env(env_name);
         if (cur_limit > 0) {
             arr[i] = cur_limit;
@@ -197,10 +195,8 @@ void do_init_device_sm_limits(uint64_t *arr, int len) {
     if (fallback_limit == 0) fallback_limit = 100;
     int i;
     for (i = 0; i < len; ++i) {
-        char env_name[CUDA_DEVICE_SM_LIMIT_KEY_LENGTH] = CUDA_DEVICE_SM_LIMIT;
-        char index_name[8];
-        snprintf(index_name, 8, "_%d", i);
-        strcat(env_name, index_name);
+        char env_name[CUDA_DEVICE_SM_LIMIT_KEY_LENGTH];
+        snprintf(env_name, sizeof(env_name), "%s_%d", CUDA_DEVICE_SM_LIMIT, i);
         size_t cur_limit = get_limit_from_env(env_name);
         if (cur_limit > 0) {
             arr[i] = cur_limit;


### PR DESCRIPTION
`hook.c` `load_cuda_libraries`: replace `memset` + `strcpy` with a single `snprintf`

`hook.c` `find_symbols_in_table`: replace `strcpy` + `strcat` with `snprintf`, simplify the branch structure

`multiprocess_memory_limit.c` `do_init_device_memory_limits` and `do_init_device_sm_limits`: replace two-step 
`snprintf` + `strcat` env name construction with a single `snprintf` call, removing the intermediate `index_name` variable