### PR TITLE
fix: resolve LIBCUDA_LOG_LEVEL on first use so early messages honour it

### DIFF
--- a/src/include/log_utils.h
+++ b/src/include/log_utils.h
@@ -22,27 +22,33 @@ extern int g_log_level;
 /* Call once during early initialization to cache LIBCUDA_LOG_LEVEL. */
 void log_utils_init(void);
 
+/*
+ * Level accessor used by the macros below. Resolves LIBCUDA_LOG_LEVEL on first
+ * use, so messages emitted before log_utils_init() runs honour it as well.
+ */
+int log_level(void);
+
 #ifdef FILEDEBUG
 #define LOG_DEBUG(msg, ...) { \
-    if (g_log_level >= 4) {\
+    if (log_level() >= 4) {\
         if (fp1==NULL) fp1 = fopen ("/tmp/vgpulog", "a"); \
         fprintf(fp1, "[HAMI-core Debug(%d:%ld:%s:%d)]: "msg"\n",getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
         }\
     }
 #define LOG_INFO(msg, ...) { \
-    if (g_log_level >= 3) {\
+    if (log_level() >= 3) {\
         if (fp1==NULL) fp1 = fopen ("/tmp/vgpulog", "a"); \
         fprintf(fp1, "[HAMI-core Info(%d:%ld:%s:%d)]: "msg"\n", getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
          }\
     }
 #define LOG_WARN(msg, ...) { \
-    if (g_log_level >= 2) {\
+    if (log_level() >= 2) {\
         if (fp1==NULL) fp1 = fopen ("/tmp/vgpulog", "a"); \
         fprintf(fp1, "[HAMI-core Warn(%d:%ld:%s:%d)]: "msg"\n", getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
         }\
     }
 #define LOG_MSG(msg, ...) { \
-    if (g_log_level >= 2) {\
+    if (log_level() >= 2) {\
         if (fp1==NULL) fp1 = fopen ("/tmp/vgpulog", "a"); \
         fprintf(fp1, "[HAMI-core Msg(%d:%ld:%s:%d)]: "msg"\n", getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
          }\
@@ -53,22 +59,22 @@ void log_utils_init(void);
 }
 #else
 #define LOG_DEBUG(msg, ...) { \
-    if (g_log_level >= 4) {\
+    if (log_level() >= 4) {\
         fprintf(stderr, "[HAMI-core Debug(%d:%ld:%s:%d)]: "msg"\n",getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
          }\
     }
 #define LOG_INFO(msg, ...) { \
-    if (g_log_level >= 3) {\
+    if (log_level() >= 3) {\
         fprintf(stderr, "[HAMI-core Info(%d:%ld:%s:%d)]: "msg"\n", getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
         }\
     }
 #define LOG_WARN(msg, ...) { \
-    if (g_log_level >= 2) {\
+    if (log_level() >= 2) {\
         fprintf(stderr, "[HAMI-core Warn(%d:%ld:%s:%d)]: "msg"\n", getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
         }\
     }
 #define LOG_MSG(msg, ...) { \
-    if (g_log_level >= 2) {\
+    if (log_level() >= 2) {\
         fprintf(stderr, "[HAMI-core Msg(%d:%ld:%s:%d)]: "msg"\n", getpid(),pthread_self(),basename(__FILE__),__LINE__,##__VA_ARGS__); \
          }\
     }

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <pthread.h>
 
 /*
  * Cached log level, read once from LIBCUDA_LOG_LEVEL by log_utils_init().
@@ -9,10 +10,22 @@ int g_log_level = 2;
 
 FILE *fp1 = NULL;
 
+static pthread_once_t log_level_once = PTHREAD_ONCE_INIT;
+
 void log_utils_init(void) {
     const char *env = getenv("LIBCUDA_LOG_LEVEL");
     if (env != NULL) {
         g_log_level = atoi(env);
     }
     /* else: keep default of 2 (warn level) */
+}
+
+/*
+ * The dlsym hook and preInit() log before preInit() reaches log_utils_init(),
+ * so reading the cached value directly ignores LIBCUDA_LOG_LEVEL for exactly
+ * those messages. Resolve on first use instead.
+ */
+int log_level(void) {
+    pthread_once(&log_level_once, log_utils_init);
+    return g_log_level;
 }


### PR DESCRIPTION
I spent most of a day chasing this before reading the source, so I figured I should write it up
properly rather than just work around it.

Every process in our HAMi containers prints these to stderr, no matter what I set
`LIBCUDA_LOG_LEVEL` to:

```
[HAMI-core Warn(556:140497071547584:libvgpu.c:115)]: recursive dlsym : open64
[HAMI-core Warn(556:140497071547584:libvgpu.c:115)]: recursive dlsym : openat64
[HAMI-core Msg(9255:140295499897728:libvgpu.c:870)]: Initializing.....
```

What eventually made it click is that the device plugin already sets `LIBCUDA_LOG_LEVEL=1` in the
container environment. The container is asking for warn level to be quiet, and it isn't, so
something was off rather than me holding it wrong.

The reason is just ordering. `g_log_level` starts at 2 in `log_utils.c`, and both `LOG_WARN` and
`LOG_MSG` fire at `>= 2`. But the variable is only read by `log_utils_init()`, and in `libvgpu.c`
that call sits at line 872, while the dlsym hook lives at 74 with its warning at 115 and the
"Initializing" message at 870. Both messages happen while `g_log_level` is still the compile time
default, which is exactly the threshold. Setting the variable to 0 in the pod environment changes
nothing for the warnings, and the Msg lines are identical for every value from 0 to 5.

One thing that might help reproducing: we only see the `recursive dlsym` warnings in containers
that ask for `graphics` in `NVIDIA_DRIVER_CAPABILITIES`. Compute only pods on the same node and
the same card have never shown them, presumably because far fewer libraries get resolved on the
way up.

Why I care enough to send a patch rather than pipe it to /dev/null: we run KDE desktops on HAMi
GPUs through Coder, which collects a few workspace metrics by running a small script per metric
and storing whatever comes back. The shell it spawns emits the warning while it is still being
linked, before the script's first line runs, so the warning ends up as the metric value. I tried
to filter it and could not, and the thing that finally convinced me was setting one metric's
entire script to `echo ok`. It came back as a HAMi warning. There is no point in the script that
is early enough, so there is nothing a consumer can do about it.

I did look for a way to patch around it on our side first. `/etc/ld.so.preload` and
`/usr/local/vgpu/libvgpu.so` are read only bind mounts, so nothing inside the container can
redirect them, and patching the library on the node gets overwritten on the next upgrade.

## The change

`log_level()` resolves `LIBCUDA_LOG_LEVEL` on first use via `pthread_once` instead of depending
on `log_utils_init()` having run, and the four threshold checks in the macros go through it.
`log_utils_init()` keeps working and stays the thing `pthread_once` calls, so the existing call
site in `preInit()` is harmless either way. `LOG_ERROR` is untouched, it has no threshold.

Behaviour is unchanged when the variable is unset, and the levels now apply from the very first
message:

```
$ ./t                       # env unset, default 2
[HAMI-core Warn(...)]: recursive dlsym : open64
[HAMI-core Msg(...)]: Initializing.....
[HAMI-core ERROR (...)]: boom 1

$ LIBCUDA_LOG_LEVEL=1 ./t
[HAMI-core ERROR (...)]: boom 1

$ LIBCUDA_LOG_LEVEL=0 ./t
[HAMI-core ERROR (...)]: boom 1
```

In case it comes up in review: calling `getenv()` from inside the dlsym hook is fine, it does not
route through `dlsym` itself, so this does not feed the recursion the hook exists to catch.

If you would rather keep `log_utils_init()` as the single entry point and call it from a
constructor instead, that works for me too. I went with the accessor because it does not depend
on constructor ordering, which is the part that broke here in the first place.

Tested against HAMi v2.9.0 on an RTX PRO 6000 Blackwell, driver 610.43.02, Debian 13 on kernel
6.12, k3s v1.35.1 with containerd.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging behavior when messages are emitted before logging initialization.
  * Log-level settings are now resolved consistently on first use, preventing initialization-order issues.
  * Logging configuration is safely handled when accessed concurrently.
  * Existing default behavior and output destinations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->