### PR TITLE
fix: sweep dead process slots only when slots are scarce

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1072,6 +1072,20 @@ void init_proc_slot_withlock() {
     shared_region_t* region = region_info.shared_region;
 
     int proc_num = atomic_load_explicit(&region->proc_num, memory_order_acquire);
+
+    // A full sweep reads /proc/<pid>/stat once per occupied slot, so it costs
+    // O(proc_num) filesystem syscalls while the region lock is held. Running it
+    // on every join makes N processes starting together O(N^2) serialised work.
+    // Reclaiming a slot whose process already died is not needed for the join
+    // itself to be correct: oom_check() sweeps before it reports OOM, which is
+    // where a stale slot actually changes an outcome. So sweep here only when
+    // slots are scarce -- and do it before deciding the table is full, so a
+    // table filled with dead slots is recovered instead of being fatal.
+    if (proc_num >= SHARED_REGION_SWEEP_THRESHOLD) {
+        clear_proc_slot_nolock(1);
+        proc_num = atomic_load_explicit(&region->proc_num, memory_order_acquire);
+    }
+
     if (proc_num >= SHARED_REGION_MAX_PROCESS_NUM) {
         exit_withlock(-1);
     }
@@ -1123,7 +1137,9 @@ void init_proc_slot_withlock() {
         atomic_fetch_add_explicit(&region->proc_num, 1, memory_order_release);
     }
 
-    clear_proc_slot_nolock(1);
+    // Slots that exit cleanup already marked dead carry PID 0, and dropping
+    // those reads no files at all, so that part stays on the join path.
+    clear_proc_slot_nolock(0);
     unlock_shrreg();
 }
 

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -40,6 +40,12 @@
 
 #define SHARED_REGION_SIZE_MAGIC  sizeof(shared_region_t)
 #define SHARED_REGION_MAX_PROCESS_NUM 1024
+// Slot-table occupancy at which joining a process performs a full liveness
+// sweep. See init_proc_slot_withlock(). Overridable at build time so the
+// regression test can reach the sweep without spawning 768 processes.
+#ifndef SHARED_REGION_SWEEP_THRESHOLD
+    #define SHARED_REGION_SWEEP_THRESHOLD ((SHARED_REGION_MAX_PROCESS_NUM * 3) / 4)
+#endif
 
 // macros for debugging
 #define SEQ_FIX_SHRREG_ACQUIRE_FLOCK_OK 0

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -46,6 +46,12 @@
 #ifndef SHARED_REGION_SWEEP_THRESHOLD
     #define SHARED_REGION_SWEEP_THRESHOLD ((SHARED_REGION_MAX_PROCESS_NUM * 3) / 4)
 #endif
+// Past capacity the sweep could never run, so a table full of dead slots would
+// reach the capacity check and exit. At zero every join sweeps again.
+#if SHARED_REGION_SWEEP_THRESHOLD < 1 || \
+    SHARED_REGION_SWEEP_THRESHOLD > SHARED_REGION_MAX_PROCESS_NUM
+    #error "SHARED_REGION_SWEEP_THRESHOLD must be between 1 and SHARED_REGION_MAX_PROCESS_NUM"
+#endif
 
 // macros for debugging
 #define SEQ_FIX_SHRREG_ACQUIRE_FLOCK_OK 0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,20 +14,31 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     get_filename_component(TEST_TARGET_NAME ${RELATIVE_TEST_PATH} NAME_WE)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR})
 
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR TEST_TARGET_NAME STREQUAL "test_pid_discovery")
-        if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
-            add_executable(${TEST_TARGET_NAME}
-                ${TEST_SCRIPT}
-                ${CMAKE_CURRENT_SOURCE_DIR}/../src/multiprocess/multiprocess_memory_limit.c
-                ${CMAKE_CURRENT_SOURCE_DIR}/../src/log_utils.c)
-        else()
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR
+        TEST_TARGET_NAME STREQUAL "test_pid_discovery" OR
+        TEST_TARGET_NAME STREQUAL "test_proc_slot_reclaim")
+        # These focused regression tests build against production sources and do
+        # not invoke any CUDA/NVML entry point at runtime.  Section garbage
+        # collection drops the unrelated GPU-facing production functions.
+        if (TEST_TARGET_NAME STREQUAL "test_pid_discovery")
             add_executable(${TEST_TARGET_NAME}
                 ${TEST_SCRIPT}
                 ${CMAKE_CURRENT_SOURCE_DIR}/../src/utils.c
                 ${CMAKE_CURRENT_SOURCE_DIR}/../src/log_utils.c)
+        else()
+            add_executable(${TEST_TARGET_NAME}
+                ${TEST_SCRIPT}
+                ${CMAKE_CURRENT_SOURCE_DIR}/../src/multiprocess/multiprocess_memory_limit.c
+                ${CMAKE_CURRENT_SOURCE_DIR}/../src/log_utils.c)
         endif()
         target_compile_definitions(${TEST_TARGET_NAME} PRIVATE
             _GNU_SOURCE)
+        if (TEST_TARGET_NAME STREQUAL "test_proc_slot_reclaim")
+            # Reach the liveness sweep without spawning three quarters of the
+            # slot table.
+            target_compile_definitions(${TEST_TARGET_NAME} PRIVATE
+                SHARED_REGION_SWEEP_THRESHOLD=8)
+        endif()
         target_compile_options(${TEST_TARGET_NAME} PRIVATE
             -ffunction-sections -fdata-sections)
         set_target_properties(${TEST_TARGET_NAME} PROPERTIES
@@ -41,7 +52,9 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     endif()
 
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR TEST_TARGET_NAME STREQUAL "test_pid_discovery")
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR
+        TEST_TARGET_NAME STREQUAL "test_pid_discovery" OR
+        TEST_TARGET_NAME STREQUAL "test_proc_slot_reclaim")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         target_link_libraries(${TEST_TARGET_NAME} -ldl)
@@ -75,6 +88,10 @@ if (TARGET vgpu)
         ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:vgpu>"
         TIMEOUT 10)
 endif()
+
+add_test(NAME proc_slot_reclaim
+    COMMAND test_proc_slot_reclaim)
+set_tests_properties(proc_slot_reclaim PROPERTIES TIMEOUT 30)
 
 
 add_custom_target(python_test ALL

--- a/test/test_proc_slot_reclaim.c
+++ b/test/test_proc_slot_reclaim.c
@@ -1,0 +1,278 @@
+/*
+ * GPU-free regression test for process-slot reclamation on the join path.
+ *
+ * Joining the shared region used to sweep every occupied slot for liveness,
+ * and that sweep reads /proc/<pid>/stat once per slot while the region lock is
+ * held.  The sweep now runs only once slots are scarce, so this test pins both
+ * halves of that contract: below the threshold a join must leave slots held by
+ * dead processes alone, and at the threshold a join must reclaim them so the
+ * table cannot grow without bound.
+ *
+ * The target is built with a small SHARED_REGION_SWEEP_THRESHOLD so the
+ * reclaim path is reachable without spawning three quarters of the table.
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "multiprocess/multiprocess_memory_limit.h"
+
+#define TEST_TIMEOUT_MS 5000.0
+/* Above this the test would have to spawn too many processes to be useful. */
+#define MAX_TEST_THRESHOLD 32
+#define DEAD_SLOTS_BELOW_THRESHOLD 2
+/* Enough cycles to cross the threshold several times over. */
+#define RECLAIM_CYCLES (SHARED_REGION_SWEEP_THRESHOLD * 3)
+/* A recycled PID reads as alive and survives one sweep, so allow slack. */
+#define OCCUPANCY_SLACK 2
+
+typedef struct {
+    _Atomic int joined;
+} test_state_t;
+
+static test_state_t *state;
+/* Read-only view of the cache file, so the test can read proc_num without
+ * taking a slot of its own or reaching into the module's statics. */
+static shared_region_t *region_view;
+
+static double now_ms(void) {
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0.0;
+    }
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1000000.0;
+}
+
+static void sleep_ms(int milliseconds) {
+    struct timespec ts;
+
+    ts.tv_sec = milliseconds / 1000;
+    ts.tv_nsec = (milliseconds % 1000) * 1000000L;
+    while (nanosleep(&ts, &ts) != 0 && errno == EINTR) {
+    }
+}
+
+static int wait_for_counter(_Atomic int *counter, int expected,
+                            double timeout_ms) {
+    double deadline = now_ms() + timeout_ms;
+
+    while (atomic_load_explicit(counter, memory_order_acquire) < expected) {
+        if (now_ms() >= deadline) {
+            return -1;
+        }
+        sleep_ms(1);
+    }
+    return 0;
+}
+
+static void kill_and_reap(pid_t child) {
+    int status;
+
+    if (child <= 0) {
+        return;
+    }
+    kill(child, SIGKILL);
+    while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+    }
+}
+
+static int map_region_view(const char *cache_path) {
+    int fd = open(cache_path, O_RDONLY);
+
+    if (fd < 0) {
+        perror("open(shared-region cache)");
+        return -1;
+    }
+    region_view = mmap(NULL, SHARED_REGION_SIZE_MAGIC, PROT_READ, MAP_SHARED,
+                       fd, 0);
+    close(fd);
+    if (region_view == MAP_FAILED) {
+        perror("mmap(shared-region cache)");
+        region_view = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+static int occupied_slots(void) {
+    return atomic_load_explicit(&region_view->proc_num, memory_order_acquire);
+}
+
+/* Take a slot, announce it, then wait to be killed so the slot is left behind
+ * with a PID that no longer exists -- exactly what a SIGKILL'd container does,
+ * since the exit handler never runs. */
+static void slot_worker(void) {
+    ensure_initialized();
+    atomic_fetch_add_explicit(&state->joined, 1, memory_order_release);
+    for (;;) {
+        sleep_ms(10);
+    }
+}
+
+static pid_t spawn_joined_worker(int expected_joins) {
+    pid_t child = fork();
+
+    if (child == 0) {
+        slot_worker();
+        _exit(0);
+    }
+    if (child < 0) {
+        perror("fork");
+        return -1;
+    }
+    if (wait_for_counter(&state->joined, expected_joins, TEST_TIMEOUT_MS) != 0) {
+        fprintf(stderr, "worker %d did not join the shared region\n",
+                expected_joins);
+        kill_and_reap(child);
+        return -1;
+    }
+    return child;
+}
+
+/* Below the threshold a join must not pay for a liveness sweep, so slots held
+ * by processes that already died stay in the table. */
+static int test_dead_slots_are_kept_below_threshold(int *joins) {
+    pid_t child;
+    int expected;
+    int observed;
+    int i;
+
+    for (i = 0; i < DEAD_SLOTS_BELOW_THRESHOLD; i++) {
+        child = spawn_joined_worker(++(*joins));
+        if (child < 0) {
+            return -1;
+        }
+        kill_and_reap(child);
+    }
+
+    child = spawn_joined_worker(++(*joins));
+    if (child < 0) {
+        return -1;
+    }
+    /* This process holds a slot too, hence the +1. */
+    expected = 1 + DEAD_SLOTS_BELOW_THRESHOLD + 1;
+    observed = occupied_slots();
+    kill_and_reap(child);
+
+    if (observed != expected) {
+        fprintf(stderr,
+                "join below the sweep threshold changed the table: "
+                "expected %d occupied slots, saw %d\n",
+                expected, observed);
+        return -1;
+    }
+    return 0;
+}
+
+/* Once slots are scarce a join must reclaim the dead ones, so repeated
+ * join-and-die cycles cannot grow the table past the threshold. */
+static int test_dead_slots_are_reclaimed_at_threshold(int *joins) {
+    int previous = occupied_slots();
+    int peak = previous;
+    int reclaims = 0;
+    pid_t child;
+    int observed;
+    int i;
+
+    for (i = 0; i < RECLAIM_CYCLES; i++) {
+        child = spawn_joined_worker(++(*joins));
+        if (child < 0) {
+            return -1;
+        }
+        observed = occupied_slots();
+        kill_and_reap(child);
+
+        if (observed > peak) {
+            peak = observed;
+        }
+        if (observed < previous) {
+            reclaims++;
+        }
+        previous = observed;
+    }
+
+    if (peak > SHARED_REGION_SWEEP_THRESHOLD + OCCUPANCY_SLACK) {
+        fprintf(stderr,
+                "slot table grew past the sweep threshold: peak %d, "
+                "threshold %d\n",
+                peak, (int)SHARED_REGION_SWEEP_THRESHOLD);
+        return -1;
+    }
+    if (reclaims == 0) {
+        fprintf(stderr, "no join ever reclaimed a dead slot in %d cycles\n",
+                RECLAIM_CYCLES);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void) {
+    char cache_path[] = "/tmp/hami-proc-slot-reclaim.XXXXXX";
+    int cache_fd;
+    int joins = 0;
+    int failures = 0;
+
+    if ((int)SHARED_REGION_SWEEP_THRESHOLD > MAX_TEST_THRESHOLD) {
+        printf("skipping: sweep threshold %d needs too many processes\n",
+               (int)SHARED_REGION_SWEEP_THRESHOLD);
+        return 0;
+    }
+
+    cache_fd = mkstemp(cache_path);
+    if (cache_fd < 0) {
+        perror("mkstemp(shared-region cache)");
+        return 1;
+    }
+    close(cache_fd);
+    unlink(cache_path);
+    if (setenv(MULTIPROCESS_SHARED_REGION_CACHE_ENV, cache_path, 1) != 0 ||
+        setenv("CUDA_DEVICE_MEMORY_LIMIT", "1024m", 1) != 0 ||
+        setenv("LIBCUDA_LOG_LEVEL", "0", 1) != 0) {
+        perror("setenv");
+        return 1;
+    }
+
+    state = mmap(NULL, sizeof(*state), PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (state == MAP_FAILED) {
+        perror("mmap(test state)");
+        return 1;
+    }
+    memset(state, 0, sizeof(*state));
+    atomic_init(&state->joined, 0);
+    log_utils_init();
+    ensure_initialized();
+
+    if (map_region_view(cache_path) != 0) {
+        unlink(cache_path);
+        return 1;
+    }
+
+    if (test_dead_slots_are_kept_below_threshold(&joins) != 0) {
+        failures++;
+    }
+    if (test_dead_slots_are_reclaimed_at_threshold(&joins) != 0) {
+        failures++;
+    }
+
+    munmap(region_view, SHARED_REGION_SIZE_MAGIC);
+    unlink(cache_path);
+    if (failures != 0) {
+        fprintf(stderr, "%d process-slot reclamation test(s) failed\n",
+                failures);
+        return 1;
+    }
+    munmap(state, sizeof(*state));
+    puts("process-slot reclamation tests passed");
+    return 0;
+}


### PR DESCRIPTION
Fixes the O(N²) join path measured in #252.

## What the problem is

`init_proc_slot_withlock()` calls `clear_proc_slot_nolock(1)` on every join. That sweep walks every occupied slot and calls `proc_alive()`, which is an `fopen("/proc/<pid>/stat")` + read + close per slot (`src/include/process_utils.h:17`). All of it runs under `lock_shrreg()`, the single region-wide semaphore.

So the Nth process to join does O(N) filesystem syscalls while holding a lock every other joining process needs. Across N processes starting together that is O(N²) serialised work — the shape a TP=N inference job or a pod whose containers all start at once produces.

## What this changes

A join now sweeps for liveness only once occupancy reaches three quarters of the table.

Why that is safe: reclaiming a slot whose process died is not needed for a join to be correct. It matters in two places, and both are still covered.

- **Memory accounting.** A dead process's slot inflates `get_gpu_memory_usage()`, which could cause a spurious OOM. `oom_check()` already calls `clear_proc_slot_nolock(1)` and retries before it reports OOM (`src/allocator/allocator.c:54`), so the reclaim still happens exactly where a stale slot changes an outcome.
- **Slot exhaustion.** Handled by the threshold. The sweep now runs *before* the `proc_num >= SHARED_REGION_MAX_PROCESS_NUM` capacity check instead of after the insert, so a table filled with dead slots is recovered rather than hitting `exit_withlock(-1)`. That case used to be fatal.

Slots that exit cleanup already marked with PID 0 are still compacted on every join. That path reads no files, so it costs nothing.

## Measurements

Harness from #252 — fork N children, hold them at a shared start barrier, release them together, time exactly one `ensure_initialized()` per child; the region is deleted before every round so each round measures cold first-touch: https://gist.github.com/keshav9926/9e8f4c29eebd104ba02891e4733b9dfb

Both arms were built from this tree, one with the patch and one without, and run **interleaved** — base, fix, base, fix — for 6 iterations of 10 repeats each, so thermal drift and background load hit both arms equally. Values below are the median across the 6 iterations.

| procs | init p50 before | init p50 after | |
|------:|----------------:|---------------:|-----:|
| 1  | 0.35 ms | 0.27 ms | 1.3× |
| 2  | 0.43 ms | 0.30 ms | 1.4× |
| 4  | 0.64 ms | 0.42 ms | 1.5× |
| 8  | 1.03 ms | 0.63 ms | 1.6× |
| 16 | 1.42 ms | 0.71 ms | 2.0× |
| 32 | 2.66 ms | 0.99 ms | 2.7× |
| 64 | 6.06 ms | 1.11 ms | 5.5× |

Before, p50 grows 17× from 1 to 64 processes. After, it grows 4×, and the gap widens with process count — which is what you would expect if the removed term was the quadratic one. The remaining growth is the `lockf` in `try_create_shrreg()` and the semaphore itself; this PR does not touch either.

`wall_ms`, `init_p95` and `init_max` are dominated by fork/exit scheduling noise on this hardware and I would not read anything into them.

## Test

`test/test_proc_slot_reclaim.c` — GPU-free, built against the production shared-region sources the same way `test_postinit_owner_death` is, and registered with ctest.

It pins both halves of the new contract:

- below the threshold, a join leaves slots held by dead processes in place (children are SIGKILL'd, so exit cleanup never runs and the slot keeps a PID that no longer exists);
- at the threshold, a join reclaims them, so repeated join-and-die cycles cannot grow the table without bound.

The target is compiled with `SHARED_REGION_SWEEP_THRESHOLD=8` so the reclaim path is reachable without spawning 768 processes. The production constant is unchanged; it is now `#ifndef`-guarded only so the test can override it.

Verified red/green: against `main` without the fix the test fails (`join below the sweep threshold changed the table: expected 4 occupied slots, saw 2`); with the fix it passes 5/5 consecutive runs.

## What was tested, and what wasn't

- Environment: WSL2 (Ubuntu 24.04, kernel 6.6.87), NVIDIA GeForce RTX 3050 Laptop GPU, driver 592.82, single GPU, driver libs via `/usr/lib/wsl/lib`.
- This change does not touch device allocation or in-container isolation — it only changes *when* the slot table is swept — so I did not run the GPU allocation suite against it. I have not run it on a multi-GPU datacenter node, and `/proc` and file-lock behaviour under WSL2 may differ from bare metal. Happy to re-run anywhere if someone has a node available.
- Only `ensure_initialized()` is timed. No CUDA context creation, no real workload.
- The absolute numbers are small. What I think matters is the shape: the cost scaled with process count, which is the thing operators scale up.

## Trade-off worth flagging

Between sweeps, slots held by dead processes stay in the table, so `proc_num` and the usage totals derived from it can be stale for longer than before. `oom_check()` covers the case where that changes an allocation outcome. If you would rather also bound the staleness in wall-clock terms, a "sweep if the last one was more than N seconds ago" rule would do it, but that needs a timestamp in the shared region and therefore a layout change — happy to do it that way instead if you prefer.

(Disclosure: I use AI assistance in my workflow. The measurements, the code reading and the reasoning above are my own, and I'm happy to walk through any part of it.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery of shared resources after worker processes terminate unexpectedly.
  - Reduced unnecessary process checks during normal worker cleanup, improving reliability when joining shared regions.
  - Added threshold-based reclamation to prevent exhausted process slots from blocking new workers.

- **Tests**
  - Added regression coverage for reclaiming slots from forcibly terminated workers, including timeout and cleanup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->