### PR TITLE
check malloc return value in allocator_init

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -91,8 +91,16 @@ void allocator_init() {
     LOG_DEBUG("Allocator_init\n");
 
     device_overallocated = malloc(sizeof(allocated_list));
+    if (!device_overallocated) {
+        LOG_ERROR("allocator_init: malloc failed");
+        exit(EXIT_FAILURE);
+    }
     LIST_INIT(device_overallocated);
-    device_allocasync=malloc(sizeof(allocated_list));
+    device_allocasync = malloc(sizeof(allocated_list));
+    if (!device_allocasync) {
+        LOG_ERROR("allocator_init: malloc failed");
+        exit(EXIT_FAILURE);
+    }
     LIST_INIT(device_allocasync);
 
     pthread_mutex_init(&mutex,NULL);


### PR DESCRIPTION
`LIST_INIT` dereferences the pointer immediately after `malloc`. If `malloc` returns NULL (e.g. under memory pressure), the process crashes with a segfault and no diagnostic output.

Add a NULL check after each `malloc` call and exit with an error log so the failure is visible.