### PR TITLE
fix(core): skip false ERROR logs when env vars are stripped after fork/exec

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1055,7 +1055,20 @@ int set_env_utilization_switch() {
     }
     return 0;
 }
-
+ //  returns 1 if any is present, 0 if all are missing.
+int env_limit_family_present(const char* base_name) {
+    if (getenv(base_name) != NULL) {
+        return 1;
+    }
+    for (int i = 0; i < CUDA_DEVICE_MAX_COUNT; i++) {
+        char indexed_name[64];
+        snprintf(indexed_name, sizeof(indexed_name), "%s_%d", base_name, i);
+        if (getenv(indexed_name) != NULL) {
+            return 1;
+        }
+    }
+    return 0;
+}
 void try_create_shrreg() {
     LOG_DEBUG("Try create shrreg")
     if (region_info.fd == -1) {
@@ -1153,26 +1166,45 @@ void try_create_shrreg() {
                     MAJOR_VERSION, MINOR_VERSION,
                     region->major_version, region->minor_version);
         }
-        uint64_t local_limits[CUDA_DEVICE_MAX_COUNT];
-        do_init_device_memory_limits(local_limits, CUDA_DEVICE_MAX_COUNT);
-        int i;
-        for (i = 0; i < CUDA_DEVICE_MAX_COUNT; ++i) {
-            if (local_limits[i] != region->limit[i]) {
-                LOG_ERROR("Limit inconsistency detected for %dth device"
-                    ", %lu expected, get %lu", 
-                    i, local_limits[i], region->limit[i]);
+        /*
+         * when environment variables are stripped (fork+exec with cleaned env,
+         * ssh, su, systemd), skip the consistency check and adopt shared memory
+         * limits directly...prevents false ERROR logs when the child inherits
+         * limits correctly via mmap but has no env vars to compare against.
+         */
+        int mem_env_present = env_limit_family_present(CUDA_DEVICE_MEMORY_LIMIT);
+        int sm_env_present = env_limit_family_present(CUDA_DEVICE_SM_LIMIT);
+        if (mem_env_present) {
+            uint64_t local_limits[CUDA_DEVICE_MAX_COUNT];
+            do_init_device_memory_limits(local_limits, CUDA_DEVICE_MAX_COUNT);
+            int i;
+            for (i = 0; i < CUDA_DEVICE_MAX_COUNT; ++i) {
+                if (local_limits[i] != region->limit[i]) {
+                    LOG_ERROR("Limit inconsistency detected for %dth device"
+                        ", %lu expected, get %lu", 
+                        i, local_limits[i], region->limit[i]);
+                }
             }
+        } else {
+            LOG_INFO("Memory env vars stripped; adopting shared memory limits "
+                     "for pid=%d", getpid());
         }
-        do_init_device_sm_limits(local_limits,CUDA_DEVICE_MAX_COUNT);
-        for (i = 0; i < CUDA_DEVICE_MAX_COUNT; ++i) {
-            if (local_limits[i] != region->sm_limit[i]) {
-                LOG_INFO("SM limit inconsistency detected for %dth device"
-                    ", %lu expected, get %lu", 
-                    i, local_limits[i], region->sm_limit[i]);
-            //    exit(1); 
+        if (sm_env_present) {
+            uint64_t local_limits[CUDA_DEVICE_MAX_COUNT];
+            do_init_device_sm_limits(local_limits, CUDA_DEVICE_MAX_COUNT);
+            int i;
+            for (i = 0; i < CUDA_DEVICE_MAX_COUNT; ++i) {
+                if (local_limits[i] != region->sm_limit[i]) {
+                    LOG_INFO("SM limit inconsistency detected for %dth device"
+                        ", %lu expected, get %lu", 
+                        i, local_limits[i], region->sm_limit[i]);
+                }
             }
+        } else {
+            LOG_INFO("SM env vars stripped; adopting shared memory limits "
+                     "for pid=%d", getpid());
         }
-    }
+    } 
     region->last_kernel_time = region_info.last_kernel_time;
     if (lockf(fd, F_ULOCK, SHARED_REGION_SIZE_MAGIC) != 0) {
         LOG_ERROR("Fail to unlock shrreg %s: errno=%d", shr_reg_file, errno);


### PR DESCRIPTION
## Description

When a child process inherits `libvgpu.so` via `LD_PRELOAD` after `fork()`+`execve()` with a stripped environment (common with `ssh`, `su`, `systemd`, or custom process supervisors), the shared memory region already contains valid GPU limits from the parent. However, the existing code in `try_create_shrreg()` unconditionally runs a consistency check by re-reading environment variables into `local_limits[]` and comparing them against the shared memory values. When the environment is stripped, `getenv()` returns `NULL`, `local_limits[]` becomes all zeros, and the comparison triggers false `LOG_ERROR` spam about "Limit inconsistency detected."

This change detects when `CUDA_DEVICE_MEMORY_LIMIT` environment variables are absent and skips the consistency check, adopting the shared memory limits directly with an informative `LOG_INFO` message instead.

## Changes

- In `try_create_shrreg()`, wrap the `do_init_device_memory_limits()` / `do_init_device_sm_limits()` consistency check inside an `if (getenv(...) != NULL)` guard.
- If env vars are missing, log `LOG_INFO("Environment variables stripped; adopting shared memory limits for pid=%d", getpid())` and skip the check.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Normal parent with env vars | Consistency check runs, ERROR on mismatch | Unchanged |
| Child fork()+exec(), same SHM, env stripped | False ERROR logs (0 vs real limit) | Clean INFO log, adopts limits |
| Child cannot find SHM (path discovery bug) | Zero limits — **not fixed by this PR** | Still zero limits — tracked in #2125 |

## Backward Compatibility

Fully backward compatible. When env vars are present, behavior is identical. When absent, it avoids false ERROR logs instead of spamming the log.

## Related Issues

- Project-HAMi/HAMi#2125 : Fix GPU Memory Isolation for Child and SSH Processes
- Project-HAMi/HAMi#1090 : vGPU memory limit lost after SSH login
- Project-HAMi/HAMi#1112 : Child process does not inherit GPU memory limit

## Testing

- Local build attempted; requires CUDA toolkit for full test compilation (unavailable on my machine). The change is a conditional guard around existing logic with no control flow alterations.
- Code review: verified that `local_limits[]` array and loops remain scoped correctly inside the new `if` block.

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] This PR fixes a real issue (false ERROR logs) .
- [x] Related issues are linked above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of CUDA memory limits when configuration variables are unavailable.
  * Preserves inherited shared-memory limits when no applicable environment settings are defined.
  * Prevents unnecessary consistency checks for memory-limit settings that are not configured.
  * Added clearer informational logging to explain when inherited limits are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->