### PR TITLE
remove enable_eager_execution call in TF2 test

### DIFF
--- a/test/python/limit_tensorflow2.py
+++ b/test/python/limit_tensorflow2.py
@@ -20,8 +20,7 @@ def app(args):
     print("Test use float device tensor: (%s)" % ", ".join([str(_) for _ in shape])) 
 
     print("Tensorflow version: " + tf.__version__)
-    tf.enable_eager_execution()
-    data = tf.ones(shape=shape, dtype=tf.float32) 
+    data = tf.ones(shape=shape, dtype=tf.float32)
     summation = tf.reduce_sum(data)  
     print("Tensor sum: " + str(summation.numpy()))
 


### PR DESCRIPTION
`tf.enable_eager_execution()` raises `ValueError` in TF2 since eager mode is on by default. Removed the call.