### PR TITLE
fix: pass device arg to cuda() in pytorch test

### DIFF
--- a/test/python/limit_pytorch.py
+++ b/test/python/limit_pytorch.py
@@ -20,7 +20,7 @@ def app(args):
     print("Test use float device tensor: (%s)" % ", ".join([str(_) for _ in shape])) 
 
     print("PyTorch version: " + torch.__version__)
-    data = torch.ones(size=shape, dtype=torch.float32).cuda()
+    data = torch.ones(size=shape, dtype=torch.float32).cuda(args.device)
     summation = data.sum()
     print("Tensor sum: " + str(summation.cpu().numpy()))
 


### PR DESCRIPTION
`--device` argument was parsed but never forwarded to `.cuda()`, so the test always ran on GPU 0 regardless of input.

Fix: `.cuda()` -> `.cuda(args.device)`, consistent with `limit_mxnet.py` and `limit_tensorflow.py`.