### PR TITLE
fix: scale utilization watcher correction step linearly with SM count

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -86,13 +86,27 @@ static void change_token(int64_t delta, int device_id) {
 static int64_t delta(int up_limit, int user_current, int64_t share, int device_id) {
   int utilization_diff =
       abs(up_limit - user_current) < 5 ? 5 : abs(up_limit - user_current);
+  /* Scale the correction step linearly with the device's compute size.
+   * The previous sm_num * sm_num factor grows quadratically with the SM
+   * count relative to the pool (pool = sm_num * max_thread * 32, so the
+   * step/pool ratio is sm_num * diff / 81920). On 188 SMs a large error
+   * plus the acceleration branch reached ~2M tokens per 120ms tick and
+   * refilled the ~9.2M pool in under a second, while draining it took
+   * minutes -- the controller degenerated into a bang-bang loop whose ON
+   * phase ran at ~100% utilization for minutes. */
   int64_t increment =
-      (int64_t)g_sm_num[device_id] * (int64_t)g_sm_num[device_id] *
+      (int64_t)g_sm_num[device_id] *
       (int64_t)g_max_thread_per_sm[device_id] * (int64_t)utilization_diff / 2560;
 
   /* Accelerate cuda cores allocation when utilization vary widely */
   if (utilization_diff > up_limit / 2) {
     increment = increment * utilization_diff * 2 / (up_limit + 1);
+  }
+
+  /* Bound a single correction step so even very large devices converge in
+   * measured steps instead of saturating the pool in one tick. */
+  if (increment > g_total_cuda_cores[device_id] / 10) {
+    increment = g_total_cuda_cores[device_id] / 10;
   }
 
   if (user_current <= up_limit) {
@@ -190,7 +204,10 @@ int setspec() {
             CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, cu_dev));
         CHECK_CU_RESULT(cuDeviceGetAttribute(&g_max_thread_per_sm[dev],
             CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR, cu_dev));
-        g_total_cuda_cores[dev] = g_max_thread_per_sm[dev] * g_sm_num[dev] * FACTOR;
+        /* Promote to int64_t before multiplying — an int product could
+         * overflow on very large future devices and a wrapped total would
+         * corrupt the per-tick correction cap derived from it. */
+        g_total_cuda_cores[dev] = (int64_t)g_max_thread_per_sm[dev] * g_sm_num[dev] * FACTOR;
         LOG_INFO("setspec: device %d sm_num=%d max_threads_per_sm=%d total_cores=%ld FACTOR=%d",
                  dev, g_sm_num[dev], g_max_thread_per_sm[dev], g_total_cuda_cores[dev], FACTOR);
     }


### PR DESCRIPTION
## Problem

On high-SM GPUs the SM utilization limiter (`CUDA_DEVICE_SM_LIMIT` + utilization watcher) is effectively inert: under sustained load the process runs at 99-100% utilization for minutes at a time regardless of the configured limit.

Observed on an NVIDIA RTX PRO 6000 Blackwell Server Edition (188 SMs, `maxThreadsPerSM=1536`), driver 580.173.02, CUDA 13 / PyTorch 2.13, HAMi-core at `5496322`, env `CUDA_DEVICE_SM_LIMIT=50` + `GPU_CORE_UTILIZATION_POLICY=FORCE`. The machinery itself is engaged (hostPid discovered, `util_switch=1`, `limit=50` cached, `rate_limiter()` reached from `cuLaunchKernelEx`).

## Root cause

In `delta()` the correction step scales with `sm_num * sm_num`, while the token pool (`g_total_cuda_cores = sm_num * max_thread_per_sm * 32`) scales linearly — so the step-to-pool ratio grows with the SM count (`sm_num * diff / 81920` per 120 ms tick). On 188 SMs a large utilization error plus the acceleration branch produces ~2M tokens per tick and refills the ~9.2M pool in under a second, while draining it under load takes minutes. The controller degenerates into a bang-bang cycle whose ON phase runs at ~100% for minutes.

Watcher samples under a sustained matmul load, one line per minute (**before**):

| t | userutil | g_cur_cuda_cores |
|---|---|---|
| m1 | 99 | 3,984,504 |
| m2 | 99 | 1,746,792 |
| m3 | 48 | 5,012,008 (refilled) |
| m4-m11 | mostly 99 | oscillating 1.2M-8.9M |
| m12 | 81 | -4,096 → limiter finally blocks, device util drops to 17% |
| m13 | 99 | 5,762,893 (refilled again) |

Time-averaged utilization stays near 100%. Any workload with idle gaps shorter than the drain time never sees throttling at all.

## Fix

- Scale the step linearly with the SM count. The step-to-pool ratio becomes `diff / 81920` — independent of the device size, so small and large GPUs get identical controller dynamics.
- Additionally clamp a single step to one tenth of the pool as a guard for very large future devices.

Memory limiting and all hook paths are untouched; only the numbers fed to `change_token()` change.

## Result with this patch (same GPU, same load, 20 s samples)

| t | device util | userutil | share |
|---|---|---|---|
| 20s | 53% | 45 | 17,742 |
| 40s | 40% | 49 | 21,024 |
| 60s | 40% | 52 | 16,068 |
| 80s | 58% | 51 | 17,202 |
| 100s | 29% | 41 | 18,331 |
| 120s | 50% | 50 | 18,449 |

Converges to the configured 50% within ~20 seconds and holds a small oscillation band, instead of minutes-long 100% phases.

Happy to run additional tests on this hardware if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved utilization correction behavior across devices with different GPU sizes.
  * Adjustments now scale consistently with available hardware capacity.
  * Added safeguards to prevent individual corrections from becoming disproportionately large.
  * Improved stability when calculating corrections on devices with high core counts.
  * Existing utilization-based acceleration behavior remains unchanged.
  * These updates provide more predictable performance across a wider range of GPU configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->