### PR TITLE
fix(utils): prevent unsigned integer underflow in getextrapid

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -79,7 +79,7 @@ int getextrapid(unsigned int prev, unsigned int current, nvmlProcessInfo_t1 *pre
     for (i=0; i< current; i++) {
         LOG_INFO("current pids[%d]=%d",i,pids_on_device[i].pid);
     }
-    if (current-prev<=0)
+    if (current <= prev)
         return 0;
     for (i=0; i<current; i++) {
         found = 0;


### PR DESCRIPTION
### Description

**Fixes #264**

This PR fixes a silent logic error in `getextrapid()` caused by an unsigned integer underflow. 

**The Bug:**
In `libvgpu/src/utils.c`, the `getextrapid()` function takes `unsigned int prev` and `unsigned int current` as arguments and attempts to check if the current process count is less than or equal to the previous count using the logic: `if (current - prev <= 0)`.

Because both variables are unsigned integers, if `current` is strictly less than `prev` (e.g., if a background GPU process exits between NVML probes, making `current=5` and `prev=6`), the subtraction `current - prev` underflows and wraps around to a massive positive integer (e.g., `4294967295`). 

As a result, the `<= 0` condition fails when it is logically intended to succeed, causing the function to incorrectly fall through and execute the loop logic.

**The Fix:**
Updated the condition to safely compare unsigned integers without subtraction: `if (current <= prev)`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Verification
- Confirmed the C behavior of `unsigned int` underflow locally. 
- The logic change is mathematically identical for positive numbers but safe from underflow.

---
*Note: I used an AI assistant to help trace this integer underflow behavior, but the final solution and testing were authored and verified manually.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process-count handling so no extra process ID is returned when the current count has not increased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->