### PR TITLE
fix(utils): prevent global buffer overflow in parse_cuda_visible_env

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -182,6 +182,10 @@ int parse_cuda_visible_env() {
     if (need_cuda_virtualize()) {
         for (int i = 0; i < strlen(s); i++) {
             if ((s[i] == ',') || (i == 0)) {
+                if (count >= CUDA_DEVICE_MAX_COUNT) {
+                    LOG_ERROR("CUDA_VISIBLE_DEVICES exceeds max count");
+                    break;
+                }
                 int tmp = (i==0) ? atoi(s) : atoi(s + i +1);
                 cuda_to_nvml_map_array[count] = tmp; 
                 count++;


### PR DESCRIPTION
### Description

**Fixes #266** *(Note: please update this number to your actual issue number!)*

This PR fixes a global buffer overflow vulnerability in `parse_cuda_visible_env()` caused by missing array bounds checking.

**The Bug:**
In `libvgpu/src/utils.c`, `parse_cuda_visible_env()` iterates over the `CUDA_VISIBLE_DEVICES` environment variable string and stores parsed device IDs into `cuda_to_nvml_map_array`. 

Because `cuda_to_nvml_map_array` is defined globally with a strict capacity of `CUDA_DEVICE_MAX_COUNT` (16), parsing an environment variable containing more than 16 comma-separated items caused the loop to write past the end of the array, silently corrupting adjacent global memory.

**The Fix:**
Added a boundary check inside the loop to ensure the index `count` never exceeds `CUDA_DEVICE_MAX_COUNT`. If it hits the maximum allowed devices, it logs an error and breaks out of the loop safely.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

### Verification
- Confirmed the global buffer overflow mechanism locally using C
- Verified that the new `break` condition safely exits before the 17th write.

---
*Note: I used an AI assistant to help trace this global buffer overflow behavior, but the final solution and testing were authored and verified manually.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configurations with more visible devices than supported.
  * Prevented excess device entries from being processed and reported an error instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->