### PR TITLE
chore: remove sm scale from sm limit setter

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1235,14 +1235,14 @@ int set_host_pid(int hostpid) {
     return 0;
 }
 
-int set_current_device_sm_limit_scale(int dev, int scale) {
+int set_current_device_sm_limit(int dev, int limit) {
     ensure_initialized();
     if (region_info.shared_region->sm_init_flag==1) return 0;
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
     }
-    LOG_INFO("dev %d new sm limit set mul by %d",dev,scale);
-    region_info.shared_region->sm_limit[dev]=region_info.shared_region->sm_limit[dev]*scale;
+    LOG_INFO("dev %d new sm limit set to %d",dev,limit);
+    region_info.shared_region->sm_limit[dev]=limit;
     region_info.shared_region->sm_init_flag = 1;
     return 0;
 }

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1240,6 +1240,7 @@ int set_current_device_sm_limit(int dev, int limit) {
     if (region_info.shared_region->sm_init_flag==1) return 0;
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return -1;
     }
     LOG_INFO("dev %d new sm limit set to %d",dev,limit);
     region_info.shared_region->sm_limit[dev]=limit;

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -128,8 +128,7 @@ void ensure_initialized();
 int get_current_device_sm_limit(int dev);
 uint64_t get_current_device_memory_limit(const int dev);
 int set_current_device_memory_limit(const int dev,size_t newlimit);
-int set_current_device_sm_limit(int dev,int scale);
-int set_current_device_sm_limit_scale(int dev,int scale);
+int set_current_device_sm_limit(int dev, int limit);
 int update_host_pid();
 int set_host_pid(int hostpid);
 


### PR DESCRIPTION
Closes #231

This PR removes the ambiguous sm-scale API path and keeps SM limit setting as an explicit limit value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for setting a device’s SM memory limit using a specific absolute value.

* **Bug Fixes**
  * Improved memory-limit configuration consistency by switching from scale-based adjustments to direct limit assignment.

* **Breaking Changes**
  * Updated the public SM-limit setter to accept `limit` (absolute) instead of a `scale` value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->