### PR TITLE
docs: close unclosed code block in readme

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -102,3 +102,4 @@ Mon Dec  2 04:38:12 2024
 
 ```bash
 ./test/test_alloc
+```


### PR DESCRIPTION
The last code block under Test Raw APIs in README_CN.md was missing its closing fence, so everything after it renders wrong.