### PR TITLE
fix: fallback to GetProcessesUtilizationInfo on Blackwell GPUs

### DIFF
--- a/src/include/libnvml_hook.h
+++ b/src/include/libnvml_hook.h
@@ -55,6 +55,8 @@ typedef enum {
   NVML_OVERRIDE_ENUM(nvmlDeviceGetPciInfo),
   /** nvmlDeviceGetProcessUtilization */
   NVML_OVERRIDE_ENUM(nvmlDeviceGetProcessUtilization),
+  /** nvmlDeviceGetProcessesUtilizationInfo */
+  NVML_OVERRIDE_ENUM(nvmlDeviceGetProcessesUtilizationInfo),
   /** nvmlDeviceGetCount */
   NVML_OVERRIDE_ENUM(nvmlDeviceGetCount),
   /** nvmlDeviceClearAccountingPids */

--- a/src/include/nvml-subset.h
+++ b/src/include/nvml-subset.h
@@ -158,6 +158,8 @@ typedef struct nvmlProcessUtilizationSample_st {
   unsigned int decUtil;          //!< Decoder Util Value
 } nvmlProcessUtilizationSample_t;
 
+#include "include/nvml_processes_utilization_subset.h"
+
 /**
  * ECC counter types.
  *

--- a/src/include/nvml_processes_utilization_subset.h
+++ b/src/include/nvml_processes_utilization_subset.h
@@ -1,0 +1,45 @@
+/*
+ * Per-process GPU utilization types for nvmlDeviceGetProcessesUtilizationInfo
+ * (driver 580+). Omitted from older CUDA nvml.h headers shipped with the
+ * project build; skipped when a newer nvml.h already defines them.
+ */
+#ifndef HIJACK_NVML_PROCESSES_UTILIZATION_SUBSET_H
+#define HIJACK_NVML_PROCESSES_UTILIZATION_SUBSET_H
+
+#ifndef nvmlProcessesUtilizationInfo_v1
+
+/**
+ * Structure to store utilization value and process Id -- version 1
+ */
+typedef struct nvmlProcessUtilizationInfo_v1_st {
+  unsigned long long timeStamp;  //!< CPU Timestamp in microseconds
+  unsigned int pid;              //!< PID of process
+  unsigned int smUtil;           //!< SM (3D/Compute) Util Value
+  unsigned int memUtil;          //!< Frame Buffer Memory Util Value
+  unsigned int encUtil;          //!< Encoder Util Value
+  unsigned int decUtil;          //!< Decoder Util Value
+  unsigned int jpgUtil;          //!< Jpeg Util Value
+  unsigned int ofaUtil;          //!< Ofa Util Value
+} nvmlProcessUtilizationInfo_v1_t;
+
+/**
+ * Structure to store utilization and process ID for each running process -- version 1
+ */
+typedef struct nvmlProcessesUtilizationInfo_v1_st {
+  unsigned int version;            //!< The version number of this struct
+  unsigned int processSamplesCount;  //!< Caller array size / returned count
+  unsigned long long lastSeenTimeStamp;  //!< Min timestamp for returned samples
+  nvmlProcessUtilizationInfo_v1_t *procUtilArray;  //!< Caller-allocated samples
+} nvmlProcessesUtilizationInfo_v1_t;
+
+typedef nvmlProcessesUtilizationInfo_v1_t nvmlProcessesUtilizationInfo_t;
+
+#define nvmlProcessesUtilizationInfo_v1 \
+    ((unsigned int)(sizeof(nvmlProcessesUtilizationInfo_v1_t) | (1U << 24U)))
+
+nvmlReturn_t nvmlDeviceGetProcessesUtilizationInfo(
+    nvmlDevice_t device, nvmlProcessesUtilizationInfo_t *processesUtilInfo);
+
+#endif /* nvmlProcessesUtilizationInfo_v1 */
+
+#endif /* HIJACK_NVML_PROCESSES_UTILIZATION_SUBSET_H */

--- a/src/include/nvml_processes_utilization_subset.h
+++ b/src/include/nvml_processes_utilization_subset.h
@@ -3,8 +3,8 @@
  * (driver 580+). Omitted from older CUDA nvml.h headers shipped with the
  * project build; skipped when a newer nvml.h already defines them.
  */
-#ifndef HIJACK_NVML_PROCESSES_UTILIZATION_SUBSET_H
-#define HIJACK_NVML_PROCESSES_UTILIZATION_SUBSET_H
+#ifndef SRC_INCLUDE_NVML_PROCESSES_UTILIZATION_SUBSET_H_
+#define SRC_INCLUDE_NVML_PROCESSES_UTILIZATION_SUBSET_H_
 
 #ifndef nvmlProcessesUtilizationInfo_v1
 
@@ -42,4 +42,4 @@ nvmlReturn_t nvmlDeviceGetProcessesUtilizationInfo(
 
 #endif /* nvmlProcessesUtilizationInfo_v1 */
 
-#endif /* HIJACK_NVML_PROCESSES_UTILIZATION_SUBSET_H */
+#endif /* SRC_INCLUDE_NVML_PROCESSES_UTILIZATION_SUBSET_H_ */

--- a/src/include/nvml_processes_utilization_subset.h
+++ b/src/include/nvml_processes_utilization_subset.h
@@ -6,13 +6,15 @@
 #ifndef SRC_INCLUDE_NVML_PROCESSES_UTILIZATION_SUBSET_H_
 #define SRC_INCLUDE_NVML_PROCESSES_UTILIZATION_SUBSET_H_
 
+#include <stdint.h>
+
 #ifndef nvmlProcessesUtilizationInfo_v1
 
 /**
  * Structure to store utilization value and process Id -- version 1
  */
 typedef struct nvmlProcessUtilizationInfo_v1_st {
-  unsigned long long timeStamp;  //!< CPU Timestamp in microseconds
+  uint64_t timeStamp;  //!< CPU Timestamp in microseconds
   unsigned int pid;              //!< PID of process
   unsigned int smUtil;           //!< SM (3D/Compute) Util Value
   unsigned int memUtil;          //!< Frame Buffer Memory Util Value
@@ -28,7 +30,7 @@ typedef struct nvmlProcessUtilizationInfo_v1_st {
 typedef struct nvmlProcessesUtilizationInfo_v1_st {
   unsigned int version;            //!< The version number of this struct
   unsigned int processSamplesCount;  //!< Caller array size / returned count
-  unsigned long long lastSeenTimeStamp;  //!< Min timestamp for returned samples
+  uint64_t lastSeenTimeStamp;  //!< Min timestamp for returned samples
   nvmlProcessUtilizationInfo_v1_t *procUtilArray;  //!< Caller-allocated samples
 } nvmlProcessesUtilizationInfo_v1_t;
 
@@ -42,4 +44,4 @@ nvmlReturn_t nvmlDeviceGetProcessesUtilizationInfo(
 
 #endif /* nvmlProcessesUtilizationInfo_v1 */
 
-#endif /* SRC_INCLUDE_NVML_PROCESSES_UTILIZATION_SUBSET_H_ */
+#endif  // SRC_INCLUDE_NVML_PROCESSES_UTILIZATION_SUBSET_H_

--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -389,6 +389,8 @@ void* __dlsym_hook_section_nvml(void* handle, const char* symbol) {
     DLSYM_HOOK_FUNC(nvmlDeviceGetPciInfo);
     /** nvmlDeviceGetProcessUtilization */
     DLSYM_HOOK_FUNC(nvmlDeviceGetProcessUtilization);
+    /** nvmlDeviceGetProcessesUtilizationInfo */
+    DLSYM_HOOK_FUNC(nvmlDeviceGetProcessesUtilizationInfo);
     /** nvmlDeviceGetCount */
     DLSYM_HOOK_FUNC(nvmlDeviceGetCount);
     /** nvmlDeviceClearAccountingPids */

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -22,7 +22,7 @@
 #include "multiprocess/multiprocess_memory_limit.h"
 #include "multiprocess/multiprocess_utilization_watcher.h"
 #include "include/log_utils.h"
-#include "include/nvml_override.h"
+#include "include/nvml_processes_utilization_subset.h"
 
 
 static int g_sm_num[CUDA_DEVICE_MAX_COUNT];
@@ -121,6 +121,62 @@ unsigned int cuda_to_nvml_map(unsigned int cudadev){
     return cuda_to_nvml_map_array[cudadev];
 }
 
+static nvmlReturn_t get_process_utilization_samples(
+    nvmlDevice_t device,
+    unsigned long long last_seen,
+    nvmlProcessUtilizationSample_t *out,
+    unsigned int *out_count) {
+  unsigned int processes_num = *out_count;
+  nvmlReturn_t res = nvmlDeviceGetProcessUtilization(
+      device, out, &processes_num, last_seen);
+  int i;
+
+  if (res == NVML_SUCCESS) {
+    *out_count = processes_num;
+    return NVML_SUCCESS;
+  }
+  if (res != NVML_ERROR_NOT_SUPPORTED) {
+    return res;
+  }
+
+  nvmlProcessUtilizationInfo_v1_t local_samples[SHARED_REGION_MAX_PROCESS_NUM];
+  nvmlProcessesUtilizationInfo_v1_t info;
+  info.version = nvmlProcessesUtilizationInfo_v1;
+  info.processSamplesCount = 0;
+  info.lastSeenTimeStamp = last_seen;
+  info.procUtilArray = NULL;
+
+  res = nvmlDeviceGetProcessesUtilizationInfo(
+      device, (nvmlProcessesUtilizationInfo_t *)&info);
+  if (res == NVML_ERROR_INSUFFICIENT_SIZE) {
+    info.procUtilArray = local_samples;
+    info.processSamplesCount = SHARED_REGION_MAX_PROCESS_NUM;
+    res = nvmlDeviceGetProcessesUtilizationInfo(
+        device, (nvmlProcessesUtilizationInfo_t *)&info);
+  }
+  if (res == NVML_ERROR_NOT_FOUND) {
+    *out_count = 0;
+    return NVML_SUCCESS;
+  }
+  if (res != NVML_SUCCESS) {
+    return res;
+  }
+
+  if (info.processSamplesCount > SHARED_REGION_MAX_PROCESS_NUM) {
+    info.processSamplesCount = SHARED_REGION_MAX_PROCESS_NUM;
+  }
+  for (i = 0; i < (int)info.processSamplesCount; i++) {
+    out[i].pid = local_samples[i].pid;
+    out[i].timeStamp = local_samples[i].timeStamp;
+    out[i].smUtil = local_samples[i].smUtil;
+    out[i].memUtil = local_samples[i].memUtil;
+    out[i].encUtil = local_samples[i].encUtil;
+    out[i].decUtil = local_samples[i].decUtil;
+  }
+  *out_count = info.processSamplesCount;
+  return NVML_SUCCESS;
+}
+
 int setspec() {
     unsigned int device_count;
 
@@ -175,7 +231,8 @@ int get_used_gpu_utilization(int *userutil,int *sysprocnum) {
       microsec = (cur.tv_sec - 1) * 1000UL * 1000UL + cur.tv_usec;
       nvmlProcessUtilizationSample_t processes_sample[SHARED_REGION_MAX_PROCESS_NUM];
       unsigned int processes_num = SHARED_REGION_MAX_PROCESS_NUM;
-      nvmlReturn_t res2 = nvmlDeviceGetProcessUtilization(device, processes_sample, &processes_num, microsec);
+      nvmlReturn_t res2 = get_process_utilization_samples(
+          device, microsec, processes_sample, &processes_num);
 
       // Now acquire lock only for the brief period needed to update shared memory
       lock_shrreg();

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -123,7 +123,7 @@ unsigned int cuda_to_nvml_map(unsigned int cudadev){
 
 static nvmlReturn_t get_process_utilization_samples(
     nvmlDevice_t device,
-    unsigned long long last_seen,
+    uint64_t last_seen,
     nvmlProcessUtilizationSample_t *out,
     unsigned int *out_count) {
   unsigned int processes_num = *out_count;

--- a/src/nvml/hook.c
+++ b/src/nvml/hook.c
@@ -14,6 +14,7 @@ entry_t nvml_library_entry[] = {
     {.name = "nvmlDeviceGetComputeRunningProcesses"},
     {.name = "nvmlDeviceGetPciInfo"},
     {.name = "nvmlDeviceGetProcessUtilization"},
+    {.name = "nvmlDeviceGetProcessesUtilizationInfo"},
     {.name = "nvmlDeviceGetCount"},
     {.name = "nvmlDeviceClearAccountingPids"},
     {.name = "nvmlDeviceClearCpuAffinity"},

--- a/src/nvml/nvml_entry.c
+++ b/src/nvml/nvml_entry.c
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include "include/nvml_prefix.h"
 #include "include/libnvml_hook.h"
+#include "include/nvml_processes_utilization_subset.h"
 #include "include/utils.h"
 
 extern entry_t cuda_library_entry[];
@@ -59,6 +60,17 @@ nvmlReturn_t nvmlDeviceGetProcessUtilization(
   return NVML_OVERRIDE_CALL_NO_LOG(nvml_library_entry, nvmlDeviceGetProcessUtilization,
                          device, utilization, processSamplesCount,
                          lastSeenTimeStamp);
+}
+
+nvmlReturn_t nvmlDeviceGetProcessesUtilizationInfo(
+    nvmlDevice_t device, nvmlProcessesUtilizationInfo_t *processesUtilInfo) {
+  driver_sym_t entry = NVML_FIND_ENTRY(nvml_library_entry,
+                                       nvmlDeviceGetProcessesUtilizationInfo);
+  if (entry == NULL) {
+    return NVML_ERROR_NOT_SUPPORTED;
+  }
+  typedef nvmlReturn_t (*sym_t)(nvmlDevice_t, nvmlProcessesUtilizationInfo_t *);
+  return ((sym_t)entry)(device, processesUtilInfo);
 }
 /*
 nvmlReturn_t nvmlDeviceGetCount_v2(unsigned int *deviceCount) {


### PR DESCRIPTION
# [Bug] Task detail GPU compute utilization always shows 0% on Blackwell (RTX PRO 6000) despite active GPU load

## Summary

On **NVIDIA RTX PRO 6000 Blackwell Server Edition** with **HAMi v2.9.0** and **HAMi-WebUI v1.2.0**, the **task detail page** always shows **0% GPU compute utilization** (`hami_container_core_util`), even when:

- `nvidia-smi` inside the container reports high GPU utilization (e.g. 61–100%)
- `hami_host_gpu_utilization_ratio` (card-level metric from device-plugin) correctly reports non-zero values during load
- `hami_container_device_memory_bytes` (container memory) is accurate

This appears to be a **data source / upstream metrics limitation** on Blackwell, but WebUI currently has no fallback or user-visible indication when per-container SM metrics are unavailable.

## Environment

| Item | Value |
|------|-------|
| GPU | 4× NVIDIA RTX PRO 6000 Blackwell Server Edition |
| Driver | 580.159.03 |
| NVML | 13.580.159.03 |
| CUDA (host) | 13.0 |
| Kubernetes | k3s / single node (`dept-ssh-vm`) |
| HAMi | v2.9.0 (`projecthami/hami:v2.9.0`) |
| HAMi-WebUI | v1.2.0 |
| DCGM Exporter | 4.5.2 |

## Steps to Reproduce

1. Deploy HAMi + HAMi-WebUI with Prometheus integration (WebUI backend metrics scraping configured).
2. Schedule a GPU workload on Blackwell.
3. Generate GPU compute load inside the pod (inference, torch matmul, etc.).
4. Observe GPU utilization via `nvidia-smi` inside the pod → **non-zero**.
5. Open HAMi-WebUI → **Task detail page** for that pod → **GPU compute utilization = 0%**.

### Example: API query used by WebUI monitoring

```bash
curl 'http://<webui>/api/vgpu/v1/monitor/query/instant-vector' \
  -H 'Content-Type: application/json' \
  --data-raw '{"query":"hami_container_core_util{pod_name=\"msa-search-service-76b4f474d8-8wngl\"}"}'
```

**Result:** `value: 0` even during active GPU load.

### Example: upstream device-plugin metric

```bash
curl -s http://<node>:31992/metrics | grep hami_container_device_utilization_ratio | grep msa-search
```

**Result:** always `0`.

### Example: card-level metric (works)

```bash
curl -s http://<node>:31992/metrics | grep hami_host_gpu_utilization_ratio
```

**Result:** reports `39`, `99`, `100` during the same load test window.

## Expected Behavior

- Task detail page should show non-zero GPU compute utilization when the container is actively using the GPU.
- Alternatively, if per-container SM metrics are unavailable on a given GPU architecture, WebUI should:
  - show a clear warning/tooltip (e.g. "per-container SM utilization not supported on this GPU/driver"), and/or
  - fall back to card-level utilization (`hami_host_gpu_utilization_ratio` / `hami_core_util`) with appropriate labeling.

## Actual Behavior

- `hami_container_core_util` is always **0** on task detail page.
- `hami_container_device_utilization_ratio` from device-plugin is always **0**.
- Memory metrics (`hami_container_memory_util`, `hami_container_device_memory_bytes`) work correctly.

## Root Cause Analysis (upstream, affects WebUI data)

We traced the metric pipeline:

```
WebUI frontend
  → WebUI backend (:8000) aggregates Prometheus metrics
    → hami_container_core_util
      ← hami_container_device_utilization_ratio (device-plugin :31992)
        ← libvgpu.so shared memory sm_util
          ← nvmlDeviceGetProcessUtilization() in HAMi-core watcher
```

### Key finding: NVML API returns NOT_SUPPORTED on Blackwell

On **host** and **inside vGPU containers**, `nvmlDeviceGetProcessUtilization` returns **`NVML_ERROR_NOT_SUPPORTED (7)`**, while `nvmlDeviceGetUtilizationRates` works:

| Location | GetUtilizationRates | GetProcessUtilization |
|----------|--------------------|-----------------------|
| Host (all 4 GPUs, GPU3 at 100% load) | SUCCESS | **NOT_SUPPORTED (7)** |
| logos-service pod (CUDA_DEVICE_SM_LIMIT=99, UTILIZATION_SWITCH=1) under load | gpu=41% | **NOT_SUPPORTED (7)** |
| msa-search-service pod | OK | **NOT_SUPPORTED (7)** |

HAMi-core (`multiprocess_utilization_watcher.c`, v2.9.0 / master) only writes `sm_util` when `res2 == NVML_SUCCESS`:

```c
nvmlReturn_t res2 = nvmlDeviceGetProcessUtilization(...);
if (res2 == NVML_SUCCESS) {
    proc->device_util[cudadev].sm_util = processes_sample[i].smUtil;
}
```

When the API returns `NOT_SUPPORTED`, container SM utilization stays 0 forever.

### Environment variables alone do not fix it

| Pod | CUDA_DEVICE_SM_LIMIT | CUDA_DEVICE_UTILIZATION_SWITCH | utilization_ratio |
|-----|------------------------|-------------------------------|-------------------|
| logos-service | **99** | **1** | **0** |
| msa-search-service | 0 | not set | **0** |
| protenix-service | 0 | not set | **0** |

`logos-service` has the recommended env vars but still reports 0 → confirms this is not a WebUI-only bug, but WebUI has no handling for this case.

### What still works

| Metric | Status |
|--------|--------|
| `hami_container_device_memory_bytes` | ✅ accurate |
| `hami_host_gpu_utilization_ratio` | ✅ reflects card-level load |
| `hami_container_last_kernel_elapsed_seconds` | ✅ updates (CUDA hook active) |
| `DCGM_FI_DEV_GPU_UTIL` / `hami_core_util` | ⚠️ card-level only, scrape interval dependent |

## Card Detail Page vs Task Detail Page: Why 100% vs 0%?

This is **not a WebUI inconsistency** — the two pages intentionally query **different metrics at different granularity**.

### WebUI source code (HAMi-WebUI `main` branch)

**Card detail page** — `packages/web/projects/vgpu/views/card/admin/Detail.vue`:

```javascript
// GPU compute utilization (card-level)
query: `avg(sum(hami_core_util{device_uuid=~"$device_uuid"}) by (instance))`
percentQuery: `avg(sum(hami_core_util_avg{device_uuid=~"$device_uuid"}) by (instance))`
```

**Task detail page** — `packages/web/projects/vgpu/views/task/admin/Detail.vue`:

```javascript
// GPU compute utilization (per-container)
query: `avg(sum(hami_container_core_util{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (instance))`

// GPU memory utilization (per-container) — works correctly
query: `avg(sum(hami_container_memory_util{container_name=~"$container",pod_name=~"$pod",namespace_name="$namespace"}) by (instance))`
```

### Side-by-side comparison

| | Card detail page | Task detail page |
|---|---|---|
| **URL example** | `/admin/vgpu/card/admin/GPU-de9f6409-...` | `/admin/vgpu/task/admin/detail?name=model-service&podUid=245e145b-...` |
| **PromQL metric** | `hami_core_util` | `hami_container_core_util` |
| **Granularity** | Whole GPU card | Single Pod/container |
| **Data source** | DCGM Exporter → `GetUtilizationRates()` | device-plugin → libvgpu `sm_util` → `GetProcessUtilization()` |
| **On Blackwell** | ✅ Works (e.g. 100%) | ❌ Always 0 |
| **Answers** | "Is this GPU busy?" | "How much SM does this Pod use?" |

### Live evidence (GPU3 `GPU-de9f6409-...`, logos-service under torch load)

```
# Card page reads these — non-zero
hami_core_util{device_uuid="GPU-de9f6409-..."}                  = 100
hami_host_gpu_utilization_ratio{device_uuid="GPU-de9f6409-..."} = 100

# Task page reads these — always zero
hami_container_core_util{pod_name="logos-service-..."}          = 0
hami_container_device_utilization_ratio{pod="logos-service-..."}  = 0

# Task page memory — works fine
hami_container_memory_util{pod_name="logos-service-..."}          = 47.5
```

### Data flow diagram

```
Card page (100%)                         Task page (0%)
──────────────                           ──────────────
hami_core_util                           hami_container_core_util
    │                                        │
    ▼                                        ▼
DCGM Exporter                            WebUI backend aggregate
    │                                        │
    ▼                                        ▼
nvmlDeviceGetUtilizationRates() ✅         hami_container_device_utilization_ratio
(card-level SM%)                             │
                                             ▼
                                         libvgpu shared memory sm_util
                                             │
                                             ▼
                                         nvmlDeviceGetProcessUtilization() ❌
                                         (NOT_SUPPORTED on Blackwell)
```

### User-visible scenario

When `logos-service` runs a torch matmul stress test on GPU3:

- **Card page shows 100%** — the whole GPU is busy (correct).
- **Task page for logos shows 0%** — per-container SM cannot be attributed (broken upstream).
- **Task page memory shows ~47.5%** — container memory tracking works via a separate CUDA hook path.

Multiple Pods can share the same GPU via HAMi vGPU. Card-level 100% does not tell which Pod caused it; task-level SM would, but that metric is unavailable on Blackwell.

## Impact on WebUI

1. **Task detail page** is misleading — shows 0% compute util for all Blackwell workloads.
2. **Card detail page** works correctly — can show 100% while all task pages on that GPU show 0%, causing user confusion.
3. **Node-level monitoring** partially works (allocation %, card-level util via separate queries) after Prometheus scrape config is correct.
4. No UI indication that per-container SM metrics are unsupported on this platform.

## Suggested Fixes (WebUI side)

1. **Fallback display**: When `hami_container_device_utilization_ratio == 0` for extended period but `hami_host_gpu_utilization_ratio` or `hami_core_util` on the assigned GPU is non-zero, show card-level util with label `"card-level (per-container SM unavailable)"`.
2. **Capability detection**: Document or detect Blackwell + driver combo and show an info banner on task detail page.
3. **Cross-link upstream**: Track [HAMi-core](https://github.com/Project-HAMi/HAMi-core) fix for `NOT_SUPPORTED` fallback to `GetUtilizationRates`.

## Suggested Fixes (upstream HAMi / NVIDIA)

- HAMi-core: fallback when `nvmlDeviceGetProcessUtilization` returns `NOT_SUPPORTED`
- NVIDIA driver: enable per-process SM utilization on Blackwell via NVML

## Workarounds (current)

- Use **node/GPU card-level** metrics in WebUI system monitoring (`hami_host_gpu_utilization_ratio`, `hami_core_util_avg`).
- Use **container memory** metrics on task detail (accurate).
- Use `nvidia-smi` inside pod for compute utilization until fixed.

## Additional Context

- Related HAMi issue area: [HAMi #1864](https://github.com/Project-HAMi/HAMi/issues/1864) (utilization watcher env requirements)
- Related Blackwell NVML gap: [HAMi #1511](https://github.com/Project-HAMi/HAMi/issues/1511) (GB10 `GetMemoryInfo` NOT_SUPPORTED)
- Prometheus scrape fix for WebUI backend metrics (`hami_container_vmemory_allocated`, etc.) was configured separately and is working; this issue is specifically about **per-container GPU compute utilization**.

## Logs / Evidence

<details>
<summary>NVML test on host (GPU3 at 100% utilization)</summary>

```
GetUtilizationRates:        ret=0 (SUCCESS), gpu=100%
GetProcessUtilization:      ret=7 (NOT_SUPPORTED)
GetComputeRunningProcesses: ret=7 (NOT_SUPPORTED)
```

</details>

<details>
<summary>NVML test in logos-service pod under torch load (env correctly configured)</summary>

```
CUDA_DEVICE_SM_LIMIT=99
CUDA_DEVICE_UTILIZATION_SWITCH=1

UNDER_LOAD GetUtilizationRates: gpu=41%
UNDER_LOAD GetProcessUtilization: ret=7 (NOT_SUPPORTED)
UNDER_LOAD nvidia-smi: 41%
hami_container_device_utilization_ratio: 0
```

</details>

<details>
<summary>Metrics during MSA search load test</summary>

```
hami_host_gpu_utilization_ratio{device_uuid="GPU-de9f6409-..."} 39 → 99 → 100
hami_container_device_utilization_ratio{pod="msa-search-service-..."} 0 (all samples)
hami_container_core_util{pod_name="msa-search-service-..."} 0 (all samples)
```

</details>

---

**Labels suggestion:** `bug`, `monitoring`, `blackwell`, `nvml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-process GPU utilization via the newer NVML per-process utilization interface on supported driver versions.
* **Bug Fixes**
  * Improved utilization reporting by automatically falling back to the newer per-process API when legacy support isn’t available.
  * Enhanced robustness for insufficient buffer sizing and “no processes found” cases to provide correct, complete results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->