### PR TITLE
fix feof antipattern in load_env_from_file

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -154,17 +154,17 @@ int load_env_from_file(char *filename) {
     if (f==NULL)
         return 0;
     char tmp[10000];
-    int cursor=0;
-    size_t tmplen=0;
+    int cursor = 0;
+    size_t tmplen = 0;
     while (fgets(tmp, sizeof(tmp), f) != NULL) {
-        if (strstr(tmp,"=")==NULL)
+        if (strstr(tmp, "=") == NULL)
             break;
-        tmplen=strlen(tmp);
-        if (tmp[tmplen-1]=='\n')
-            tmp[--tmplen]='\0';
-        for (cursor=0;cursor<(int)tmplen;cursor++){
-            if (tmp[cursor]=='=') {
-                tmp[cursor]='\0';
+        tmplen = strlen(tmp);
+        if (tmp[tmplen - 1] == '\n')
+            tmp[--tmplen] = '\0';
+        for (cursor = 0; cursor < (int)tmplen; cursor++) {
+            if (tmp[cursor] == '=') {
+                tmp[cursor] = '\0';
                 setenv(tmp,tmp+cursor+1,1);
                 LOG_INFO("SET %s to %s",tmp,tmp+cursor+1);
                 break;

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -155,13 +155,14 @@ int load_env_from_file(char *filename) {
         return 0;
     char tmp[10000];
     int cursor=0;
-    while (!feof(f)){
-        fgets(tmp,10000,f);
+    size_t tmplen=0;
+    while (fgets(tmp, sizeof(tmp), f) != NULL) {
         if (strstr(tmp,"=")==NULL)
             break;
-        if (tmp[strlen(tmp)-1]=='\n')
-            tmp[strlen(tmp)-1]='\0';
-        for (cursor=0;cursor<strlen(tmp);cursor++){
+        tmplen=strlen(tmp);
+        if (tmp[tmplen-1]=='\n')
+            tmp[--tmplen]='\0';
+        for (cursor=0;cursor<(int)tmplen;cursor++){
             if (tmp[cursor]=='=') {
                 tmp[cursor]='\0';
                 setenv(tmp,tmp+cursor+1,1);


### PR DESCRIPTION
`feof()` only returns true after a read has already hit EOF, not before. The previous code called `fgets` unconditionally inside the loop without checking its return value, which could process stale buffer content on the last iteration.

Replace `while (!feof(f))` + bare `fgets` with `while (fgets(...) != NULL)` so the loop exits as soon as the read fails.