### PR TITLE
fix: probe CUDA context on correct device in set_task_pid()

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -111,6 +111,7 @@ nvmlReturn_t set_task_pid() {
     CHECK_NVML_API(nvmlDeviceGetCount(&nvmlCounts));
     
     int cudaDev;
+    int probeDev = 0;
     for (i=0;i<nvmlCounts;i++){
         cudaDev=nvml_to_cuda_map(i);
         if (cudaDev<0) {
@@ -123,14 +124,15 @@ nvmlReturn_t set_task_pid() {
                 LOG_ERROR("Device2GetComputeRunningProcesses failed %d,%d\n",res,i);
                 return res;
             }
-        }while(res==NVML_ERROR_INSUFFICIENT_SIZE); 
+        }while(res==NVML_ERROR_INSUFFICIENT_SIZE);
         mergepid(&previous,&merged_num,(nvmlProcessInfo_t1 *)tmp_pids_on_device,pre_pids_on_device);
+        probeDev = cudaDev;
         break;
     }
     previous = merged_num;
     merged_num = 0;
     memset(tmp_pids_on_device,0,sizeof(nvmlProcessInfo_v1_t)*SHARED_REGION_MAX_PROCESS_NUM);
-    CHECK_CU_RESULT(cuDevicePrimaryCtxRetain(&pctx,0));
+    CHECK_CU_RESULT(cuDevicePrimaryCtxRetain(&pctx,probeDev));
     for (i=0;i<nvmlCounts;i++) {
         cudaDev=nvml_to_cuda_map(i);
         if (cudaDev<0) {
@@ -168,7 +170,7 @@ nvmlReturn_t set_task_pid() {
             }
         }
     }
-    CHECK_CU_RESULT(cuDevicePrimaryCtxRelease(0));
+    CHECK_CU_RESULT(cuDevicePrimaryCtxRelease(probeDev));
     return NVML_SUCCESS; 
 }
 


### PR DESCRIPTION
## Problem

`set_task_pid()` in `src/utils.c` polls NVML processes on the first physical device where `nvml_to_cuda_map(i) >= 0`, but the probe context is always created on hardcoded CUDA device 0 via `cuDevicePrimaryCtxRetain(&pctx, 0)`.

When `CUDA_VISIBLE_DEVICES` does not start with the pod's device 0 (e.g., `CVD=1` or `CVD=1,0`), the polled NVML device and the probe context device are different physical GPUs. `getextrapid()` never finds the new PID, causing a spurious "host pid is error!" and subsequent fake Device 0 OOM due to incorrect memory accounting.

## Fix

Save the `cudaDev` found in the NVML enumeration loop and use it for both `cuDevicePrimaryCtxRetain` and `cuDevicePrimaryCtxRelease`, ensuring the probe context runs on the same device being polled.

## Testing

Verified on an 8x RTX 3090 machine with all CVD combinations.

(Closed in favor of #230)