### PR TITLE
fix: use CUDA_DEVICE_MAX_COUNT for ctx_activate declaration

### DIFF
--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -2,7 +2,7 @@
 #include "multiprocess/multiprocess_memory_limit.h"
 
 extern size_t context_size;
-extern int ctx_activate[16];
+extern int ctx_activate[CUDA_DEVICE_MAX_COUNT];
 
 
 CUresult cuDevicePrimaryCtxGetState( CUdevice dev, unsigned int* flags, int* active ){

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -43,7 +43,7 @@ _Static_assert(POSTINIT_FILE_LOCK_OFFSET > (off_t)sizeof(shared_region_t),
 
 int pidfound;
 
-int ctx_activate[32];
+int ctx_activate[CUDA_DEVICE_MAX_COUNT];
 
 static shared_region_info_t region_info = {0, -1, PTHREAD_ONCE_INIT, NULL, 0, NULL};
 static atomic_flag postinit_local_lock = ATOMIC_FLAG_INIT;


### PR DESCRIPTION
`ctx_activate` is defined as `int[32]` in `multiprocess_memory_limit.c` but declared `extern int[16]` in `cuda/context.c`. Incompatible declarations of the same object are undefined behaviour, and it's the kind of mismatch LTO builds and newer compilers diagnose — relevant given #262.

Every other per-device array in the tree is sized with `CUDA_DEVICE_MAX_COUNT` and the device loops bound on it, so this uses the constant in both places instead of either magic number. `context.c` already includes the header that defines it.

No behaviour change: nothing indexes `ctx_activate` above `CUDA_DEVICE_MAX_COUNT`.