### PR TITLE
fix: update branch name from master to main in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,16 @@ Before submitting a pull request, run these local verifications to predict wheth
 
 * Run `make build-in-docker`
 
+## Issue and PR Lifecycle
+
+To keep the project manageable, we apply the following policy to all open issues and pull requests:
+
+- If a maintainer or contributor leaves a comment or review requesting a response, the author has **two weeks** to reply.
+- If there is no response within two weeks, the issue or PR will be closed.
+- Closing is not permanent. If the issue is still relevant or the PR is still needed, it can be reopened or submitted again at any time.
+
+This policy helps us keep the backlog focused and avoids letting stale work block active contributors.
+
 ## Code Review
 
 To make it easier for your PR to receive reviews, consider that reviewers will need you to:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Please never hesitate to ask questions or submit a pull request.
 
 This is a rough outline of what a contributor's workflow looks like:
 
-- Create a topic branch from where you want to base the contribution (usually master)
+- Create a topic branch from where you want to base the contribution (usually main)
 - Make commits of logical units
 - Push changes in your topic branch to your personal fork of the repository
 - Submit a pull request to [Project-HAMi/HAMi-core](https://github.com/Project-HAMi/HAMi-core)


### PR DESCRIPTION
The default branch is `main`, not `master`. Updated the contributor workflow section to reflect this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to recommend creating topic branches from `main` instead of `master`.
  * Added an “Issue and PR Lifecycle” section defining response expectations (including a two-week follow-up window) and closing behavior when there’s no reply.
  * Clarified that issues and pull requests can be reopened or resubmitted later if still relevant, to help keep the backlog focused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->