### PR TITLE
fix: forward untracked pointers to the driver on the synchronous free path

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -181,7 +181,10 @@ int remove_chunk(allocated_list *a_list, CUdeviceptr dptr) {
     CUdevice t_dev;
 
     if (a_list->length == 0) {
-        return -1;
+        /* Nothing tracked here, so the pointer was not allocated through this
+         * list. Forward the free to the real driver rather than returning -1
+         * (see the not-found path below). */
+        return cuMemoryFree(dptr);
     }
 
     pthread_mutex_lock(&mutex);
@@ -203,7 +206,12 @@ int remove_chunk(allocated_list *a_list, CUdeviceptr dptr) {
     }
 
     pthread_mutex_unlock(&mutex);
-    return -1;
+    /* Not tracked in this list (e.g. a stream-ordered allocation reaching the
+     * synchronous free path): forward the free to the real driver instead of
+     * returning -1, which leaves the allocation live and surfaces to the caller
+     * as an unrecognized CUresult. Mirrors the not-found path in
+     * remove_chunk_async. */
+    return cuMemoryFree(dptr);
 }
 
 int remove_chunk_only(CUdeviceptr dptr) {


### PR DESCRIPTION
## What this does

`remove_chunk` is the synchronous free path behind `cuMemFree_v2` -> `free_raw`. It returned `-1` without freeing when a pointer wasn't found in `device_overallocated`, both on the empty-list early return and on the loop not-found return. That `-1` propagates back through `free_raw` and the `cuMemFree_v2` hook, so freeing a pointer libvgpu didn't track leaves the memory live on the device and hands the caller a value that isn't a valid `CUresult`.

`remove_chunk_async` already forwards such frees to the real driver; its comment notes the old behavior "leaked and surfaced as an unrecognized error code". This applies the same fix to the synchronous path, using the existing `cuMemoryFree` helper that the found path already calls.

Fixes #257

## How a pointer reaches this path untracked

- a stream-ordered allocation (`cuMemAllocAsync`) freed with `cuMemFree` instead of `cuMemFreeAsync`
- an allocation made before tracking started

## Verification

The change reuses `cuMemoryFree(dptr)`, which `remove_chunk` already calls on its found path, so it adds no new dependency and is build-identical to existing code. I couldn't run a full build locally (it needs the CUDA toolkit); the Build libvgpu CI will confirm compilation.

I used AI assistance while reviewing the allocator . I read the code and the async twin's fix myself and take responsibility for the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup for untracked device-pointer allocations.
  * Device memory can now be freed correctly even when no matching allocation record exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->