### PR TITLE
fix: use atomic load/store for device limit/sm_limit in shared region

### DIFF
--- a/src/cuda/device.c
+++ b/src/cuda/device.c
@@ -90,6 +90,10 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
 CUresult cuDeviceTotalMem_v2 ( size_t* bytes, CUdevice dev ) {
     LOG_DEBUG("into cuDeviceTotalMem");
     ENSURE_INITIALIZED();
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        LOG_ERROR("Illegal device id: %d", dev);
+        return CUDA_ERROR_INVALID_DEVICE;
+    }
     size_t limit = get_current_device_memory_limit(dev);
     *bytes = limit;
     return CUDA_SUCCESS;

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1121,10 +1121,18 @@ void try_create_shrreg() {
     if (init_flag != MULTIPROCESS_SHARED_REGION_MAGIC_FLAG) {
         region->major_version = MAJOR_VERSION;
         region->minor_version = MINOR_VERSION;
-        do_init_device_memory_limits(
-            region->limit, CUDA_DEVICE_MAX_COUNT);
-        do_init_device_sm_limits(
-            region->sm_limit,CUDA_DEVICE_MAX_COUNT);
+        {
+            uint64_t init_limits[CUDA_DEVICE_MAX_COUNT];
+            int i;
+            do_init_device_memory_limits(init_limits, CUDA_DEVICE_MAX_COUNT);
+            for (i = 0; i < CUDA_DEVICE_MAX_COUNT; ++i) {
+                atomic_store_explicit(&region->limit[i], init_limits[i], memory_order_relaxed);
+            }
+            do_init_device_sm_limits(init_limits, CUDA_DEVICE_MAX_COUNT);
+            for (i = 0; i < CUDA_DEVICE_MAX_COUNT; ++i) {
+                atomic_store_explicit(&region->sm_limit[i], init_limits[i], memory_order_relaxed);
+            }
+        }
         if (sem_init(&region->sem, 1, 1) != 0) {
             LOG_ERROR("Fail to init sem %s: errno=%d", shr_reg_file, errno);
         }
@@ -1240,6 +1248,7 @@ int set_current_device_sm_limit_scale(int dev, int scale) {
     if (region_info.shared_region->sm_init_flag==1) return 0;
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return -1;
     }
     LOG_INFO("dev %d new sm limit set mul by %d",dev,scale);
     region_info.shared_region->sm_limit[dev]=region_info.shared_region->sm_limit[dev]*scale;
@@ -1251,26 +1260,29 @@ int get_current_device_sm_limit(int dev) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return -1;
     }
-    return region_info.shared_region->sm_limit[dev];
+    return atomic_load_explicit(&region_info.shared_region->sm_limit[dev], memory_order_acquire);
 }
 
 int set_current_device_memory_limit(const int dev,size_t newlimit) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return -1;
     }
     LOG_INFO("dev %d new limit set to %ld",dev,newlimit);
-    region_info.shared_region->limit[dev]=newlimit;
-    return 0; 
+    atomic_store_explicit(&region_info.shared_region->limit[dev], newlimit, memory_order_release);
+    return 0;
 }
 
 uint64_t get_current_device_memory_limit(const int dev) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return 0;
     }
-    return region_info.shared_region->limit[dev];       
+    return atomic_load_explicit(&region_info.shared_region->limit[dev], memory_order_acquire);
 }
 
 uint64_t get_current_device_memory_monitor(const int dev) {

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1245,13 +1245,13 @@ int set_host_pid(int hostpid) {
 
 int set_current_device_sm_limit_scale(int dev, int scale) {
     ensure_initialized();
-    if (region_info.shared_region->sm_init_flag==1) return 0;
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
         return -1;
     }
-    LOG_INFO("dev %d new sm limit set mul by %d",dev,scale);
-    region_info.shared_region->sm_limit[dev]=region_info.shared_region->sm_limit[dev]*scale;
+    if (region_info.shared_region->sm_init_flag == 1) return 0;
+    LOG_INFO("dev %d new sm limit set mul by %d", dev, scale);
+    region_info.shared_region->sm_limit[dev] = region_info.shared_region->sm_limit[dev] * scale;
     region_info.shared_region->sm_init_flag = 1;
     return 0;
 }

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -97,8 +97,8 @@ typedef struct {
     sem_t sem;  // Only for process slot add/remove
     uint64_t device_num;
     uuid uuids[CUDA_DEVICE_MAX_COUNT];
-    uint64_t limit[CUDA_DEVICE_MAX_COUNT];
-    uint64_t sm_limit[CUDA_DEVICE_MAX_COUNT];
+    _Atomic uint64_t limit[CUDA_DEVICE_MAX_COUNT];
+    _Atomic uint64_t sm_limit[CUDA_DEVICE_MAX_COUNT];
     shrreg_proc_slot_t procs[SHARED_REGION_MAX_PROCESS_NUM];
     _Atomic int proc_num;
     _Atomic int utilization_switch;


### PR DESCRIPTION
Closes part of Project-HAMi/HAMi#2127.

`context_size`, `hostpid`, `proc_num`, `status` and `last_kernel_time` in `shared_region_t` were all made `_Atomic` in 24a0f49, but `limit` and `sm_limit` were missed.

Both are read on the CUDA allocation hot path (`get_current_device_memory_limit`, called from every hooked `cuMemAlloc`) and are exposed through public, tested setters on this side (`set_current_device_memory_limit`) and on the Go monitor side (`SetDeviceMemoryLimit`, `SetDeviceSmLimit` in `pkg/monitor/nvidia`), so a plain `uint64_t` here does not match the atomicity already guaranteed for the rest of the struct.

I checked and there is currently only one writer of these two fields in the whole system: `do_init_device_memory_limits`/`do_init_device_sm_limits` at shared-region creation, serialized by the region's file lock before the region is published. So this is not fixing an observed bug, it is closing the one gap left from 24a0f49 in a struct where every other field already carries this guarantee, and in tested API surface that a future caller could otherwise reintroduce the same race through.

## Compatibility

`_Atomic uint64_t` has the same size and representation as `uint64_t` on the supported targets, so this does not change `shared_region_t`'s layout. I verified with `sizeof`/`offsetof` before and after the change:

```
sizeof(shared_region_t) = 2008952
offsetof(limit)         = 1600
offsetof(sm_limit)      = 1728
offsetof(procs)         = 1856
sizeof(limit[0])        = 8
```

All identical, so the on-disk `cudevshr.cache` format and the Go-side mirror struct are unaffected.

Re-verified against the current head (`3b56dde`) with `bench/abi_check` from #239:

```
sizeof(shared_region_t)  = 2008952    (expected 2008952) OK
offsetof(limit)          = 1600       (expected 1600) OK
offsetof(sm_limit)       = 1728       (expected 1728) OK
offsetof(procs)          = 1856       (expected 1856) OK
sizeof(limit[0])         = 8          (expected 8) OK
```

## Changes

- `limit`/`sm_limit` in `shared_region_t` are now `_Atomic uint64_t[CUDA_DEVICE_MAX_COUNT]`.
- `get_current_device_memory_limit`, `get_current_device_sm_limit`, `set_current_device_memory_limit` use `atomic_load_explicit`/`atomic_store_explicit` with acquire/release, matching the style already used elsewhere in this file for `proc_num`, `status`, `last_kernel_time`.
- `do_init_device_memory_limits`/`do_init_device_sm_limits` still take a plain `uint64_t*` and are otherwise unchanged, including the already-initialized comparison branch that calls them. `try_create_shrreg` now fills a local `uint64_t` array through them and copies that into the region with `atomic_store_explicit` (`memory_order_relaxed`, since the existing `atomic_thread_fence(release)` a few lines down already publishes it), instead of writing through a plain-`uint64_t*` cast into the `_Atomic`-qualified fields, which would have been a type violation independent of whether it's safe on current targets.
- `set_current_device_sm_limit_scale`, `get_current_device_sm_limit`, `set_current_device_memory_limit`, and `get_current_device_memory_limit` now `return` after `LOG_ERROR("Illegal device id...")` instead of falling through to index the array anyway, which was an out-of-bounds read for an invalid `dev`. `cuDeviceTotalMem_v2` (`src/cuda/device.c`) additionally now returns `CUDA_ERROR_INVALID_DEVICE` directly for an out-of-range `dev`, rather than forwarding whatever `get_current_device_memory_limit`'s 0 return produces: that 0 means "no limit configured" everywhere else it's read (`oom_check`, `cuMemGetInfo_v2`, the NVML hook), so it does not fail closed, and this PR doesn't claim it does for those three; the `cuDeviceTotalMem_v2` check is the one place that needed and got an explicit fix instead.

## Testing

- `libvgpu.so` builds clean with no new warnings.
- Verified the ABI check above against the pre-change header to confirm zero layout drift.
- Ran a concurrent initialization benchmark (fork+exec N processes through `libvgpu.so`, `LD_PRELOAD`-interposed) before and after this change as a functional regression check; numbers are unchanged.

A companion PR updates the Go side of this same shared struct: Project-HAMi/HAMi#2179.

Note on the CodeRabbit summary below: "kept existing input validation and return behavior unchanged" was accurate for the version it was generated against, but is no longer accurate as of the illegal-`dev` fix described above; return behavior does change for that case now, on purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading and updating shared device memory and SM limits across processes and threads.
  * Ensured limit values remain consistent and visible during concurrent operations.
  * Added validation for invalid device IDs, returning an appropriate invalid-device error.
  * Improved initialization of per-device limits to ensure correct setup before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->