### PR TITLE
fix(core): recover from SIGKILL race in unlock_shrreg()

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -787,6 +787,22 @@ void lock_shrreg() {
                 }
                 continue;  // slow wait path
             }
+            // RECOVERY: unlock_shrreg() race where owner_pid was cleared
+            // but sem_post() never executed (e.g., SIGKILL between the two)
+            if (current_owner == 0 && trials > 5) {
+                int sem_val;
+                if (sem_getvalue(&region->sem, &sem_val) == 0 && sem_val < 0) {
+                    LOG_WARN("Detected stuck semaphore with owner_pid == 0 "
+                             "(possible unlock race), forcing recovery post");
+                    if (sem_post(&region->sem) != 0) {
+                        LOG_ERROR("Forced sem_post failed: errno=%d", errno);
+                    } else {
+                        LOG_INFO("Recovered stuck semaphore successfully");
+                    }
+                }
+                usleep(10000);
+                continue;
+            }
 
             // If we're still waiting after many tries, something is seriously wrong
             if (trials > 30) {  // 30 × 10s = 5 minutes
@@ -812,7 +828,10 @@ void unlock_shrreg() {
 
     __sync_synchronize();
     region->owner_pid = 0;
-    // TODO: irregular exit here will hang pending locks
+    // NOTE: If SIGKILL arrives between owner_pid = 0 and sem_post(),
+    // the semaphore remains locked with no owner...recovery exists in
+    // lock_shrreg() which detects owner_pid == 0 after timeout and
+    // forces a sem_post() to unstick pending waiters.
     SEQ_POINT_MARK(SEQ_RESET_OWNER_OK);
 
     sem_post(&region->sem);


### PR DESCRIPTION
## Description

`unlock_shrreg()` has a microsecond race window between `owner_pid = 0` and `sem_post()`. If the kernel delivers SIGKILL in that window, the semaphore stays locked forever but `owner_pid` is already cleared. `lock_shrreg()` recovery only handled `current_owner != 0` (dead owner cleanup), so all waiting processes hung indefinitely.

This PR adds recovery for the `current_owner == 0` case after repeated timeouts, forcing a `sem_post()` to unstick the semaphore. It also replaces the vague `// TODO: irregular exit here will hang pending locks` with a proper comment.

## Changes

- `lock_shrreg()`: add `current_owner == 0 && trials > 5` recovery branch
- `unlock_shrreg()`: replace vague TODO with descriptive comment

## Why not swap sem_post() and owner_pid = 0?

If `sem_post()` runs first, a new acquirer can set `owner_pid` before the original unlocker clears it overwriting the legitimate owner. Recovery in the waiter is the safe design.

## Related
- Project-HAMi/HAMi #2500 : TODO issue in main repo
- Project-HAMi/HAMi #2125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from rare shared-memory locking races.
  * Prevented repeated timeouts when a stale lock is detected.
  * Improved reliability when acquiring and releasing shared resources.
  * Added safeguards to restore normal operation after interrupted processes.
  * Improved error reporting and recovery handling for lock-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->