### PR TITLE
fix: dlsym hook self-lookup degrades to RTLD_DEFAULT, crashing cuDNN 9 apps (silent SIGSEGV at first convolution)

### DIFF
--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -98,6 +98,19 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
         }else{
             vgpulib = dlopen("/usr/local/vgpu/libvgpu.so",RTLD_LAZY);
         }
+        if (vgpulib == NULL) {
+            /* libvgpu was preloaded from a different path: recover our own
+             * handle via dladdr instead of falling back to a NULL handle,
+             * which glibc treats as RTLD_DEFAULT (global scope). A global
+             * lookup can resolve a "cu"-prefixed symbol to the CALLER's own
+             * export (cuDNN 9's dispatcher dlsym's cudnnCreate from its
+             * engine sub-library; global search returns the dispatcher
+             * itself) causing infinite self-recursion and stack overflow. */
+            Dl_info self_info;
+            if (dladdr((void*)&init_dlsym, &self_info) && self_info.dli_fname) {
+                vgpulib = dlopen(self_info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+            }
+        }
         if (real_dlsym == NULL) {
             LOG_ERROR("real dlsym not found");
             void *libc_handle = dlopen("libc.so.6", RTLD_LAZY);
@@ -120,12 +133,21 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
         return h;
     }
     if (symbol[0] == 'c' && symbol[1] == 'u') {
-        //Compatible with cuda 12.8+ fix
-        if (strcmp(symbol,"cuGetExportTable")!=0)
-            pthread_once(&pre_cuinit_flag,(void(*)(void))preInit);
-        void *f = real_dlsym(vgpulib,symbol);
-        if (f!=NULL)
+        /* Resolve against libvgpu's own exports FIRST and run preInit only
+         * on a hit. The "cu" prefix also matches CUDA *library* symbols
+         * (cudnnCreate, cublas*, cufft*, ...) that libvgpu does not export:
+         * for those, firing preInit here reenters the dynamic loader while
+         * the caller is mid-dlopen (LibTorch >= 2.5 cu12x lazily dlopens
+         * cuDNN 9 and resolves cudnnCreate at its first convolution) and
+         * segfaults. Symbols libvgpu actually hooks keep the original
+         * behavior: preInit fires, the hook is returned. */
+        void *f = (vgpulib != NULL) ? real_dlsym(vgpulib,symbol) : NULL;
+        if (f!=NULL) {
+            //Compatible with cuda 12.8+ fix
+            if (strcmp(symbol,"cuGetExportTable")!=0)
+                pthread_once(&pre_cuinit_flag,(void(*)(void))preInit);
             return f;
+        }
     }
     #ifdef HOOK_NVML_ENABLE
     if (symbol[0] == 'n' && symbol[1] == 'v' &&


### PR DESCRIPTION

## Symptom

Any LibTorch >= 2.5 cu12x application preloaded with `libvgpu.so` from a path other than `/usr/local/vgpu/libvgpu.so` dies with a **silent SIGSEGV at its first convolution** (no HAMI-core error banner), at every `CUDA_DEVICE_MEMORY_LIMIT` including very loose ones, and even with `LD_PRELOAD` set but **no limit configured at all**. On cuDNN 8 stacks (torch cu118) the same defect can surface as a livelock instead of a crash. This looks related to the reports in #169 (vllm 0.18 = torch 2.7 + cu128).

gdb backtrace at the crash (20 identical frames — infinite self-recursion until stack overflow):

```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007.. in cudnnCreate () from /opt/libtorch/lib/libcudnn.so.9
#0  cudnnCreate () from libcudnn.so.9
#1  cudnnCreate () from libcudnn.so.9     <- same return address, recursing
#2  cudnnCreate () from libcudnn.so.9
... (identical frames all the way down)
```

## Root cause

In `src/libvgpu.c`, the dlsym hook resolves every `"cu"`-prefixed symbol against a libvgpu self-handle:

```c
vgpulib = dlopen("/usr/local/vgpu/libvgpu.so", RTLD_LAZY);   // fails on nonstandard installs
...
if (symbol[0] == 'c' && symbol[1] == 'u') {
    ...
    void *f = real_dlsym(vgpulib, symbol);   // vgpulib == NULL here
```

When libvgpu is preloaded from any other location (bind-mounted container paths, `/opt/hami/...`, etc.) and `CUDA_REDIRECT` is unset, `vgpulib` is NULL — and on glibc, `dlsym(NULL, ...)` means **RTLD_DEFAULT**: a global-scope search.

The `"cu"` prefix also matches CUDA **library** symbols, not just driver API. cuDNN 9 is a dispatcher architecture: `libcudnn.so.9`'s `cudnnCreate` lazily resolves the real engine implementation via `dlsym` at first use. The interposed global-scope search hands the dispatcher its **own** `cudnnCreate` export back, and the self-call recurses until the stack overflows. Additionally, the unconditional `pthread_once(preInit)` for any `cu*` symbol runs full CUDA pre-initialization inside the caller's dynamic-loader call (the caller is mid-`dlopen` of cuDNN at that moment).

## Fix (three small parts, one function)

1. **Recover the self-handle via `dladdr`** on a known own symbol, `dlopen(dli_fname, RTLD_LAZY | RTLD_NOLOAD)`, when the hardcoded path misses — the lookup is then always genuinely against libvgpu.
2. **Never RTLD_DEFAULT**: if the self-handle is still NULL, treat the lookup as a miss and fall through to `real_dlsym(handle, symbol)` with the **caller's own handle**.
3. **`preInit` only on a confirmed hook hit**, so non-driver `cu*` symbols (`cudnnCreate`, `cublas*`, `cufft*`, ...) no longer trigger CUDA pre-initialization inside the loader. (Hooks self-initialize via `ensure_post_init`, so deferral is safe.)

Deployments using the standard `/usr/local/vgpu` install path are unaffected by construction: the new code paths never execute there.

## Verification

| Case | Before | After |
| --- | --- | --- |
| LibTorch 2.7.1+cu128 stereo-depth app (TorchScript), preloaded from `/opt/hami/` | SIGSEGV at first conv, every cap, even with no cap set | Completes; caps enforced 12 GB down to 1 GB |
| Same app, LibTorch 2.4.1+cu118 build | Livelock (100% CPU, 0% GPU, stuck in first inference) | Completes |
| PyTorch cu118 application (previously working) | works | works, output numerically unchanged |
| C++ LibTorch cu118 application (previously working) | works | works, output numerically unchanged |
| `nvidia-smi` binding sanity, 2048 MiB cap | 2048 MiB reported | 2048 MiB reported |

## Possible follow-up (not in this PR)

The underlying discrimination mechanism ("prefix-match `cu*`, resolve against own exports") could instead gate on the explicit hook table (`__dlsym_hook_section`), which would also make the behavior independent of ELF export visibility. That requires reworking the table's pre-init early-return, so it is left as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA symbol lookup reliability when libvgpu is loaded from a different path than expected.
  * Prevented failed lookups from falling back to an invalid library handle, reducing load-time issues.
  * Made CUDA symbol resolution more stable by avoiding unnecessary initialization when a symbol is not available in libvgpu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->