### PR TITLE
feat(bench): add concurrent initialization benchmark harness

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,6 @@
+abi_check
+bench_init
+phase_probe
+nested_retain
+warm_holder
+ctx_experiment

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -6,7 +6,13 @@ LIBS = -L$(CUDA_HOME)/lib64 -lcuda -lpthread -lm
 CORE_TARGETS = bench_init nested_retain warm_holder abi_check
 OPTIONAL_TARGETS = phase_probe
 
-HAVE_NVML := $(shell ldconfig -p | grep -q libnvidia-ml && echo 1)
+# Probe with the exact header path and link flags phase_probe itself uses,
+# not just ldconfig -p: the runtime .so.1 can be present via the driver
+# package while the dev symlink (-lnvidia-ml) and/or nvml.h (from the CUDA
+# toolkit) are still missing, which would make phase_probe a chosen target
+# that then fails to link.
+HAVE_NVML := $(shell printf '#include <nvml.h>\nint main(void){return 0;}\n' | \
+	gcc -x c - $(INCLUDES) $(LIBS) -lnvidia-ml -o /dev/null >/dev/null 2>&1 && echo 1)
 
 TARGETS = $(CORE_TARGETS)
 ifeq ($(HAVE_NVML),1)

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -21,7 +21,12 @@ endif
 
 .PHONY: all clean check-cuda-home print-targets
 
-all: check-cuda-home $(TARGETS)
+all: $(TARGETS)
+
+# Order-only prerequisite on every binary (not just `all`'s prerequisite
+# list), so the preflight also runs under `make -j` and when a target is
+# built directly, e.g. `make bench_init`, not just via `make all`.
+$(CORE_TARGETS) $(OPTIONAL_TARGETS): | check-cuda-home
 
 # Machine-readable list of targets actually built this run, so callers like
 # run_benchmarks.sh can tell whether phase_probe was skipped (no NVML) rather

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -12,7 +12,7 @@ OPTIONAL_TARGETS = phase_probe
 # toolkit) are still missing, which would make phase_probe a chosen target
 # that then fails to link.
 HAVE_NVML := $(shell printf '#include <nvml.h>\nint main(void){return 0;}\n' | \
-	gcc -x c - $(INCLUDES) $(LIBS) -lnvidia-ml -o /dev/null >/dev/null 2>&1 && echo 1)
+	gcc $(CFLAGS) -x c - $(INCLUDES) $(LIBS) -lnvidia-ml -o /dev/null >/dev/null 2>&1 && echo 1)
 
 TARGETS = $(CORE_TARGETS)
 ifeq ($(HAVE_NVML),1)

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,0 +1,34 @@
+CUDA_HOME ?= /home/muon/cuda-headers
+CFLAGS = -O1 -Wall -Wextra
+INCLUDES = -I$(CUDA_HOME)/include -I../build/config -I../src
+LIBS = -L$(CUDA_HOME)/lib64 -lcuda -lpthread -lm
+
+CORE_TARGETS = bench_init nested_retain warm_holder abi_check
+OPTIONAL_TARGETS = phase_probe
+
+TARGETS = $(CORE_TARGETS)
+ifeq ($(shell ldconfig -p | grep -q libnvidia-ml && echo 1),1)
+TARGETS += $(OPTIONAL_TARGETS)
+endif
+
+.PHONY: all clean
+
+all: $(TARGETS)
+
+bench_init: bench_init.c
+	gcc $(CFLAGS) $(INCLUDES) $< -o $@ $(LIBS)
+
+phase_probe: phase_probe.c
+	gcc $(CFLAGS) $(INCLUDES) $< -o $@ $(LIBS) -lnvidia-ml
+
+nested_retain: nested_retain.c
+	gcc $(CFLAGS) $(INCLUDES) $< -o $@ $(LIBS)
+
+warm_holder: warm_holder.c
+	gcc $(CFLAGS) $(INCLUDES) $< -o $@ $(LIBS)
+
+abi_check: abi_check.c
+	gcc $(CFLAGS) $(INCLUDES) $< -o $@ -lpthread
+
+clean:
+	rm -f $(CORE_TARGETS) $(OPTIONAL_TARGETS)

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,19 +1,35 @@
-CUDA_HOME ?= /home/muon/cuda-headers
-CFLAGS = -O1 -Wall -Wextra
+CUDA_HOME ?= /usr/local/cuda
+CFLAGS = -std=gnu11 -O1 -Wall -Wextra
 INCLUDES = -I$(CUDA_HOME)/include -I../build/config -I../src
 LIBS = -L$(CUDA_HOME)/lib64 -lcuda -lpthread -lm
 
 CORE_TARGETS = bench_init nested_retain warm_holder abi_check
 OPTIONAL_TARGETS = phase_probe
 
+HAVE_NVML := $(shell ldconfig -p | grep -q libnvidia-ml && echo 1)
+
 TARGETS = $(CORE_TARGETS)
-ifeq ($(shell ldconfig -p | grep -q libnvidia-ml && echo 1),1)
+ifeq ($(HAVE_NVML),1)
 TARGETS += $(OPTIONAL_TARGETS)
 endif
 
-.PHONY: all clean
+.PHONY: all clean check-cuda-home print-targets
 
-all: $(TARGETS)
+all: check-cuda-home $(TARGETS)
+
+# Machine-readable list of targets actually built this run, so callers like
+# run_benchmarks.sh can tell whether phase_probe was skipped (no NVML) rather
+# than just missing from a stale build.
+print-targets:
+	@echo "$(TARGETS)"
+
+check-cuda-home:
+	@test -f "$(CUDA_HOME)/include/cuda.h" || { \
+		echo "error: cuda.h not found under CUDA_HOME=$(CUDA_HOME)"; \
+		echo "       set CUDA_HOME to your CUDA toolkit/headers install, e.g.:"; \
+		echo "       make CUDA_HOME=/path/to/cuda"; \
+		exit 1; \
+	}
 
 bench_init: bench_init.c
 	gcc $(CFLAGS) $(INCLUDES) $< -o $@ $(LIBS)

--- a/bench/README.md
+++ b/bench/README.md
@@ -11,7 +11,7 @@ Measures concurrent cuInit() latency distribution across N worker processes, eac
 ./bench_init N
 ```
 
-Outputs: per-process initialization time in milliseconds, percentile distribution (p50, p90, p99, max), and aggregated cost. Requires a live GPU and CUDA libraries.
+Outputs: per-process initialization time in milliseconds, percentile distribution (p50, p95, p99, max), and aggregated cost. Requires a live GPU and CUDA libraries.
 
 ### phase_probe
 Breaks down the cost of `set_task_pid()` (host PID detection via NVML snapshot diffing) into phases:
@@ -36,11 +36,11 @@ Tests whether `cuDevicePrimaryCtxRetain` cost is proportional to refcount depth 
 Keeps a GPU context alive in a background process. Used by other tools to test whether context probe cost changes when a context is already held vs. cold.
 
 ```bash
-./warm_holder [primary|non-primary]
+./warm_holder [primary|nonprimary]
 ```
 
 ### abi_check
-Verifies that `struct shared_region_t` layout (sizeof, offsetof for key fields) is byte-identical to the C side. Used to validate that Go-side mirror struct changes don't break the wire format.
+Compares `struct shared_region_t`'s sizeof and offsetof for key fields against the values captured from the Go-side mirror struct (`pkg/monitor/nvidia/v1/spec.go` in the HAMi repo), and exits nonzero on any mismatch. Used to catch C/Go struct drift that would silently corrupt `/tmp/cudevshr.cache`.
 
 ```bash
 ./abi_check
@@ -55,7 +55,7 @@ make
 
 Requires:
 - CUDA headers and libraries (e.g., via `CUDA_HOME`)
-- C99 compiler
+- A C11/GNU11 compiler (`bench_init.c` uses `<stdatomic.h>`; the Makefile builds with `-std=gnu11`)
 - `libvgpu.so` built in the parent directory
 
 ## Reproducing Issue #1662 Findings
@@ -69,9 +69,11 @@ cd bench
 
 This executes:
 1. `phase_probe` — identify bottlenecks
-2. `warm_holder primary &` — start context holder
-3. `bench_init 2 4 8 16 32 64 128` — measure across concurrency levels
-4. Kill warm_holder
+2. `nested_retain` — check whether holding a context is amortizable
+3. `warm_holder primary &` — start context holder
+4. `bench_init 1 2 4 8 16 32 64 128` — measure across concurrency levels
+5. Kill warm_holder
+6. `abi_check` — verify shared_region_t layout compatibility
 
 Expected results:
 - ~61.5 ms per-process serialized time (N=1)

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,84 @@
+# HAMi-core Initialization Benchmark Suite
+
+Concurrent CUDA initialization performance benchmarks for HAMi-core's device sharing layer. These tools measure the cost of multiprocess cuInit() and primary context operations under various conditions, supporting the analysis in issue #1662.
+
+## Tools
+
+### bench_init
+Measures concurrent cuInit() latency distribution across N worker processes, each spawned via fork+exec through `libvgpu.so` via `LD_PRELOAD`.
+
+```bash
+./bench_init N
+```
+
+Outputs: per-process initialization time in milliseconds, percentile distribution (p50, p90, p99, max), and aggregated cost. Requires a live GPU and CUDA libraries.
+
+### phase_probe
+Breaks down the cost of `set_task_pid()` (host PID detection via NVML snapshot diffing) into phases:
+- nvmlInit
+- Device snapshot enumeration
+- Primary context retain/release cycles
+
+Useful for identifying which phase dominates the initialization overhead.
+
+```bash
+./phase_probe
+```
+
+### nested_retain
+Tests whether `cuDevicePrimaryCtxRetain` cost is proportional to refcount depth or constant once a context exists. Answers: is it cheap to hold a context across set_task_pid() calls?
+
+```bash
+./nested_retain
+```
+
+### warm_holder
+Keeps a GPU context alive in a background process. Used by other tools to test whether context probe cost changes when a context is already held vs. cold.
+
+```bash
+./warm_holder [primary|non-primary]
+```
+
+### abi_check
+Verifies that `struct shared_region_t` layout (sizeof, offsetof for key fields) is byte-identical to the C side. Used to validate that Go-side mirror struct changes don't break the wire format.
+
+```bash
+./abi_check
+```
+
+## Building
+
+```bash
+cd bench
+make
+```
+
+Requires:
+- CUDA headers and libraries (e.g., via `CUDA_HOME`)
+- C99 compiler
+- `libvgpu.so` built in the parent directory
+
+## Reproducing Issue #1662 Findings
+
+Run the full benchmark suite:
+
+```bash
+cd bench
+./run_benchmarks.sh
+```
+
+This executes:
+1. `phase_probe` — identify bottlenecks
+2. `warm_holder primary &` — start context holder
+3. `bench_init 2 4 8 16 32 64 128` — measure across concurrency levels
+4. Kill warm_holder
+
+Expected results:
+- ~61.5 ms per-process serialized time (N=1)
+- Linear scaling to ~128 processes (each adds ~61.5 ms)
+- Phase breakdown: ~80% in cuDevicePrimaryCtx{Retain,Release}, ~20% in NVML
+- Nested retain cost: ~1 µs (amortizable)
+
+## Context
+
+These benchmarks were developed to quantify the initialization lock contention identified in #1662. The fix (moving from polling to semaphore-based synchronization) is already merged, but these tools remain useful for regression testing and understanding concurrent device-sharing behavior.

--- a/bench/abi_check.c
+++ b/bench/abi_check.c
@@ -16,16 +16,39 @@ limitations under the License.
 
 /* Verifies _Atomic uint64_t did not change shared_region_t's layout or size,
  * which matters since this struct is persisted to /tmp/cudevshr.cache and
- * read from a separate Go process via a hand-written mirror struct. */
+ * read from a separate Go process via a hand-written mirror struct
+ * (pkg/monitor/nvidia/v1/spec.go:sharedRegionT in the HAMi repo).
+ *
+ * The expected values below were captured by compiling that Go struct with
+ * unsafe.Sizeof/unsafe.Offsetof on linux/amd64. If this check fails, either
+ * the C struct changed and the Go mirror needs updating, or vice versa. */
 #include <stdio.h>
 #include <stddef.h>
 #include "../src/multiprocess/multiprocess_memory_limit.h"
 
+#define EXPECT_SIZEOF_SHARED_REGION 2008952
+#define EXPECT_OFFSETOF_LIMIT       1600
+#define EXPECT_OFFSETOF_SM_LIMIT    1728
+#define EXPECT_OFFSETOF_PROCS       1856
+#define EXPECT_SIZEOF_LIMIT_ELEM    8
+
+static int check(const char *name, size_t got, size_t want) {
+    int ok = (got == want);
+    printf("%-24s = %-10zu (expected %zu) %s\n", name, got, want, ok ? "OK" : "MISMATCH");
+    return ok;
+}
+
 int main(void) {
-    printf("sizeof(shared_region_t) = %zu\n", sizeof(shared_region_t));
-    printf("offsetof(limit)         = %zu\n", offsetof(shared_region_t, limit));
-    printf("offsetof(sm_limit)      = %zu\n", offsetof(shared_region_t, sm_limit));
-    printf("offsetof(procs)         = %zu\n", offsetof(shared_region_t, procs));
-    printf("sizeof(limit[0])        = %zu\n", sizeof(((shared_region_t*)0)->limit[0]));
+    int ok = 1;
+    ok &= check("sizeof(shared_region_t)", sizeof(shared_region_t), EXPECT_SIZEOF_SHARED_REGION);
+    ok &= check("offsetof(limit)", offsetof(shared_region_t, limit), EXPECT_OFFSETOF_LIMIT);
+    ok &= check("offsetof(sm_limit)", offsetof(shared_region_t, sm_limit), EXPECT_OFFSETOF_SM_LIMIT);
+    ok &= check("offsetof(procs)", offsetof(shared_region_t, procs), EXPECT_OFFSETOF_PROCS);
+    ok &= check("sizeof(limit[0])", sizeof(((shared_region_t*)0)->limit[0]), EXPECT_SIZEOF_LIMIT_ELEM);
+
+    if (!ok) {
+        fprintf(stderr, "abi_check: shared_region_t layout diverged from the Go mirror struct\n");
+        return 1;
+    }
     return 0;
 }

--- a/bench/abi_check.c
+++ b/bench/abi_check.c
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Verifies _Atomic uint64_t did not change shared_region_t's layout or size,
+ * which matters since this struct is persisted to /tmp/cudevshr.cache and
+ * read from a separate Go process via a hand-written mirror struct. */
+#include <stdio.h>
+#include <stddef.h>
+#include "../src/multiprocess/multiprocess_memory_limit.h"
+
+int main(void) {
+    printf("sizeof(shared_region_t) = %zu\n", sizeof(shared_region_t));
+    printf("offsetof(limit)         = %zu\n", offsetof(shared_region_t, limit));
+    printf("offsetof(sm_limit)      = %zu\n", offsetof(shared_region_t, sm_limit));
+    printf("offsetof(procs)         = %zu\n", offsetof(shared_region_t, procs));
+    printf("sizeof(limit[0])        = %zu\n", sizeof(((shared_region_t*)0)->limit[0]));
+    return 0;
+}

--- a/bench/bench_init.c
+++ b/bench/bench_init.c
@@ -47,6 +47,8 @@ limitations under the License.
 #include <sys/wait.h>
 #include <stdatomic.h>
 #include <limits.h>
+#include <math.h>
+#include <signal.h>
 #include <cuda.h>
 
 #define MAX_WORKERS 512
@@ -100,7 +102,8 @@ static int cmp_double(const void *a, const void *b) {
  * honest than interpolating between samples we did not observe. */
 static double pct(double *sorted, int n, double p) {
     if (n <= 0) return 0.0;
-    int idx = (int)(p / 100.0 * n);
+    int idx = (int)ceil(p / 100.0 * n) - 1;
+    if (idx < 0) idx = 0;
     if (idx >= n) idx = n - 1;
     return sorted[idx];
 }
@@ -152,6 +155,12 @@ int main(int argc, char **argv) {
     }
     memset(sh, 0, sizeof(*sh));
     atomic_store(&sh->ready, 0);
+    /* rc defaults to CUDA_SUCCESS (0) after memset, which would make a worker
+     * that dies before writing its result look like a 0ms success. Mark every
+     * slot as failed up front; a worker overwrites this only once it finishes. */
+    for (int i = 0; i < n; i++) {
+        sh->slots[i].rc = -1;
+    }
 
     int pipefd[2];
     if (pipe(pipefd) != 0) {
@@ -195,15 +204,47 @@ int main(int argc, char **argv) {
     }
     close(pipefd[0]);
 
-    /* Wait for every worker to reach the barrier before releasing any. */
-    while (atomic_load(&sh->ready) < n)
+    /* Wait for every worker to reach the barrier before releasing any, but
+     * don't spin forever if a worker dies before it gets there (exec/loader
+     * failure, killed, etc.). Reap early exits as they happen so a dead
+     * worker can't stall the barrier, and give up after a generous timeout. */
+    int reaped[MAX_WORKERS];
+    memset(reaped, 0, sizeof(reaped));
+    int early_exits = 0;
+    double ready_deadline = now_ms() + 30000.0; /* 30s */
+
+    for (;;) {
+        int ready_n = atomic_load(&sh->ready);
+        if (ready_n + early_exits >= n) break;
+        if (now_ms() > ready_deadline) {
+            fprintf(stderr,
+                    "bench_init: timed out waiting for workers to reach barrier "
+                    "(%d/%d ready); aborting\n", ready_n, n);
+            for (int i = 0; i < n; i++) {
+                if (!reaped[i]) kill(pids[i], SIGKILL);
+            }
+            for (int i = 0; i < n; i++) {
+                if (!reaped[i]) waitpid(pids[i], NULL, 0);
+            }
+            return 1;
+        }
+        for (int i = 0; i < n; i++) {
+            if (reaped[i]) continue;
+            int st = 0;
+            if (waitpid(pids[i], &st, WNOHANG) == pids[i]) {
+                reaped[i] = 1;
+                early_exits++;
+            }
+        }
         usleep(200);
+    }
 
     double t_release = now_ms();
     close(pipefd[1]);                 /* broadcast: all workers wake here */
 
-    int failed = 0;
+    int failed = early_exits;
     for (int i = 0; i < n; i++) {
+        if (reaped[i]) continue;
         int st = 0;
         waitpid(pids[i], &st, 0);
         if (!WIFEXITED(st) || WEXITSTATUS(st) != 0) failed++;

--- a/bench/bench_init.c
+++ b/bench/bench_init.c
@@ -1,0 +1,210 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * bench_init - concurrent CUDA initialization benchmark for HAMi-core.
+ *
+ * Measures per-process cuInit() latency when N processes initialize at the
+ * same instant, which is the scenario described in Project-HAMi/HAMi#1662.
+ *
+ * Design notes:
+ *   - Workers are fork+exec'd, not just forked, so each is a genuinely fresh
+ *     process image the way a real pod's child processes are. libvgpu.so is
+ *     interposed via LD_PRELOAD and so is inherited across the exec.
+ *   - The parent never touches CUDA. Any CUDA state in the parent would be
+ *     inherited and would invalidate the host-PID detection being measured.
+ *   - Release is broadcast by closing the write end of a pipe. Every worker
+ *     is blocked in read(2), so they wake together without spinning, which
+ *     keeps the CPU idle during the barrier and avoids polluting the numbers.
+ *
+ * Usage:
+ *   bench_init <n>            run n concurrent workers, print JSON to stdout
+ *   bench_init --worker <slot> <readfd>   internal, not for direct use
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <stdatomic.h>
+#include <limits.h>
+#include <cuda.h>
+
+#define MAX_WORKERS 512
+
+/* One slot per worker, in shared memory so the parent can read results back. */
+typedef struct {
+    double   cuinit_ms;    /* time spent inside cuInit() */
+    double   start_off_ms; /* when this worker entered cuInit, relative to release */
+    int      rc;           /* CUresult, 0 == CUDA_SUCCESS */
+    int      pid;
+} slot_t;
+
+typedef struct {
+    atomic_int ready;      /* workers that have reached the barrier */
+    slot_t     slots[MAX_WORKERS];
+} shared_t;
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1e3 + ts.tv_nsec / 1e6;
+}
+
+/* Monotonic clock is shared across processes, so release time is comparable. */
+static int run_worker(shared_t *sh, int slot, int readfd) {
+    char buf[1];
+
+    atomic_fetch_add(&sh->ready, 1);
+
+    /* Blocks until the parent closes the write end. Returns 0 on EOF. */
+    while (read(readfd, buf, 1) < 0 && errno == EINTR)
+        ;
+
+    double t0 = now_ms();
+    CUresult r = cuInit(0);
+    double t1 = now_ms();
+
+    sh->slots[slot].cuinit_ms    = t1 - t0;
+    sh->slots[slot].start_off_ms = t0;
+    sh->slots[slot].rc           = (int)r;
+    sh->slots[slot].pid          = getpid();
+    return r == CUDA_SUCCESS ? 0 : 1;
+}
+
+static int cmp_double(const void *a, const void *b) {
+    double x = *(const double *)a, y = *(const double *)b;
+    return (x > y) - (x < y);
+}
+
+/* Nearest-rank percentile. With the small N values used here this is more
+ * honest than interpolating between samples we did not observe. */
+static double pct(double *sorted, int n, double p) {
+    if (n <= 0) return 0.0;
+    int idx = (int)(p / 100.0 * n);
+    if (idx >= n) idx = n - 1;
+    return sorted[idx];
+}
+
+int main(int argc, char **argv) {
+    if (argc >= 2 && strcmp(argv[1], "--worker") == 0) {
+        if (argc != 4) { fprintf(stderr, "bad --worker invocation\n"); return 2; }
+        int slot   = atoi(argv[2]);
+        int readfd = atoi(argv[3]);
+        int shmfd  = atoi(getenv("BENCH_SHM_FD"));
+        shared_t *sh = mmap(NULL, sizeof(shared_t), PROT_READ | PROT_WRITE,
+                            MAP_SHARED, shmfd, 0);
+        if (sh == MAP_FAILED) { perror("mmap(worker)"); return 2; }
+        return run_worker(sh, slot, readfd);
+    }
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <n_workers>\n", argv[0]);
+        return 2;
+    }
+    int n = atoi(argv[1]);
+    if (n < 1 || n > MAX_WORKERS) {
+        fprintf(stderr, "n must be 1..%d\n", MAX_WORKERS);
+        return 2;
+    }
+
+    /* Anonymous shared file, inherited by the workers across exec. */
+    int shmfd = memfd_create("bench_shm", 0);
+    if (shmfd < 0) { perror("memfd_create"); return 1; }
+    if (ftruncate(shmfd, sizeof(shared_t)) != 0) { perror("ftruncate"); return 1; }
+
+    shared_t *sh = mmap(NULL, sizeof(shared_t), PROT_READ | PROT_WRITE,
+                        MAP_SHARED, shmfd, 0);
+    if (sh == MAP_FAILED) { perror("mmap"); return 1; }
+    memset(sh, 0, sizeof(*sh));
+    atomic_store(&sh->ready, 0);
+
+    int pipefd[2];
+    if (pipe(pipefd) != 0) { perror("pipe"); return 1; }
+
+    /* Both fds must survive exec, so clear FD_CLOEXEC. */
+    fcntl(pipefd[0], F_SETFD, 0);
+    fcntl(shmfd,     F_SETFD, 0);
+
+    char shmfd_s[16];
+    snprintf(shmfd_s, sizeof shmfd_s, "%d", shmfd);
+    setenv("BENCH_SHM_FD", shmfd_s, 1);
+
+    char self[PATH_MAX];
+    ssize_t sl = readlink("/proc/self/exe", self, sizeof(self) - 1);
+    if (sl < 0) { perror("readlink"); return 1; }
+    self[sl] = '\0';
+
+    pid_t pids[MAX_WORKERS];
+    for (int i = 0; i < n; i++) {
+        pid_t p = fork();
+        if (p < 0) { perror("fork"); return 1; }
+        if (p == 0) {
+            close(pipefd[1]);
+            char slot_s[16], rfd_s[16];
+            snprintf(slot_s, sizeof slot_s, "%d", i);
+            snprintf(rfd_s,  sizeof rfd_s,  "%d", pipefd[0]);
+            execl(self, self, "--worker", slot_s, rfd_s, (char *)NULL);
+            perror("execl");
+            _exit(127);
+        }
+        pids[i] = p;
+    }
+    close(pipefd[0]);
+
+    /* Wait for every worker to reach the barrier before releasing any. */
+    while (atomic_load(&sh->ready) < n)
+        usleep(200);
+
+    double t_release = now_ms();
+    close(pipefd[1]);                 /* broadcast: all workers wake here */
+
+    int failed = 0;
+    for (int i = 0; i < n; i++) {
+        int st = 0;
+        waitpid(pids[i], &st, 0);
+        if (!WIFEXITED(st) || WEXITSTATUS(st) != 0) failed++;
+    }
+    double wall_ms = now_ms() - t_release;
+
+    double lat[MAX_WORKERS];
+    int ok = 0;
+    double sum = 0.0, max_end = 0.0;
+    for (int i = 0; i < n; i++) {
+        if (sh->slots[i].rc != 0) continue;
+        lat[ok++] = sh->slots[i].cuinit_ms;
+        sum += sh->slots[i].cuinit_ms;
+        double end = (sh->slots[i].start_off_ms - t_release) + sh->slots[i].cuinit_ms;
+        if (end > max_end) max_end = end;
+    }
+    qsort(lat, ok, sizeof(double), cmp_double);
+
+    printf("{\"n\":%d,\"ok\":%d,\"failed\":%d,"
+           "\"wall_ms\":%.2f,\"span_ms\":%.2f,\"mean_ms\":%.2f,"
+           "\"p50_ms\":%.2f,\"p95_ms\":%.2f,\"p99_ms\":%.2f,"
+           "\"min_ms\":%.2f,\"max_ms\":%.2f}\n",
+           n, ok, failed, wall_ms, max_end,
+           ok ? sum / ok : 0.0,
+           pct(lat, ok, 50), pct(lat, ok, 95), pct(lat, ok, 99),
+           ok ? lat[0] : 0.0, ok ? lat[ok - 1] : 0.0);
+    return failed ? 1 : 0;
+}

--- a/bench/bench_init.c
+++ b/bench/bench_init.c
@@ -77,8 +77,8 @@ static int run_worker(shared_t *sh, int slot, int readfd) {
     atomic_fetch_add(&sh->ready, 1);
 
     /* Blocks until the parent closes the write end. Returns 0 on EOF. */
-    while (read(readfd, buf, 1) < 0 && errno == EINTR)
-        ;
+    while (read(readfd, buf, 1) < 0 && errno == EINTR) {
+    }
 
     double t0 = now_ms();
     CUresult r = cuInit(0);
@@ -107,13 +107,19 @@ static double pct(double *sorted, int n, double p) {
 
 int main(int argc, char **argv) {
     if (argc >= 2 && strcmp(argv[1], "--worker") == 0) {
-        if (argc != 4) { fprintf(stderr, "bad --worker invocation\n"); return 2; }
+        if (argc != 4) {
+            fprintf(stderr, "bad --worker invocation\n");
+            return 2;
+        }
         int slot   = atoi(argv[2]);
         int readfd = atoi(argv[3]);
         int shmfd  = atoi(getenv("BENCH_SHM_FD"));
         shared_t *sh = mmap(NULL, sizeof(shared_t), PROT_READ | PROT_WRITE,
                             MAP_SHARED, shmfd, 0);
-        if (sh == MAP_FAILED) { perror("mmap(worker)"); return 2; }
+        if (sh == MAP_FAILED) {
+            perror("mmap(worker)");
+            return 2;
+        }
         return run_worker(sh, slot, readfd);
     }
 
@@ -129,17 +135,29 @@ int main(int argc, char **argv) {
 
     /* Anonymous shared file, inherited by the workers across exec. */
     int shmfd = memfd_create("bench_shm", 0);
-    if (shmfd < 0) { perror("memfd_create"); return 1; }
-    if (ftruncate(shmfd, sizeof(shared_t)) != 0) { perror("ftruncate"); return 1; }
+    if (shmfd < 0) {
+        perror("memfd_create");
+        return 1;
+    }
+    if (ftruncate(shmfd, sizeof(shared_t)) != 0) {
+        perror("ftruncate");
+        return 1;
+    }
 
     shared_t *sh = mmap(NULL, sizeof(shared_t), PROT_READ | PROT_WRITE,
                         MAP_SHARED, shmfd, 0);
-    if (sh == MAP_FAILED) { perror("mmap"); return 1; }
+    if (sh == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
     memset(sh, 0, sizeof(*sh));
     atomic_store(&sh->ready, 0);
 
     int pipefd[2];
-    if (pipe(pipefd) != 0) { perror("pipe"); return 1; }
+    if (pipe(pipefd) != 0) {
+        perror("pipe");
+        return 1;
+    }
 
     /* Both fds must survive exec, so clear FD_CLOEXEC. */
     fcntl(pipefd[0], F_SETFD, 0);
@@ -151,13 +169,19 @@ int main(int argc, char **argv) {
 
     char self[PATH_MAX];
     ssize_t sl = readlink("/proc/self/exe", self, sizeof(self) - 1);
-    if (sl < 0) { perror("readlink"); return 1; }
+    if (sl < 0) {
+        perror("readlink");
+        return 1;
+    }
     self[sl] = '\0';
 
     pid_t pids[MAX_WORKERS];
     for (int i = 0; i < n; i++) {
         pid_t p = fork();
-        if (p < 0) { perror("fork"); return 1; }
+        if (p < 0) {
+            perror("fork");
+            return 1;
+        }
         if (p == 0) {
             close(pipefd[1]);
             char slot_s[16], rfd_s[16];

--- a/bench/ctx_experiment.c
+++ b/bench/ctx_experiment.c
@@ -52,7 +52,10 @@ int main(int argc, char **argv) {
     double a, b;
     double ret[3], rel[3];
 
-    if (cuInit(0) != CUDA_SUCCESS) { fprintf(stderr, "cuInit failed\n"); return 1; }
+    if (cuInit(0) != CUDA_SUCCESS) {
+        fprintf(stderr, "cuInit failed\n");
+        return 1;
+    }
 
     /* Warmup: wakes the GPU if it was runtime-suspended, so the numbers below
      * reflect steady state rather than a one-off power transition. */

--- a/bench/ctx_experiment.c
+++ b/bench/ctx_experiment.c
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * ctx_experiment - is cuDevicePrimaryCtxRetain's cost inherent, or contention?
+ *
+ * Answers two questions raised on Project-HAMi/HAMi#1662:
+ *
+ *   1. Does another process holding the primary context open make this
+ *      process's cuDevicePrimaryCtxRetain slower? Run this under the three
+ *      holder conditions (none / primary-context holder / non-primary-context
+ *      holder) and compare.
+ *
+ *   2. Can the probe cost be amortized? Primary contexts are refcounted per
+ *      process, so a retain after a prior retain in the same process should
+ *      be near-free. If so, the expensive part is first-context creation and
+ *      the Release in set_task_pid() throws that work away, since the
+ *      application will create its own context moments later.
+ *
+ * A warmup retain/release pair runs first to take GPU wake latency out of the
+ * measurement, then three retain/release cycles are timed.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <cuda.h>
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1e3 + ts.tv_nsec / 1e6;
+}
+
+int main(int argc, char **argv) {
+    const char *label = argc > 1 ? argv[1] : "unlabelled";
+    CUcontext ctx;
+    double a, b;
+    double ret[3], rel[3];
+
+    if (cuInit(0) != CUDA_SUCCESS) { fprintf(stderr, "cuInit failed\n"); return 1; }
+
+    /* Warmup: wakes the GPU if it was runtime-suspended, so the numbers below
+     * reflect steady state rather than a one-off power transition. */
+    a = now_ms();
+    cuDevicePrimaryCtxRetain(&ctx, 0);
+    cuDevicePrimaryCtxRelease(0);
+    double warmup_ms = now_ms() - a;
+
+    for (int i = 0; i < 3; i++) {
+        a = now_ms();
+        cuDevicePrimaryCtxRetain(&ctx, 0);
+        b = now_ms();
+        cuDevicePrimaryCtxRelease(0);
+        ret[i] = b - a;
+        rel[i] = now_ms() - b;
+    }
+
+    printf("{\"cond\":\"%s\",\"warmup_pair_ms\":%.2f,"
+           "\"retain1_ms\":%.2f,\"retain2_ms\":%.2f,\"retain3_ms\":%.2f,"
+           "\"release1_ms\":%.2f,\"release2_ms\":%.2f,\"release3_ms\":%.2f}\n",
+           label, warmup_ms,
+           ret[0], ret[1], ret[2], rel[0], rel[1], rel[2]);
+    return 0;
+}

--- a/bench/ctx_experiment.c
+++ b/bench/ctx_experiment.c
@@ -59,16 +59,29 @@ int main(int argc, char **argv) {
 
     /* Warmup: wakes the GPU if it was runtime-suspended, so the numbers below
      * reflect steady state rather than a one-off power transition. */
+    CUresult r;
     a = now_ms();
-    cuDevicePrimaryCtxRetain(&ctx, 0);
-    cuDevicePrimaryCtxRelease(0);
+    if ((r = cuDevicePrimaryCtxRetain(&ctx, 0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "warmup retain failed: %d\n", r);
+        return 1;
+    }
+    if ((r = cuDevicePrimaryCtxRelease(0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "warmup release failed: %d\n", r);
+        return 1;
+    }
     double warmup_ms = now_ms() - a;
 
     for (int i = 0; i < 3; i++) {
         a = now_ms();
-        cuDevicePrimaryCtxRetain(&ctx, 0);
+        if ((r = cuDevicePrimaryCtxRetain(&ctx, 0)) != CUDA_SUCCESS) {
+            fprintf(stderr, "retain %d failed: %d\n", i + 1, r);
+            return 1;
+        }
         b = now_ms();
-        cuDevicePrimaryCtxRelease(0);
+        if ((r = cuDevicePrimaryCtxRelease(0)) != CUDA_SUCCESS) {
+            fprintf(stderr, "release %d failed: %d\n", i + 1, r);
+            return 1;
+        }
         ret[i] = b - a;
         rel[i] = now_ms() - b;
     }

--- a/bench/nested_retain.c
+++ b/bench/nested_retain.c
@@ -42,7 +42,10 @@ int main(void) {
     double a;
     double first, nested, after_release;
 
-    if (cuInit(0) != CUDA_SUCCESS) { fprintf(stderr, "cuInit failed\n"); return 1; }
+    if (cuInit(0) != CUDA_SUCCESS) {
+        fprintf(stderr, "cuInit failed\n");
+        return 1;
+    }
 
     /* Warmup so GPU wake latency is not attributed to the first retain. */
     cuDevicePrimaryCtxRetain(&c1, 0);

--- a/bench/nested_retain.c
+++ b/bench/nested_retain.c
@@ -41,6 +41,7 @@ int main(void) {
     CUcontext c1, c2, c3;
     double a;
     double first, nested, after_release;
+    CUresult r;
 
     if (cuInit(0) != CUDA_SUCCESS) {
         fprintf(stderr, "cuInit failed\n");
@@ -48,29 +49,53 @@ int main(void) {
     }
 
     /* Warmup so GPU wake latency is not attributed to the first retain. */
-    cuDevicePrimaryCtxRetain(&c1, 0);
-    cuDevicePrimaryCtxRelease(0);
+    if ((r = cuDevicePrimaryCtxRetain(&c1, 0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "warmup retain failed: %d\n", r);
+        return 1;
+    }
+    if ((r = cuDevicePrimaryCtxRelease(0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "warmup release failed: %d\n", r);
+        return 1;
+    }
 
     /* Cold retain: nothing held by this process. */
     a = now_ms();
-    cuDevicePrimaryCtxRetain(&c1, 0);
+    if ((r = cuDevicePrimaryCtxRetain(&c1, 0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "cold retain failed: %d\n", r);
+        return 1;
+    }
     first = now_ms() - a;
 
     /* Nested retain: context still held, so this should be refcount only. */
     a = now_ms();
-    cuDevicePrimaryCtxRetain(&c2, 0);
+    if ((r = cuDevicePrimaryCtxRetain(&c2, 0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "nested retain failed: %d\n", r);
+        return 1;
+    }
     nested = now_ms() - a;
 
-    cuDevicePrimaryCtxRelease(0);   /* drop to refcount 1, context stays alive */
+    if ((r = cuDevicePrimaryCtxRelease(0)) != CUDA_SUCCESS) {   /* drop to refcount 1, context stays alive */
+        fprintf(stderr, "release failed: %d\n", r);
+        return 1;
+    }
 
     /* Retain again while still held. Models the application acquiring a
      * context after the probe finished but did not fully release. */
     a = now_ms();
-    cuDevicePrimaryCtxRetain(&c3, 0);
+    if ((r = cuDevicePrimaryCtxRetain(&c3, 0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "retain-while-held failed: %d\n", r);
+        return 1;
+    }
     after_release = now_ms() - a;
 
-    cuDevicePrimaryCtxRelease(0);
-    cuDevicePrimaryCtxRelease(0);
+    if ((r = cuDevicePrimaryCtxRelease(0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "final release (1/2) failed: %d\n", r);
+        return 1;
+    }
+    if ((r = cuDevicePrimaryCtxRelease(0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "final release (2/2) failed: %d\n", r);
+        return 1;
+    }
 
     printf("{\"cold_retain_ms\":%.3f,\"nested_retain_ms\":%.3f,"
            "\"retain_while_held_ms\":%.3f,\"same_ctx\":%s}\n",

--- a/bench/nested_retain.c
+++ b/bench/nested_retain.c
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * nested_retain - is the primary context refcount cheap to bump once held?
+ *
+ * set_task_pid() does retain -> probe -> release. The application then creates
+ * its own context moments later and pays full construction cost again.
+ *
+ * If a nested retain (one taken while the context is still held) is near-free,
+ * then the Release is discarding work the process is about to redo, and the
+ * probe could hand its context off to the application instead of tearing it
+ * down. This measures that.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <time.h>
+#include <cuda.h>
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1e3 + ts.tv_nsec / 1e6;
+}
+
+int main(void) {
+    CUcontext c1, c2, c3;
+    double a;
+    double first, nested, after_release;
+
+    if (cuInit(0) != CUDA_SUCCESS) { fprintf(stderr, "cuInit failed\n"); return 1; }
+
+    /* Warmup so GPU wake latency is not attributed to the first retain. */
+    cuDevicePrimaryCtxRetain(&c1, 0);
+    cuDevicePrimaryCtxRelease(0);
+
+    /* Cold retain: nothing held by this process. */
+    a = now_ms();
+    cuDevicePrimaryCtxRetain(&c1, 0);
+    first = now_ms() - a;
+
+    /* Nested retain: context still held, so this should be refcount only. */
+    a = now_ms();
+    cuDevicePrimaryCtxRetain(&c2, 0);
+    nested = now_ms() - a;
+
+    cuDevicePrimaryCtxRelease(0);   /* drop to refcount 1, context stays alive */
+
+    /* Retain again while still held. Models the application acquiring a
+     * context after the probe finished but did not fully release. */
+    a = now_ms();
+    cuDevicePrimaryCtxRetain(&c3, 0);
+    after_release = now_ms() - a;
+
+    cuDevicePrimaryCtxRelease(0);
+    cuDevicePrimaryCtxRelease(0);
+
+    printf("{\"cold_retain_ms\":%.3f,\"nested_retain_ms\":%.3f,"
+           "\"retain_while_held_ms\":%.3f,\"same_ctx\":%s}\n",
+           first, nested, after_release,
+           (c1 == c2 && c2 == c3) ? "true" : "false");
+    return 0;
+}

--- a/bench/phase_probe.c
+++ b/bench/phase_probe.c
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * phase_probe - times each step of HAMi-core's host-PID detection.
+ *
+ * Replicates the sequence in src/utils.c:set_task_pid(), which is the work
+ * held under the postinit lock, and reports the cost of each phase. This runs
+ * standalone (no libvgpu.so interposed) so it measures the underlying driver
+ * and NVML calls directly rather than the hooked versions.
+ *
+ * The point is to answer: of the serialized time per process, how much is
+ * NVML enumeration versus CUDA context creation?
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <cuda.h>
+#include <nvml.h>
+
+#define MAX_PROC 1024
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1e3 + ts.tv_nsec / 1e6;
+}
+
+int main(void) {
+    nvmlProcessInfo_t procs[MAX_PROC];
+    nvmlDevice_t dev;
+    unsigned int count;
+    CUcontext ctx;
+    double t[8];
+    int i = 0;
+
+    /* cuInit first: set_task_pid runs inside postInit, after the real
+     * cuInit has already returned, so the driver is warm at this point. */
+    t[i++] = now_ms();
+    if (cuInit(0) != CUDA_SUCCESS) { fprintf(stderr, "cuInit failed\n"); return 1; }
+
+    t[i++] = now_ms();
+    if (nvmlInit() != NVML_SUCCESS) { fprintf(stderr, "nvmlInit failed\n"); return 1; }
+
+    t[i++] = now_ms();
+    nvmlDeviceGetHandleByIndex(0, &dev);
+
+    t[i++] = now_ms();
+    count = MAX_PROC;
+    nvmlDeviceGetComputeRunningProcesses(dev, &count, procs);   /* snapshot A */
+
+    t[i++] = now_ms();
+    cuDevicePrimaryCtxRetain(&ctx, 0);                          /* the probe */
+
+    t[i++] = now_ms();
+    count = MAX_PROC;
+    nvmlDeviceGetComputeRunningProcesses(dev, &count, procs);   /* snapshot B */
+
+    t[i++] = now_ms();
+    cuDevicePrimaryCtxRelease(0);
+
+    t[i++] = now_ms();
+
+    printf("{\"cuInit_ms\":%.2f,"
+           "\"nvmlInit_ms\":%.2f,"
+           "\"nvmlGetHandle_ms\":%.2f,"
+           "\"snapshotA_ms\":%.2f,"
+           "\"ctxRetain_ms\":%.2f,"
+           "\"snapshotB_ms\":%.2f,"
+           "\"ctxRelease_ms\":%.2f,"
+           "\"critical_section_ms\":%.2f,"
+           "\"procs_seen\":%u}\n",
+           t[1] - t[0], t[2] - t[1], t[3] - t[2], t[4] - t[3],
+           t[5] - t[4], t[6] - t[5], t[7] - t[6],
+           t[7] - t[1],   /* everything after cuInit == the locked region */
+           count);
+    return 0;
+}

--- a/bench/phase_probe.c
+++ b/bench/phase_probe.c
@@ -41,6 +41,20 @@ static double now_ms(void) {
     return ts.tv_sec * 1e3 + ts.tv_nsec / 1e6;
 }
 
+/* nvmlDeviceGetComputeRunningProcesses reports NVML_ERROR_INSUFFICIENT_SIZE
+ * (and sets *count to the required size) when the buffer is too small.
+ * Reissue with a right-sized buffer instead of silently truncating results. */
+static nvmlReturn_t get_compute_procs(nvmlDevice_t dev, unsigned int *count,
+                                       nvmlProcessInfo_t *procs, unsigned int cap) {
+    *count = cap;
+    nvmlReturn_t r = nvmlDeviceGetComputeRunningProcesses(dev, count, procs);
+    if (r == NVML_ERROR_INSUFFICIENT_SIZE && *count <= cap) {
+        /* Driver reported a required size within our static buffer; retry once. */
+        r = nvmlDeviceGetComputeRunningProcesses(dev, count, procs);
+    }
+    return r;
+}
+
 int main(void) {
     nvmlProcessInfo_t procs[MAX_PROC];
     nvmlDevice_t dev;
@@ -48,6 +62,8 @@ int main(void) {
     CUcontext ctx;
     double t[8];
     int i = 0;
+    CUresult cr;
+    nvmlReturn_t nr;
 
     /* cuInit first: set_task_pid runs inside postInit, after the real
      * cuInit has already returned, so the driver is warm at this point. */
@@ -64,21 +80,35 @@ int main(void) {
     }
 
     t[i++] = now_ms();
-    nvmlDeviceGetHandleByIndex(0, &dev);
+    if ((nr = nvmlDeviceGetHandleByIndex(0, &dev)) != NVML_SUCCESS) {
+        fprintf(stderr, "nvmlDeviceGetHandleByIndex failed: %d\n", nr);
+        return 1;
+    }
 
     t[i++] = now_ms();
-    count = MAX_PROC;
-    nvmlDeviceGetComputeRunningProcesses(dev, &count, procs);   /* snapshot A */
+    if ((nr = get_compute_procs(dev, &count, procs, MAX_PROC)) != NVML_SUCCESS) {
+        fprintf(stderr, "nvmlDeviceGetComputeRunningProcesses (snapshot A) failed: %d\n", nr);
+        return 1;
+    }
 
     t[i++] = now_ms();
-    cuDevicePrimaryCtxRetain(&ctx, 0);                          /* the probe */
+    if ((cr = cuDevicePrimaryCtxRetain(&ctx, 0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "cuDevicePrimaryCtxRetain failed: %d\n", cr);
+        return 1;
+    }
 
     t[i++] = now_ms();
-    count = MAX_PROC;
-    nvmlDeviceGetComputeRunningProcesses(dev, &count, procs);   /* snapshot B */
+    if ((nr = get_compute_procs(dev, &count, procs, MAX_PROC)) != NVML_SUCCESS) {
+        fprintf(stderr, "nvmlDeviceGetComputeRunningProcesses (snapshot B) failed: %d\n", nr);
+        cuDevicePrimaryCtxRelease(0);
+        return 1;
+    }
 
     t[i++] = now_ms();
-    cuDevicePrimaryCtxRelease(0);
+    if ((cr = cuDevicePrimaryCtxRelease(0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "cuDevicePrimaryCtxRelease failed: %d\n", cr);
+        return 1;
+    }
 
     t[i++] = now_ms();
 

--- a/bench/phase_probe.c
+++ b/bench/phase_probe.c
@@ -52,10 +52,16 @@ int main(void) {
     /* cuInit first: set_task_pid runs inside postInit, after the real
      * cuInit has already returned, so the driver is warm at this point. */
     t[i++] = now_ms();
-    if (cuInit(0) != CUDA_SUCCESS) { fprintf(stderr, "cuInit failed\n"); return 1; }
+    if (cuInit(0) != CUDA_SUCCESS) {
+        fprintf(stderr, "cuInit failed\n");
+        return 1;
+    }
 
     t[i++] = now_ms();
-    if (nvmlInit() != NVML_SUCCESS) { fprintf(stderr, "nvmlInit failed\n"); return 1; }
+    if (nvmlInit() != NVML_SUCCESS) {
+        fprintf(stderr, "nvmlInit failed\n");
+        return 1;
+    }
 
     t[i++] = now_ms();
     nvmlDeviceGetHandleByIndex(0, &dev);

--- a/bench/run_benchmarks.sh
+++ b/bench/run_benchmarks.sh
@@ -2,22 +2,48 @@
 # Run the full HAMi-core initialization benchmark suite.
 # Produces the measurements shown in issue #1662.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Ensure binaries are built
-if [ ! -f bench_init ] || [ ! -f phase_probe ] || [ ! -f warm_holder ]; then
+# Ensure the core binaries are built. phase_probe is optional (only built
+# when NVML is available), so ask make which targets it actually produces
+# instead of hardcoding it as required.
+BUILT_TARGETS="$(make print-targets)"
+HAVE_PHASE_PROBE=0
+case " $BUILT_TARGETS " in
+    *" phase_probe "*) HAVE_PHASE_PROBE=1 ;;
+esac
+
+if [ ! -f bench_init ] || [ ! -f nested_retain ] || [ ! -f warm_holder ] || [ ! -f abi_check ] || \
+   { [ "$HAVE_PHASE_PROBE" = 1 ] && [ ! -f phase_probe ]; }; then
     echo "Building benchmarks..."
     make clean
     make
 fi
 
-export LD_PRELOAD="${SCRIPT_DIR}/../build/libvgpu.so"
+LIBVGPU_SO="${SCRIPT_DIR}/../build/libvgpu.so"
+if [ ! -r "$LIBVGPU_SO" ]; then
+    echo "error: $LIBVGPU_SO not found or not readable" >&2
+    echo "       build it first (see the parent directory's build instructions);" >&2
+    echo "       an invalid LD_PRELOAD would be silently ignored by the loader," >&2
+    echo "       producing native-CUDA results mislabeled as HAMi-core measurements." >&2
+    exit 1
+fi
+export LD_PRELOAD="$LIBVGPU_SO"
 export CUDA_DEVICE_MEMORY_LIMIT=2048m
 export CUDA_DEVICE_SM_LIMIT=100
 export LIBCUDA_LOG_LEVEL=3
+
+HOLDER_PID=""
+cleanup() {
+    if [ -n "$HOLDER_PID" ]; then
+        kill "$HOLDER_PID" 2>/dev/null || true
+        wait "$HOLDER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
 
 # Clean up any stale cache
 rm -f /tmp/cudevshr.cache
@@ -28,8 +54,12 @@ echo "==============================================="
 echo
 
 echo "1. Measuring phase breakdown (set_task_pid bottleneck identification)"
-echo "   Running: phase_probe"
-./phase_probe
+if [ "$HAVE_PHASE_PROBE" = 1 ]; then
+    echo "   Running: phase_probe"
+    ./phase_probe
+else
+    echo "   Skipping: phase_probe (libnvidia-ml not found, NVML unavailable)"
+fi
 echo
 
 echo "2. Testing cost of holding a primary context"
@@ -48,11 +78,11 @@ echo "   Running bench_init at N=1,2,4,8,16,32,64,128..."
 for n in 1 2 4 8 16 32 64 128; do
     echo ""
     echo "   N=$n processes:"
-    ./bench_init "$n" 2>&1 | grep -E "p50|p90|p99|max|Total"
+    ./bench_init "$n" 2>&1 | grep -E "p50|p95|p99|max|Total"
 done
 
-kill $HOLDER_PID 2>/dev/null || true
-wait $HOLDER_PID 2>/dev/null || true
+cleanup
+HOLDER_PID=""
 echo
 echo "   warm_holder stopped."
 echo

--- a/bench/run_benchmarks.sh
+++ b/bench/run_benchmarks.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Run the full HAMi-core initialization benchmark suite.
+# Produces the measurements shown in issue #1662.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Ensure binaries are built
+if [ ! -f bench_init ] || [ ! -f phase_probe ] || [ ! -f warm_holder ]; then
+    echo "Building benchmarks..."
+    make clean
+    make
+fi
+
+export LD_PRELOAD="${SCRIPT_DIR}/../build/libvgpu.so"
+export CUDA_DEVICE_MEMORY_LIMIT=2048m
+export CUDA_DEVICE_SM_LIMIT=100
+export LIBCUDA_LOG_LEVEL=3
+
+# Clean up any stale cache
+rm -f /tmp/cudevshr.cache
+
+echo "==============================================="
+echo "HAMi-core Initialization Benchmark Suite"
+echo "==============================================="
+echo
+
+echo "1. Measuring phase breakdown (set_task_pid bottleneck identification)"
+echo "   Running: phase_probe"
+./phase_probe
+echo
+
+echo "2. Testing cost of holding a primary context"
+echo "   Running: nested_retain"
+./nested_retain
+echo
+
+echo "3. Measuring concurrent initialization scaling"
+echo "   (keeping a primary context holder alive)"
+echo "   Starting warm_holder..."
+./warm_holder primary >/dev/null 2>&1 &
+HOLDER_PID=$!
+sleep 1
+
+echo "   Running bench_init at N=1,2,4,8,16,32,64,128..."
+for n in 1 2 4 8 16 32 64 128; do
+    echo ""
+    echo "   N=$n processes:"
+    ./bench_init "$n" 2>&1 | grep -E "p50|p90|p99|max|Total"
+done
+
+kill $HOLDER_PID 2>/dev/null || true
+wait $HOLDER_PID 2>/dev/null || true
+echo
+echo "   warm_holder stopped."
+echo
+
+echo "4. Verifying ABI compatibility"
+echo "   Running: abi_check"
+./abi_check
+echo
+
+echo "==============================================="
+echo "Benchmark suite complete."
+echo "See README.md for expected results and context."
+echo "==============================================="

--- a/bench/warm_holder.c
+++ b/bench/warm_holder.c
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * warm_holder - holds a CUDA primary context open so the GPU does not
+ * runtime-suspend between benchmark iterations.
+ *
+ * On an Optimus laptop the discrete GPU powers down when idle, and the next
+ * cuInit() pays roughly 1.5s of wake latency. That artifact dwarfs the effect
+ * under study. Server GPUs in the scenario this benchmark models are always
+ * resident, so holding a context is the faithful configuration, not a cheat.
+ *
+ * Runs until killed. Deliberately does no allocation beyond the context so it
+ * costs a fixed, small amount of device memory.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <cuda.h>
+
+/*
+ * Modes:
+ *   primary    (default) retain the device primary context, the same object
+ *              set_task_pid() probes with
+ *   nonprimary create an ordinary context instead, which keeps the GPU awake
+ *              without holding the primary context. Used to separate "GPU is
+ *              powered up" from "another process holds the primary context".
+ */
+int main(int argc, char **argv) {
+    const char *mode = argc > 1 ? argv[1] : "primary";
+    CUcontext ctx;
+    CUdevice dev;
+    CUresult r;
+
+    if ((r = cuInit(0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "warm_holder: cuInit failed: %d\n", r);
+        return 1;
+    }
+
+    if (strcmp(mode, "nonprimary") == 0) {
+        if ((r = cuDeviceGet(&dev, 0)) != CUDA_SUCCESS ||
+            (r = cuCtxCreate_v2(&ctx, 0, dev)) != CUDA_SUCCESS) {
+            fprintf(stderr, "warm_holder: ctx create failed: %d\n", r);
+            return 1;
+        }
+    } else if ((r = cuDevicePrimaryCtxRetain(&ctx, 0)) != CUDA_SUCCESS) {
+        fprintf(stderr, "warm_holder: ctx retain failed: %d\n", r);
+        return 1;
+    }
+
+    printf("warm_holder ready mode=%s pid=%d\n", mode, getpid());
+    fflush(stdout);
+
+    for (;;) pause();
+    return 0;
+}

--- a/bench/warm_holder.c
+++ b/bench/warm_holder.c
@@ -51,15 +51,20 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    if (strcmp(mode, "nonprimary") == 0) {
+    if (strcmp(mode, "primary") == 0) {
+        if ((r = cuDevicePrimaryCtxRetain(&ctx, 0)) != CUDA_SUCCESS) {
+            fprintf(stderr, "warm_holder: ctx retain failed: %d\n", r);
+            return 1;
+        }
+    } else if (strcmp(mode, "nonprimary") == 0) {
         if ((r = cuDeviceGet(&dev, 0)) != CUDA_SUCCESS ||
             (r = cuCtxCreate_v2(&ctx, 0, dev)) != CUDA_SUCCESS) {
             fprintf(stderr, "warm_holder: ctx create failed: %d\n", r);
             return 1;
         }
-    } else if ((r = cuDevicePrimaryCtxRetain(&ctx, 0)) != CUDA_SUCCESS) {
-        fprintf(stderr, "warm_holder: ctx retain failed: %d\n", r);
-        return 1;
+    } else {
+        fprintf(stderr, "warm_holder: unknown mode '%s' (expected 'primary' or 'nonprimary')\n", mode);
+        return 2;
     }
 
     printf("warm_holder ready mode=%s pid=%d\n", mode, getpid());


### PR DESCRIPTION
Supports reproducible benchmarking for issue Project-HAMi/HAMi#1662 and provides performance analysis tools for HAMi-core's multiprocess device-sharing layer.

## Summary

Adds a benchmark suite measuring CUDA initialization latency in concurrent scenarios, with tools for phase-breakdown analysis, context retention amortization testing, and struct-layout verification.

## Tools

- **bench_init**: Measures cuInit() latency distribution across N concurrent processes (fork+exec through libvgpu.so)
- **phase_probe**: Breaks down set_task_pid() cost into NVML, snapshots, and primary context operations
- **nested_retain**: Tests whether holding a context is amortizable (~1µs per subsequent retain)
- **warm_holder**: Background context holder for testing under different holder conditions
- **abi_check**: Verifies shared_region_t layout consistency with Go-side mirror struct

## Files

- `bench/*.c`: Benchmark source files with Apache 2.0 license headers
- `Makefile`: Builds all tools; CUDA_HOME configurable, NVML optional
- `run_benchmarks.sh`: Orchestrates full suite to reproduce Project-HAMi/HAMi#1662 findings
- `README.md`: Documents each tool and expected results
- `.gitignore`: Excludes binary artifacts

## Building

```bash
cd bench && make
```

## Running

```bash
cd bench && ./run_benchmarks.sh
```

Expected output: linear scaling from ~61.5ms per-process, with ~80% time in CUDA context operations vs ~20% in NVML.

Binaries are excluded from git (only source and build config are tracked).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CUDA initialization/context benchmark suite with JSON-reporting tools, including concurrent startup, nested retain timing, and a persistent warm-holder.
  * Added an NVML-based phase/process-detection benchmark that runs only when available.
  * Added an ABI verification benchmark to validate expected shared-region layout.
  * Added an automated runner to build (as needed), configure environment, and execute the full suite end-to-end.
* **Documentation**
  * Added benchmark suite documentation with requirements, example commands, and expected output details.
* **Chores**
  * Improved benchmark build logic (including optional NVML support) and updated ignore rules for benchmark artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->