### PR TITLE
fix: lock shared region before clearing proc slots in oom_check

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -51,7 +51,10 @@ int oom_check(const int dev, size_t addon) {
     if (new_allocated > limit) {
         LOG_ERROR("Device %d OOM %lu / %lu", d, new_allocated, limit);
 
-        if (clear_proc_slot_nolock(1) > 0)
+        lock_shrreg();
+        int cleared = clear_proc_slot_nolock(1);
+        unlock_shrreg();
+        if (cleared > 0)
             return oom_check(dev,addon);
         return 1;
     }
@@ -116,7 +119,7 @@ int add_chunk(CUdeviceptr *address, size_t size) {
     if (oom_check(dev, size))
         return CUDA_ERROR_OUT_OF_MEMORY;
 
-    /* GPU allocation outside lock — the expensive part */
+    /* GPU allocation outside lock, the expensive part */
     if (size <= IPCSIZE) {
         res = CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemAlloc_v2, address, size);
     } else {
@@ -127,7 +130,7 @@ int add_chunk(CUdeviceptr *address, size_t size) {
         return res;
     }
 
-    /* Tracking inside lock — pure in-memory ops, microseconds */
+    /* Tracking inside lock, pure in-memory ops, microseconds */
     pthread_mutex_lock(&mutex);
 
     if (oom_check(dev, size)) {


### PR DESCRIPTION
oom_check called clear_proc_slot_nolock without holding the shrreg lock, unlike its other caller. Concurrent OOM across processes can race on the shared proc table. Now it locks around the call, same as init_proc_slot_withlock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved out-of-memory handling during resource allocation to safely retry after clearing an available process slot.

* **Documentation**
  * Clarified internal comments related to GPU allocation and resource tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->