### PR TITLE
chore: remove unused set_current_device_sm_limit setters

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1386,18 +1386,6 @@ int set_host_pid(int hostpid) {
     return 0;
 }
 
-int set_current_device_sm_limit_scale(int dev, int scale) {
-    ensure_initialized();
-    if (region_info.shared_region->sm_init_flag==1) return 0;
-    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
-        LOG_ERROR("Illegal device id: %d", dev);
-    }
-    LOG_INFO("dev %d new sm limit set mul by %d",dev,scale);
-    region_info.shared_region->sm_limit[dev]=region_info.shared_region->sm_limit[dev]*scale;
-    region_info.shared_region->sm_init_flag = 1;
-    return 0;
-}
-
 int get_current_device_sm_limit(int dev) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -132,8 +132,6 @@ void ensure_initialized();
 int get_current_device_sm_limit(int dev);
 uint64_t get_current_device_memory_limit(const int dev);
 int set_current_device_memory_limit(const int dev,size_t newlimit);
-int set_current_device_sm_limit(int dev,int scale);
-int set_current_device_sm_limit_scale(int dev,int scale);
 int update_host_pid();
 int set_host_pid(int hostpid);
 


### PR DESCRIPTION
## What this does

Removes two unused functions flagged in #231:

- `set_current_device_sm_limit(int dev, int scale)` — declared in the header but never defined or called.
- `set_current_device_sm_limit_scale(int dev, int scale)` — defined but never called anywhere in the tree, including `test/`.

A repo-wide search confirms neither symbol is referenced outside its own declaration/definition.

The `sm_init_flag` field that the scale setter used to touch is intentionally left in the shared-region struct — it is part of the memory-mapped, cross-process layout, so removing it would be a compatibility change beyond the scope of this cleanup. With the setter gone it is only initialized to `0` and never read, which is inert.

Credit to @KaminariOS for spotting these in #231.

## Verification

Repo-wide `grep` confirms no remaining references. I was not able to run a full build locally (it needs the CUDA toolkit), but since the removed symbols have no callers or other definitions, the removal cannot affect compilation — the `build-in-docker` target / CI will confirm.

Fixes #231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed legacy controls for adjusting device SM memory limits.
  * No end-user visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->