### PR TITLE
docs: add HAMi-core contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,7 +16,7 @@ labels: bug
 **Anything else we need to know?**:
 
 - The output of `nvidia-smi -a` on your host
-- Your Docker or containerd configuration file
+- Relevant Docker or containerd configuration sections. Omit credentials, tokens, passwords, private keys, certificates, and unrelated host data.
 - The HAMi-core logs and relevant `LIBCUDA_LOG_LEVEL`
 - The build and workload reproduction commands
 - Relevant `CUDA_DEVICE_MEMORY_LIMIT`, `CUDA_DEVICE_SM_LIMIT`, and `LD_PRELOAD` values

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a problem encountered while using HAMi-core
+labels: bug
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+- The output of `nvidia-smi -a` on your host
+- Your Docker or containerd configuration file
+- The HAMi-core logs and relevant `LIBCUDA_LOG_LEVEL`
+- The build and workload reproduction commands
+- Relevant `CUDA_DEVICE_MEMORY_LIMIT`, `CUDA_DEVICE_SM_LIMIT`, and `LD_PRELOAD` values
+- Any relevant kernel output lines from `dmesg`
+
+Before posting, remove or mask credentials, tokens, and other sensitive data from configuration and logs.
+
+**Environment**:
+- HAMi-core version, commit, or image:
+- GPU model:
+- NVIDIA driver version:
+- CUDA toolkit/runtime version:
+- Docker or containerd version:
+- Build/run command, image, and tag used:
+- Workload or framework:
+- Kernel version from `uname -a`:
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,13 @@
+---
+name: Enhancement Request
+about: Suggest an improvement to HAMi-core
+labels: enhancement
+---
+
+<!-- Please use this template for enhancement and feature requests. -->
+
+**What would you like to be added**:
+
+**Why is this needed**:
+
+**Anything else we need to know?**:

--- a/.github/ISSUE_TEMPLATE/good-first.md
+++ b/.github/ISSUE_TEMPLATE/good-first.md
@@ -1,0 +1,23 @@
+---
+name: Good First Issue
+about: Publish a task suitable for a first-time contributor
+labels: "good first issue"
+---
+
+<!-- Please use this template when publishing a good first issue. -->
+
+**Task description**:
+
+**Suggested solution**:
+
+**Who can take this task**:
+
+This issue is intended for a first-time contributor beginning their contribution journey.
+
+**How to take the task**:
+
+Reply to the issue and state that you would like to work on it. A maintainer can assign it to you.
+
+**How to ask for help**:
+
+If you need assistance or have questions, ask in the issue. The issue author or another community member can provide guidance.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: Question
+about: Ask a question about HAMi-core
+labels: question
+---
+
+**Please provide a detailed description of your question**:
+
+**What have you already tried or investigated?**:
+
+**Environment**:
+
+- HAMi-core version, commit, or image:
+- GPU and NVIDIA driver version, if applicable:
+- CUDA toolkit/runtime version:
+- Docker or containerd version:
+- Operating system and kernel version:
+- Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,6 @@ Fixes #
 
 **Does this PR introduce a user-facing change?**:
 
-**AI Disclosure**
+**AI Disclosure**:
 
 <!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+
+**AI Disclosure**
+
+<!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind documentation

**What this PR does / why we need it**:

Adds concise, repository-specific templates for bug reports, enhancements, good first issues, questions, and pull requests. This makes HAMi-core reports collect consistent CUDA, GPU, runtime, and reproduction details while keeping the existing contribution workflow unchanged.

**Which issue(s) this PR fixes**:
Fixes #254

**Special notes for your reviewer**:

This is a documentation-only change. The issue-template front matter was parsed locally, uses existing repository labels, and all five Markdown files were checked for whitespace errors.

**Does this PR introduce a user-facing change?**:

Yes. Contributors will see HAMi-core-specific prompts when opening issues and pull requests.

**AI Disclosure**:

AI was used only for formatting purposes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added structured templates for bug reports, enhancement requests, questions, and good-first issues.
  - Added prompts for reproduction steps, environment details, diagnostics, proposed solutions, contributor guidance, and sensitive-data removal.
  - Added a pull request template covering change type, rationale, issue links, reviewer notes, user-facing impact, and AI assistance disclosure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->