### PR TITLE
fix: start utilization_watcher thread unconditionally when initialized

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -324,19 +324,13 @@ void init_utilization_watcher() {
     setspec();
 
     // Initialize cached_sm_limit for each device
-    int has_limit = 0;
     for (unsigned int dev = 0; dev < device_count && dev < CUDA_DEVICE_MAX_COUNT; dev++) {
         cached_sm_limit[dev] = get_current_device_sm_limit(dev);
         LOG_INFO("device %d: core utilization limit = %d", dev, cached_sm_limit[dev]);
-        if (cached_sm_limit[dev] > 0 && cached_sm_limit[dev] <= 100) {
-            has_limit = 1;
-        }
     }
 
     pthread_t tid;
-    if (has_limit) {
-        pthread_create(&tid, NULL, utilization_watcher, NULL);
-    }
+    pthread_create(&tid, NULL, utilization_watcher, NULL);
     return;
 }
 

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -330,7 +330,9 @@ void init_utilization_watcher() {
     }
 
     pthread_t tid;
-    pthread_create(&tid, NULL, utilization_watcher, NULL);
+    if (pthread_create(&tid, NULL, utilization_watcher, NULL) != 0) {
+        LOG_WARN("pthread_create failed for utilization watcher thread");
+    }
     return;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, `init_utilization_watcher()` only spawns the utilization watcher thread if explicit hard SM limits are set (`has_limit > 0`).
When workloads run without explicit `gpucores` limits (`CUDA_DEVICE_SM_LIMIT=0`), the watcher thread is never started. This prevents GPU utilization stats from being written to shared memory, causing `vGPUmonitor` to report 0% utilization.
This PR removes the `has_limit` check so the watcher thread always starts when initialized, ensuring GPU utilization metrics are collected for all workloads regardless of SM limits.


**Which issue(s) this PR fixes**:
Fixes #236 

**Special notes for your reviewer**:
<img width="675" height="58" alt="image" src="https://github.com/user-attachments/assets/a1984ed1-84bb-4a98-9f00-2212ba23c8ce" />

**Does this PR introduce a user-facing change?**:
N.A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved utilization monitoring initialization across CUDA devices.
  * The utilization watcher background thread now starts consistently after device limits are cached, even when no device has a configured utilization limit.
  * Added handling to detect and warn if background thread creation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->