### PR TITLE
fix(nvml): ensure nvml_postInit only runs on NVML_SUCCESS

### DIFF
--- a/src/nvml/hook.c
+++ b/src/nvml/hook.c
@@ -438,7 +438,10 @@ nvmlReturn_t nvmlInitWithFlags( unsigned int  flags ) {
     LOG_DEBUG("nvmlInitWithFlags")
     pthread_once(&init_virtual_map_pre_flag, (void(*) (void))nvml_preInit);
     nvmlReturn_t res =  NVML_OVERRIDE_CALL(nvml_library_entry, nvmlInitWithFlags,flags);
-    pthread_once(&init_virtual_map_post_flag,(void (*)(void))nvml_postInit);
+
+    if (res == NVML_SUCCESS) {
+        pthread_once(&init_virtual_map_post_flag,(void (*)(void))nvml_postInit);
+    }
     return res;
 }
 
@@ -446,7 +449,10 @@ nvmlReturn_t nvmlInit(void) {
     LOG_DEBUG("nvmlInit")
     pthread_once(&init_virtual_map_pre_flag,(void (*)(void))nvml_preInit);
     nvmlReturn_t res = NVML_OVERRIDE_CALL(nvml_library_entry, nvmlInit_v2);
-    pthread_once(&init_virtual_map_post_flag,(void (*)(void))nvml_postInit);
+
+    if (res == NVML_SUCCESS) {
+        pthread_once(&init_virtual_map_post_flag,(void (*)(void))nvml_postInit);
+    }
     return res;
 }
 
@@ -454,7 +460,10 @@ nvmlReturn_t nvmlInit_v2(void) {
     LOG_DEBUG("nvmlInit_v2");
     pthread_once(&init_virtual_map_pre_flag,(void (*)(void))nvml_preInit);
     nvmlReturn_t res = NVML_OVERRIDE_CALL(nvml_library_entry, nvmlInit_v2);
-    pthread_once(&init_virtual_map_post_flag,(void (*)(void))nvml_postInit);
+
+    if (res == NVML_SUCCESS) {
+        pthread_once(&init_virtual_map_post_flag,(void (*)(void))nvml_postInit);
+    }
     return res;
 }
 


### PR DESCRIPTION
I closed this by mistake, while cleaning up forks. Old cleanup of https://github.com/Project-HAMi/HAMi-core/pull/168

Fixes a critical edge case where GPU initialization permanently fails in Kubernetes 1.27+ Burstable pods (e.g., when device files are temporarily locked during resize: InProgress).
Issue Related : https://github.com/Project-HAMi/HAMi-core/issues/167 and https://github.com/Project-HAMi/HAMi/issues/1704#issuecomment-4115925203

The Bug:
Because nvml_postInit used pthread_once, it was marked as "completed" even if the initial nvmlInit driver call failed. If an application retried the initialization later, nvml_postInit was bypassed, leaving the virtual GPU map permanently broken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization handling so follow-up setup runs only after successful NVML initialization.
  * Preserved initialization results and behavior when initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->