### PR TITLE
replace sprintf with snprintf in proc_alive

### DIFF
--- a/src/include/process_utils.h
+++ b/src/include/process_utils.h
@@ -16,7 +16,7 @@
 
 int proc_alive(int32_t pid) {
     char filename[FILENAME_LENGTH] = {0};
-    sprintf(filename, "/proc/%d/stat", pid);
+    snprintf(filename, sizeof(filename), "/proc/%d/stat", pid);
 
     FILE* fp;
     if ((fp = fopen(filename, "r")) == NULL) {   


### PR DESCRIPTION
`proc_alive` in `process_utils.h` still used `sprintf`. Replace with `snprintf` to be consistent with the rest of the codebase.