### PR TITLE
fix file descriptor leak in load_env_from_file

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -170,6 +170,7 @@ int load_env_from_file(char *filename) {
             }
         }
     }
+    fclose(f);
     return 0;
 }
 


### PR DESCRIPTION
`fopen` was called but `fclose` was never called before `return`, leaking a file descriptor on every invocation of `load_env_from_file`.