### PR TITLE
fix: avoid div by zero and underflow in pitch alloc size guess

### DIFF
--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -158,7 +158,8 @@ CUresult cuMemAllocManaged(CUdeviceptr* dptr, size_t bytesize, unsigned int flag
 CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInBytes, 
                                       size_t Height, unsigned int ElementSizeBytes) {
     LOG_DEBUG("cuMemAllocPitch_v2 dptr=%p (%ld,%ld)",dptr,WidthInBytes,Height);
-    size_t guess_pitch = (((WidthInBytes - 1) / ElementSizeBytes) + 1) * ElementSizeBytes;
+    size_t guess_pitch = (ElementSizeBytes == 0 || WidthInBytes == 0) ? 0 :
+        (((WidthInBytes - 1) / ElementSizeBytes) + 1) * ElementSizeBytes;
     size_t bytesize = guess_pitch * Height;
     ENSURE_RUNNING();
     CUdevice dev;


### PR DESCRIPTION
Zero WidthInBytes underflows the size guess to SIZE_MAX, zero ElementSizeBytes divides by zero and crashes. This guards both to 0 before the guess is computed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pitched memory allocation requests when the element size or width is zero.
  * Prevented invalid pitch calculations, ensuring memory sizing and out-of-memory tracking remain consistent for these edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->