### PR TITLE
fix: build on current toolchains (GCC 15/C23, CMake 4.x)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.18)
 
 project(libvgpu)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.18)
 project (libvgpu)
 
 

--- a/src/include/libcuda_hook.h
+++ b/src/include/libcuda_hook.h
@@ -30,10 +30,13 @@ typedef CUresult (*cuda_sym_t)();
 
 #define CUDA_FIND_ENTRY(table, sym) ({ (table)[CUDA_OVERRIDE_ENUM(sym)].fn_ptr; })
 
+/* Call through the hooked symbol's real function type.  An empty parameter
+ * list "()" declares a zero-argument prototype in C23 (making these calls a
+ * compile error with e.g. gcc 15), and was unchecked in older C anyway. */
 #define CUDA_OVERRIDE_CALL(table, sym, ...)                                    \
   ({    \
     LOG_DEBUG("Hijacking %s", #sym);                                           \
-    cuda_sym_t _entry = (cuda_sym_t)CUDA_FIND_ENTRY(table, sym);               \
+    typeof(&sym) _entry = (typeof(&sym))CUDA_FIND_ENTRY(table, sym);           \
     if (_entry == NULL) {                                                      \
       LOG_ERROR("Hijack failed: %s is NULL", #sym);                            \
     }                                                                          \

--- a/src/include/libnvml_hook.h
+++ b/src/include/libnvml_hook.h
@@ -24,16 +24,19 @@ typedef nvmlReturn_t (*driver_sym_t)();
 
 #define NVML_FIND_ENTRY(table, sym) ({ (table)[NVML_OVERRIDE_ENUM(sym)].fn_ptr; })
 
+/* Call through the hooked symbol's real function type.  An empty parameter
+ * list "()" declares a zero-argument prototype in C23 (making these calls a
+ * compile error with e.g. gcc 15), and was unchecked in older C anyway. */
 #define NVML_OVERRIDE_CALL(table, sym, ...)                                    \
   ({                                                                           \
     LOG_DEBUG("Hijacking %s", #sym);                                           \
-    driver_sym_t _entry = NVML_FIND_ENTRY(table, sym);                         \
+    typeof(&sym) _entry = (typeof(&sym))NVML_FIND_ENTRY(table, sym);           \
     _entry(__VA_ARGS__);                                                       \
   })
 
 #define NVML_OVERRIDE_CALL_NO_LOG(table, sym, ...)                             \
   ({                                                                           \
-    driver_sym_t _entry = NVML_FIND_ENTRY(table, sym);                         \
+    typeof(&sym) _entry = (typeof(&sym))NVML_FIND_ENTRY(table, sym);           \
     _entry(__VA_ARGS__);                                                       \
   })
 

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -265,7 +265,8 @@ int get_used_gpu_utilization(int *userutil,int *sysprocnum) {
     return 0;
 }
 
-void* utilization_watcher() {
+void* utilization_watcher(void *arg) {
+    (void)arg;
     nvmlInit();
     int userutil[CUDA_DEVICE_MAX_COUNT];
     int sysprocnum;

--- a/src/multiprocess/multiprocess_utilization_watcher.h
+++ b/src/multiprocess/multiprocess_utilization_watcher.h
@@ -19,5 +19,5 @@ static const struct timespec g_wait = {
 
 void rate_limiter(int grids, int blocks);
 void init_utilization_watcher();
-void* utilization_watcher();
+void* utilization_watcher(void *arg);
 int setspec();

--- a/src/nvml/hook.c
+++ b/src/nvml/hook.c
@@ -6,6 +6,13 @@
 #include "include/utils.h"
 #include "multiprocess/multiprocess_memory_limit.h"
 
+/* Forward declarations for hooked entry points that NVML_OVERRIDE_CALL
+ * references (via typeof) before their definitions below. */
+nvmlReturn_t nvmlInit_v2(void);
+nvmlReturn_t nvmlDeviceGetCount_v2(unsigned int *deviceCount);
+nvmlReturn_t nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *memory);
+nvmlReturn_t nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device, nvmlMemory_v2_t *memory);
+
 entry_t nvml_library_entry[] = {
     {.name = "nvmlInit"},
     {.name = "nvmlShutdown"},

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,13 @@
 
-find_package(CUDA REQUIRED)
+# The FindCUDA module was deprecated in CMake 3.10 and is removed under
+# policy CMP0146 (CMake >= 3.27).  Use first-class CUDA language support
+# plus FindCUDAToolkit instead.
+enable_language(CUDA)
+find_package(CUDAToolkit REQUIRED)
+
+# Match the previous behavior of linking the shared CUDA runtime
+# (-lcudart) rather than the static default of the CUDA language support.
+set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
 
 set(TEST_CPP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(TEST_TARGET_NAMES_LIST) 
@@ -28,7 +36,7 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
         set_target_properties(${TEST_TARGET_NAME} PROPERTIES
             LINK_FLAGS "-Wl,--no-export-dynamic,--gc-sections")
     elseif (TEST_SCRIPT MATCHES ".*cu")
-        cuda_add_executable(${TEST_TARGET_NAME}  ${TEST_SCRIPT})
+        add_executable(${TEST_TARGET_NAME}  ${TEST_SCRIPT})
     else()
         add_executable(${TEST_TARGET_NAME}  ${TEST_SCRIPT})
     endif()
@@ -38,7 +46,7 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     else()
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread
-            -lnvidia-ml -lcuda -lcudart -L${CUDA_HOME}/lib64)
+            -lnvidia-ml CUDA::cuda_driver CUDA::cudart)
     endif()
     target_compile_options(${TEST_TARGET_NAME} PUBLIC ${TEST_COMPILE_FLAGS})
 


### PR DESCRIPTION
Fixes #262

## What changed

- Call CUDA and NVML hook entries through each symbol's real function type (`typeof(&sym)`) instead of a common empty-parameter function pointer type. This restores C23 compatibility and provides argument type checking.
- Add the four declarations required where hooked NVML wrappers are referenced before their definitions, and give `utilization_watcher` the `void *arg` parameter required by `pthread_create`.
- Raise the top-level and `src/` CMake minimum versions from 2.8.x to 3.18.
- Replace the test build's deprecated FindCUDA usage with first-class CUDA language support and FindCUDAToolkit imported targets. Shared `cudart` linkage and nvcc's default architecture selection are preserved.

## Why

GCC 15 defaults to C23, where an empty function parameter list `()` is a zero-argument prototype rather than an unspecified-parameter declaration. The existing dispatch typedefs therefore produce 451 errors when the hook macros pass real CUDA or NVML arguments; the watcher callback mismatch adds one more error.

CMake 4 also rejects the project's 2.8.x minimum versions, and the test build still relies on FindCUDA, which is deprecated and removed under CMP0146's new behavior. CMake 3.18 was selected for the CMP0104 CUDA architecture behavior; the current UBI8 build image provides CMake 3.26.5.

## Validation

Current clean build:

- Ubuntu 26.04, GCC 15.2.0, CMake 4.2.3, CUDA toolkit 13.3
- NVIDIA GeForce RTX 3060 12 GB, driver 595.84
- `build.sh`: exit 0, no compiler errors
- `build/libvgpu.so`: produced
- all 19 test targets built, including both CUDA test targets
- 38 warnings

Additional validation of the same patch:

- `hack/check_cuda_hook_consistency.py`: PASS (`entries=211`, `wrappers=217`)
- `ctest`: `postinit_owner_death` passed (1/1)
- Earlier LD_PRELOAD smoke tests on the same RTX 3060 (driver 595.71.05): `test_alloc`, `test_runtime_launch`, and `test_multi_gpu_utilization` exited successfully; `test_alloc` enforced the configured 2 GiB limit

The warning count increases from 28 on `main` built with a GNU C17 workaround to 38. The ten new warnings are all `-Wdeprecated-declarations` because the typed references expose deprecation attributes on CUDA APIs that HAMi-core already wraps.

## AI assistance disclosure

AI assistance was used to help reproduce the failures, prepare the patch, and draft this description. I reviewed every hunk, can explain the changes, and rebuilt the patch from a clean directory on my own hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Compatibility**
  * Updated the minimum supported CMake version to 3.18.
  * Modernized CUDA test configuration and runtime linking.

* **Bug Fixes**
  * Improved CUDA and NVML hook calls to preserve accurate function signatures.
  * Fixed compatibility for functions with no arguments.
  * Updated watcher-thread callbacks to use the expected argument format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->