### PR TITLE
fix: prevent cross-process GPU memory overcommit on concurrent cuMemAlloc. 

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -71,24 +71,8 @@ size_t round_up(size_t size, size_t unit) {
     return size;
 }
 
-int reserve_device_memory(CUdevice dev, size_t size) {
-    lock_shrreg();
-    if (oom_check(dev, size)) {
-        unlock_shrreg();
-        return CUDA_ERROR_OUT_OF_MEMORY;
-    }
-    add_gpu_device_memory_usage(getpid(), dev, size, 2);
-    unlock_shrreg();
-    return 0;
-}
-
-void release_device_memory(CUdevice dev, size_t size) {
-    lock_shrreg();
-    rm_gpu_device_memory_usage(getpid(), dev, size, 2);
-    unlock_shrreg();
-}
-
-int oom_check(const int dev, size_t addon) {
+/* already_locked: caller already holds lock_shrreg (not reentrant). */
+static int oom_check_impl(const int dev, size_t addon, int already_locked) {
     CUdevice d;
     if (dev==-1)
         cuCtxGetDevice(&d);
@@ -104,16 +88,43 @@ int oom_check(const int dev, size_t addon) {
     size_t new_allocated = _usage + addon;
     LOG_INFO("_usage=%lu limit=%lu new_allocated=%lu",_usage,limit,new_allocated);
     if (new_allocated > limit) {
+        int cleared;
+
         LOG_ERROR("Device %d OOM %lu / %lu", d, new_allocated, limit);
 
-        lock_shrreg();
-        int cleared = clear_proc_slot_nolock(1);
-        unlock_shrreg();
+        if (already_locked) {
+            cleared = clear_proc_slot_nolock(1);
+        } else {
+            lock_shrreg();
+            cleared = clear_proc_slot_nolock(1);
+            unlock_shrreg();
+        }
         if (cleared > 0)
-            return oom_check(dev,addon);
+            return oom_check_impl(dev, addon, already_locked);
         return 1;
     }
     return 0;
+}
+
+int oom_check(const int dev, size_t addon) {
+    return oom_check_impl(dev, addon, 0);
+}
+
+int reserve_device_memory(CUdevice dev, size_t size) {
+    lock_shrreg();
+    if (oom_check_impl(dev, size, 1)) {
+        unlock_shrreg();
+        return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    add_gpu_device_memory_usage(getpid(), dev, size, 2);
+    unlock_shrreg();
+    return 0;
+}
+
+void release_device_memory(CUdevice dev, size_t size) {
+    lock_shrreg();
+    rm_gpu_device_memory_usage(getpid(), dev, size, 2);
+    unlock_shrreg();
 }
 
 CUresult view_vgpu_allocator() {

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -33,8 +33,8 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
  * Env: HAMI_ALLOC_RACE_WINDOW_US=<microseconds>, unset/0 = no delay. */
 static void maybe_widen_alloc_race_window(void) {
     const char *env = getenv("HAMI_ALLOC_RACE_WINDOW_US");
-    unsigned long us;
-    unsigned long sec;
+    uint64_t us;
+    uint64_t sec;
     char *end = NULL;
     struct timespec ts;
 
@@ -49,10 +49,10 @@ static void maybe_widen_alloc_race_window(void) {
     /* nanosleep supports >=1s; also avoids useconds_t truncation (e.g. 2^32 -> 0). */
     sec = us / 1000000UL;
     ts.tv_sec = (time_t)sec;
-    if ((unsigned long)ts.tv_sec != sec) {
+    if ((uint64_t)ts.tv_sec != sec) {
         return;
     }
-    ts.tv_nsec = (long)((us % 1000000UL) * 1000UL);
+    ts.tv_nsec = (int64_t)((us % 1000000UL) * 1000UL);
     (void)nanosleep(&ts, NULL);
 }
 

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -27,9 +27,9 @@ extern CUresult cuMemoryFree(CUdeviceptr dptr);
 pthread_once_t allocator_allocate_flag = PTHREAD_ONCE_INIT;
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
-/* Optional delay after the unlocked oom pre-check in add_chunk.
- * Used only by the race-reproduce harness to widen the TOCTOU window
- * between check and usage accounting across processes.
+/* Optional delay after reservation, before the expensive CUDA alloc.
+ * With reserve-then-alloc this only stretches the CUDA window; shared usage
+ * is already committed so a concurrent peer must OOM.
  * Env: HAMI_ALLOC_RACE_WINDOW_US=<microseconds>, unset/0 = no delay. */
 static void maybe_widen_alloc_race_window(void) {
     const char *env = getenv("HAMI_ALLOC_RACE_WINDOW_US");
@@ -50,6 +50,23 @@ size_t round_up(size_t size, size_t unit) {
     if (size & (unit-1))
         return ((size / unit) + 1 ) * unit;
     return size;
+}
+
+int reserve_device_memory(CUdevice dev, size_t size) {
+    lock_shrreg();
+    if (oom_check(dev, size)) {
+        unlock_shrreg();
+        return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    add_gpu_device_memory_usage(getpid(), dev, size, 2);
+    unlock_shrreg();
+    return 0;
+}
+
+void release_device_memory(CUdevice dev, size_t size) {
+    lock_shrreg();
+    rm_gpu_device_memory_usage(getpid(), dev, size, 2);
+    unlock_shrreg();
 }
 
 int oom_check(const int dev, size_t addon) {
@@ -134,8 +151,10 @@ int add_chunk(CUdeviceptr *address, size_t size) {
 
     cuCtxGetDevice(&dev);
 
-    /* OOM pre-check without lock */
-    if (oom_check(dev, size))
+    /* Reserve under the shared-region lock so concurrent processes cannot
+     * both pass oom_check before either commits usage. CUDA alloc stays
+     * outside the lock. */
+    if (reserve_device_memory(dev, size) != 0)
         return CUDA_ERROR_OUT_OF_MEMORY;
 
     maybe_widen_alloc_race_window();
@@ -148,44 +167,28 @@ int add_chunk(CUdeviceptr *address, size_t size) {
     }
     if (res != CUDA_SUCCESS) {
         LOG_ERROR("cuMemoryAllocate failed res=%d", res);
+        release_device_memory(dev, size);
         return res;
     }
 
-    /* Tracking inside lock, pure in-memory ops, microseconds */
+    /* Local list tracking only — usage already reserved */
     pthread_mutex_lock(&mutex);
-
-    if (oom_check(dev, size)) {
-        /* Another process consumed memory between our pre-check and now */
-        pthread_mutex_unlock(&mutex);
-        CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemFree_v2, *address);
-        return CUDA_ERROR_OUT_OF_MEMORY;
-    }
-
     allocated_list_entry *e;
     INIT_ALLOCATED_LIST_ENTRY(e, 0, size, dev);
     e->entry->address = *address;
     LIST_ADD(device_overallocated, e);
-    add_gpu_device_memory_usage(getpid(), dev, size, 2);
-
     pthread_mutex_unlock(&mutex);
     return 0;
 }
 
+/* Track a pointer in the local list. Caller must already have reserved
+ * `size` via reserve_device_memory() (or equivalent usage accounting). */
 int add_chunk_only(CUdeviceptr address, size_t size, CUdevice dev) {
     pthread_mutex_lock(&mutex);
-    size_t addr=0;
-    size_t allocsize;
-    if (oom_check(dev,size)){
-        pthread_mutex_unlock(&mutex);
-        return -1;
-    }
     allocated_list_entry *e;
-    INIT_ALLOCATED_LIST_ENTRY(e, addr, size, dev);
-    LIST_ADD(device_overallocated,e);
-    //uint64_t t_size;
-    e->entry->address=address;
-    allocsize = size;
-    add_gpu_device_memory_usage(getpid(), dev, allocsize, 2);
+    INIT_ALLOCATED_LIST_ENTRY(e, 0, size, dev);
+    e->entry->address = address;
+    LIST_ADD(device_overallocated, e);
     pthread_mutex_unlock(&mutex);
     return 0;
 }

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -34,16 +34,26 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 static void maybe_widen_alloc_race_window(void) {
     const char *env = getenv("HAMI_ALLOC_RACE_WINDOW_US");
     unsigned long us;
+    unsigned long sec;
     char *end = NULL;
+    struct timespec ts;
 
     if (env == NULL || env[0] == '\0') {
         return;
     }
+    errno = 0;
     us = strtoul(env, &end, 10);
-    if (end == env || us == 0) {
+    if (end == env || *end != '\0' || errno == ERANGE || us == 0) {
         return;
     }
-    usleep((useconds_t)us);
+    /* nanosleep supports >=1s; also avoids useconds_t truncation (e.g. 2^32 -> 0). */
+    sec = us / 1000000UL;
+    ts.tv_sec = (time_t)sec;
+    if ((unsigned long)ts.tv_sec != sec) {
+        return;
+    }
+    ts.tv_nsec = (long)((us % 1000000UL) * 1000UL);
+    (void)nanosleep(&ts, NULL);
 }
 
 size_t round_up(size_t size, size_t unit) {
@@ -145,9 +155,21 @@ void allocator_init() {
     pthread_mutex_init(&mutex,NULL);
 }
 
+/* Wrap INIT_ALLOCATED_LIST_ENTRY so QUIT_WITH_ERROR returns here, not from
+ * callers that hold mutex / CUDA memory / shared reservations. */
+static int new_allocated_list_entry(allocated_list_entry **out,
+                                    CUdeviceptr address, size_t size,
+                                    CUdevice dev) {
+    allocated_list_entry *e;
+    INIT_ALLOCATED_LIST_ENTRY(e, address, size, dev);
+    *out = e;
+    return 0;
+}
+
 int add_chunk(CUdeviceptr *address, size_t size) {
     CUdevice dev;
     CUresult res;
+    allocated_list_entry *e;
 
     cuCtxGetDevice(&dev);
 
@@ -173,8 +195,12 @@ int add_chunk(CUdeviceptr *address, size_t size) {
 
     /* Local list tracking only — usage already reserved */
     pthread_mutex_lock(&mutex);
-    allocated_list_entry *e;
-    INIT_ALLOCATED_LIST_ENTRY(e, 0, size, dev);
+    if (new_allocated_list_entry(&e, 0, size, dev) != 0) {
+        pthread_mutex_unlock(&mutex);
+        cuMemoryFree(*address);
+        release_device_memory(dev, size);
+        return -1;
+    }
     e->entry->address = *address;
     LIST_ADD(device_overallocated, e);
     pthread_mutex_unlock(&mutex);
@@ -184,9 +210,13 @@ int add_chunk(CUdeviceptr *address, size_t size) {
 /* Track a pointer in the local list. Caller must already have reserved
  * `size` via reserve_device_memory() (or equivalent usage accounting). */
 int add_chunk_only(CUdeviceptr address, size_t size, CUdevice dev) {
-    pthread_mutex_lock(&mutex);
     allocated_list_entry *e;
-    INIT_ALLOCATED_LIST_ENTRY(e, 0, size, dev);
+
+    pthread_mutex_lock(&mutex);
+    if (new_allocated_list_entry(&e, 0, size, dev) != 0) {
+        pthread_mutex_unlock(&mutex);
+        return -1;
+    }
     e->entry->address = address;
     LIST_ADD(device_overallocated, e);
     pthread_mutex_unlock(&mutex);

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -27,44 +27,6 @@ extern CUresult cuMemoryFree(CUdeviceptr dptr);
 pthread_once_t allocator_allocate_flag = PTHREAD_ONCE_INIT;
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
-/* Optional delay after reservation, before the expensive CUDA alloc.
- * With reserve-then-alloc this only stretches the CUDA window; shared usage
- * is already committed so a concurrent peer must OOM.
- * Env: HAMI_ALLOC_RACE_WINDOW_US=<microseconds>, unset/0 = no delay. */
-static void maybe_widen_alloc_race_window(void) {
-    const char *env = getenv("HAMI_ALLOC_RACE_WINDOW_US");
-    const char *p;
-    uint64_t us;
-    uint64_t sec;
-    char *end = NULL;
-    struct timespec ts;
-
-    if (env == NULL || env[0] == '\0') {
-        return;
-    }
-    p = env;
-    while (isspace((unsigned char)*p)) {
-        p++;
-    }
-    /* strtoull("-1") becomes UINT64_MAX without ERANGE. */
-    if (*p == '\0' || *p == '-') {
-        return;
-    }
-    errno = 0;
-    us = strtoull(p, &end, 10);
-    if (end == p || *end != '\0' || errno == ERANGE || us == 0) {
-        return;
-    }
-    /* nanosleep supports >=1s; also avoids useconds_t truncation (e.g. 2^32 -> 0). */
-    sec = us / 1000000UL;
-    ts.tv_sec = (time_t)sec;
-    if ((uint64_t)ts.tv_sec != sec) {
-        return;
-    }
-    ts.tv_nsec = (int64_t)((us % 1000000UL) * 1000UL);
-    (void)nanosleep(&ts, NULL);
-}
-
 size_t round_up(size_t size, size_t unit) {
     if (size & (unit-1))
         return ((size / unit) + 1 ) * unit;
@@ -198,8 +160,6 @@ int add_chunk(CUdeviceptr *address, size_t size) {
      * outside the lock. */
     if (reserve_device_memory(dev, size) != 0)
         return CUDA_ERROR_OUT_OF_MEMORY;
-
-    maybe_widen_alloc_race_window();
 
     /* GPU allocation outside lock, the expensive part */
     if (size <= IPCSIZE) {

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -27,6 +27,25 @@ extern CUresult cuMemoryFree(CUdeviceptr dptr);
 pthread_once_t allocator_allocate_flag = PTHREAD_ONCE_INIT;
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
+/* Optional delay after the unlocked oom pre-check in add_chunk.
+ * Used only by the race-reproduce harness to widen the TOCTOU window
+ * between check and usage accounting across processes.
+ * Env: HAMI_ALLOC_RACE_WINDOW_US=<microseconds>, unset/0 = no delay. */
+static void maybe_widen_alloc_race_window(void) {
+    const char *env = getenv("HAMI_ALLOC_RACE_WINDOW_US");
+    unsigned long us;
+    char *end = NULL;
+
+    if (env == NULL || env[0] == '\0') {
+        return;
+    }
+    us = strtoul(env, &end, 10);
+    if (end == env || us == 0) {
+        return;
+    }
+    usleep((useconds_t)us);
+}
+
 size_t round_up(size_t size, size_t unit) {
     if (size & (unit-1))
         return ((size / unit) + 1 ) * unit;
@@ -118,6 +137,8 @@ int add_chunk(CUdeviceptr *address, size_t size) {
     /* OOM pre-check without lock */
     if (oom_check(dev, size))
         return CUDA_ERROR_OUT_OF_MEMORY;
+
+    maybe_widen_alloc_race_window();
 
     /* GPU allocation outside lock, the expensive part */
     if (size <= IPCSIZE) {

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -33,6 +33,7 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
  * Env: HAMI_ALLOC_RACE_WINDOW_US=<microseconds>, unset/0 = no delay. */
 static void maybe_widen_alloc_race_window(void) {
     const char *env = getenv("HAMI_ALLOC_RACE_WINDOW_US");
+    const char *p;
     uint64_t us;
     uint64_t sec;
     char *end = NULL;
@@ -41,9 +42,17 @@ static void maybe_widen_alloc_race_window(void) {
     if (env == NULL || env[0] == '\0') {
         return;
     }
+    p = env;
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+    /* strtoull("-1") becomes UINT64_MAX without ERANGE. */
+    if (*p == '\0' || *p == '-') {
+        return;
+    }
     errno = 0;
-    us = strtoul(env, &end, 10);
-    if (end == env || *end != '\0' || errno == ERANGE || us == 0) {
+    us = strtoull(p, &end, 10);
+    if (end == p || *end != '\0' || errno == ERANGE || us == 0) {
         return;
     }
     /* nanosleep supports >=1s; also avoids useconds_t truncation (e.g. 2^32 -> 0). */

--- a/src/allocator/allocator.h
+++ b/src/allocator/allocator.h
@@ -156,6 +156,13 @@ CUresult view_vgpu_allocator();
 // Checks if oom
 int oom_check(const int dev,size_t addon);
 
+/* Cross-process check-and-reserve under lock_shrreg.
+ * Returns 0 on success, CUDA_ERROR_OUT_OF_MEMORY if the limit would be exceeded.
+ * On success, size is already accounted in shared usage; call
+ * release_device_memory() if the subsequent CUDA alloc fails. */
+int reserve_device_memory(CUdevice dev, size_t size);
+void release_device_memory(CUdevice dev, size_t size);
+
 // Allocate and free device memory
 int allocate_raw(CUdeviceptr *dptr, size_t size);
 int free_raw(CUdeviceptr dptr);

--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -163,6 +163,7 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInByt
     size_t guess_pitch = (ElementSizeBytes == 0 || WidthInBytes == 0) ? 0 :
         (((WidthInBytes - 1) / ElementSizeBytes) + 1) * ElementSizeBytes;
     size_t bytesize = guess_pitch * Height;
+    size_t actual;
     ENSURE_RUNNING();
     CUdevice dev;
     CHECK_DRV_API(cuCtxGetDevice(&dev));
@@ -170,12 +171,32 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInByt
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAllocPitch_v2, dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
-    if (res == CUDA_SUCCESS) {
-        add_chunk_only(*dptr, bytesize, dev);
-    } else {
+    if (res != CUDA_SUCCESS) {
         release_device_memory(dev, bytesize);
+        return res;
     }
-    return res;
+    /* Driver pitch may exceed guess_pitch due to alignment; account for real size. */
+    if (Height != 0 && pPitch != NULL && *pPitch > SIZE_MAX / Height) {
+        CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemFree_v2, *dptr);
+        release_device_memory(dev, bytesize);
+        return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    actual = (pPitch != NULL) ? (*pPitch * Height) : bytesize;
+    if (actual > bytesize) {
+        if (reserve_device_memory(dev, actual - bytesize) != 0) {
+            CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemFree_v2, *dptr);
+            release_device_memory(dev, bytesize);
+            return CUDA_ERROR_OUT_OF_MEMORY;
+        }
+    } else if (actual < bytesize) {
+        release_device_memory(dev, bytesize - actual);
+    }
+    if (add_chunk_only(*dptr, actual, dev) != 0) {
+        CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemFree_v2, *dptr);
+        release_device_memory(dev, actual);
+        return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    return CUDA_SUCCESS;
 }
 
 CUresult cuMemFree_v2(CUdeviceptr dptr) {

--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -145,12 +145,14 @@ CUresult cuMemAllocManaged(CUdeviceptr* dptr, size_t bytesize, unsigned int flag
     ENSURE_RUNNING();
     CUdevice dev;
     CHECK_DRV_API(cuCtxGetDevice(&dev));
-    if (oom_check(dev,bytesize)){
+    if (reserve_device_memory(dev, bytesize) != 0) {
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAllocManaged, dptr, bytesize, flags);
     if (res == CUDA_SUCCESS) {
         add_chunk_only(*dptr, bytesize, dev);
+    } else {
+        release_device_memory(dev, bytesize);
     }
     return res;
 }
@@ -164,12 +166,14 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInByt
     ENSURE_RUNNING();
     CUdevice dev;
     CHECK_DRV_API(cuCtxGetDevice(&dev));
-    if (oom_check(dev,bytesize)){
+    if (reserve_device_memory(dev, bytesize) != 0) {
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAllocPitch_v2, dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
     if (res == CUDA_SUCCESS) {
         add_chunk_only(*dptr, bytesize, dev);
+    } else {
+        release_device_memory(dev, bytesize);
     }
     return res;
 }
@@ -595,13 +599,17 @@ CUresult cuMemCreate ( CUmemGenericAllocationHandle* handle, size_t size, const 
     if (do_oom_check && cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
         dev = prop->location.id;
     }
-    if (do_oom_check && oom_check(dev, size)) {
+    if (do_oom_check && reserve_device_memory(dev, size) != 0) {
         return CUDA_ERROR_OUT_OF_MEMORY;
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,
         cuMemCreate, handle, size, prop, flags);
-    if (do_oom_check && res == CUDA_SUCCESS) {
-        add_chunk_only(*handle, size, dev);
+    if (do_oom_check) {
+        if (res == CUDA_SUCCESS) {
+            add_chunk_only(*handle, size, dev);
+        } else {
+            release_device_memory(dev, size);
+        }
     }
     return res;
 }

--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -150,7 +150,11 @@ CUresult cuMemAllocManaged(CUdeviceptr* dptr, size_t bytesize, unsigned int flag
     }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemAllocManaged, dptr, bytesize, flags);
     if (res == CUDA_SUCCESS) {
-        add_chunk_only(*dptr, bytesize, dev);
+        if (add_chunk_only(*dptr, bytesize, dev) != 0) {
+            CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemFree_v2, *dptr);
+            release_device_memory(dev, bytesize);
+            return CUDA_ERROR_OUT_OF_MEMORY;
+        }
     } else {
         release_device_memory(dev, bytesize);
     }
@@ -627,7 +631,11 @@ CUresult cuMemCreate ( CUmemGenericAllocationHandle* handle, size_t size, const 
         cuMemCreate, handle, size, prop, flags);
     if (do_oom_check) {
         if (res == CUDA_SUCCESS) {
-            add_chunk_only(*handle, size, dev);
+            if (add_chunk_only(*handle, size, dev) != 0) {
+                CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemRelease, *handle);
+                release_device_memory(dev, size);
+                return CUDA_ERROR_OUT_OF_MEMORY;
+            }
         } else {
             release_device_memory(dev, size);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,14 @@ if (TARGET vgpu)
         TIMEOUT 10)
 endif()
 
+# GPU + LD_PRELOAD regression for cross-process cuMemAlloc TOCTOU (#273).
+# Uses the wrapper so --expect-fixed and limit/cache env are set.
+add_test(NAME concurrent_oom_race
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/run_concurrent_oom_race.sh --expect-fixed)
+set_tests_properties(concurrent_oom_race PROPERTIES
+    TIMEOUT 180
+    ENVIRONMENT "LIBVGPU=${CMAKE_BINARY_DIR}/libvgpu.so;TEST_BIN=${CMAKE_CURRENT_BINARY_DIR}/test_concurrent_oom_race")
+
 
 add_custom_target(python_test ALL
     COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/python ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,10 +71,12 @@ endif()
 
 # GPU + LD_PRELOAD regression for cross-process cuMemAlloc TOCTOU (#273).
 # Uses the wrapper so --expect-fixed and limit/cache env are set.
+# Wrapper exits 77 when no NVIDIA GPU is present (skip, not fail).
 add_test(NAME concurrent_oom_race
     COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/run_concurrent_oom_race.sh --expect-fixed)
 set_tests_properties(concurrent_oom_race PROPERTIES
     TIMEOUT 180
+    SKIP_RETURN_CODE 77
     ENVIRONMENT "LIBVGPU=${CMAKE_BINARY_DIR}/libvgpu.so;TEST_BIN=${CMAKE_CURRENT_BINARY_DIR}/test_concurrent_oom_race")
 
 

--- a/test/run_concurrent_oom_race.sh
+++ b/test/run_concurrent_oom_race.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Run the cross-process oom_check TOCTOU reproducer against libvgpu.so.
+# Run the cross-process oom_check race test against libvgpu.so (race-fix).
+# Default: --expect-fixed (limit must hold under concurrent alloc + race window).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -31,8 +32,14 @@ export HAMI_RACE_ROUNDS="$ROUNDS"
 export HAMI_ALLOC_RACE_WINDOW_US="$WINDOW_US"
 export LIBCUDA_LOG_LEVEL="${LIBCUDA_LOG_LEVEL:-1}"
 
-echo "Running: $BIN $*"
+# Default to verifying the fix; omit args only triggers --expect-fixed.
+ARGS=("$@")
+if [[ ${#ARGS[@]} -eq 0 ]]; then
+  ARGS=(--expect-fixed)
+fi
+
+echo "Running: $BIN ${ARGS[*]}"
 echo "  LD_PRELOAD=$LD_PRELOAD"
 echo "  LIMIT=$LIMIT ALLOC=$ALLOC ROUNDS=$ROUNDS WINDOW_US=$WINDOW_US"
 echo "  CACHE=$CACHE"
-exec "$BIN" "$@"
+exec "$BIN" "${ARGS[@]}"

--- a/test/run_concurrent_oom_race.sh
+++ b/test/run_concurrent_oom_race.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Run the cross-process oom_check race test against libvgpu.so (race-fix).
-# Default: --expect-fixed (limit must hold under concurrent alloc + race window).
+# Run the cross-process oom_check race test against libvgpu.so.
+# Default: --expect-fixed (limit must hold under concurrent alloc).
 # Exit 77 = no GPU (CTest SKIP_RETURN_CODE).
 set -euo pipefail
 
@@ -11,7 +11,6 @@ CACHE="${CUDA_DEVICE_MEMORY_SHARED_CACHE:-/tmp/hami_oom_race.cache}"
 LIMIT="${CUDA_DEVICE_MEMORY_LIMIT:-1024m}"
 ALLOC="${HAMI_RACE_ALLOC:-600m}"
 ROUNDS="${HAMI_RACE_ROUNDS:-30}"
-WINDOW_US="${HAMI_ALLOC_RACE_WINDOW_US:-20000}"
 
 # Detect a usable NVIDIA GPU before LD_PRELOAD so CPU-only hosts skip cleanly.
 if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L >/dev/null 2>&1; then
@@ -36,7 +35,6 @@ export CUDA_DEVICE_MEMORY_SHARED_CACHE="$CACHE"
 export CUDA_DEVICE_MEMORY_LIMIT="$LIMIT"
 export HAMI_RACE_ALLOC="$ALLOC"
 export HAMI_RACE_ROUNDS="$ROUNDS"
-export HAMI_ALLOC_RACE_WINDOW_US="$WINDOW_US"
 export LIBCUDA_LOG_LEVEL="${LIBCUDA_LOG_LEVEL:-1}"
 
 # Default to verifying the fix; omit args only triggers --expect-fixed.
@@ -47,6 +45,6 @@ fi
 
 echo "Running: $BIN ${ARGS[*]}"
 echo "  LD_PRELOAD=$LD_PRELOAD"
-echo "  LIMIT=$LIMIT ALLOC=$ALLOC ROUNDS=$ROUNDS WINDOW_US=$WINDOW_US"
+echo "  LIMIT=$LIMIT ALLOC=$ALLOC ROUNDS=$ROUNDS"
 echo "  CACHE=$CACHE"
 exec "$BIN" "${ARGS[@]}"

--- a/test/run_concurrent_oom_race.sh
+++ b/test/run_concurrent_oom_race.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Run the cross-process oom_check race test against libvgpu.so (race-fix).
 # Default: --expect-fixed (limit must hold under concurrent alloc + race window).
+# Exit 77 = no GPU (CTest SKIP_RETURN_CODE).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -11,6 +12,12 @@ LIMIT="${CUDA_DEVICE_MEMORY_LIMIT:-1024m}"
 ALLOC="${HAMI_RACE_ALLOC:-600m}"
 ROUNDS="${HAMI_RACE_ROUNDS:-30}"
 WINDOW_US="${HAMI_ALLOC_RACE_WINDOW_US:-20000}"
+
+# Detect a usable NVIDIA GPU before LD_PRELOAD so CPU-only hosts skip cleanly.
+if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi -L >/dev/null 2>&1; then
+  echo "SKIP: no NVIDIA GPU available (nvidia-smi)" >&2
+  exit 77
+fi
 
 if [[ ! -f "$LIB" ]]; then
   echo "missing $LIB — build first: (cd \"$ROOT\" && ./build.sh)" >&2

--- a/test/run_concurrent_oom_race.sh
+++ b/test/run_concurrent_oom_race.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run the cross-process oom_check TOCTOU reproducer against libvgpu.so.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="${LIBVGPU:-$ROOT/build/libvgpu.so}"
+BIN="${TEST_BIN:-$ROOT/build/test/test_concurrent_oom_race}"
+CACHE="${CUDA_DEVICE_MEMORY_SHARED_CACHE:-/tmp/hami_oom_race.cache}"
+LIMIT="${CUDA_DEVICE_MEMORY_LIMIT:-1024m}"
+ALLOC="${HAMI_RACE_ALLOC:-600m}"
+ROUNDS="${HAMI_RACE_ROUNDS:-30}"
+WINDOW_US="${HAMI_ALLOC_RACE_WINDOW_US:-20000}"
+
+if [[ ! -f "$LIB" ]]; then
+  echo "missing $LIB — build first: (cd \"$ROOT\" && ./build.sh)" >&2
+  exit 1
+fi
+if [[ ! -x "$BIN" ]]; then
+  echo "missing $BIN — rebuild so test/CMakeLists.txt picks up the new test" >&2
+  exit 1
+fi
+
+mkdir -p /tmp/vgpulock
+rm -f "$CACHE"
+
+export LD_PRELOAD="$LIB"
+export CUDA_DEVICE_MEMORY_SHARED_CACHE="$CACHE"
+export CUDA_DEVICE_MEMORY_LIMIT="$LIMIT"
+export HAMI_RACE_ALLOC="$ALLOC"
+export HAMI_RACE_ROUNDS="$ROUNDS"
+export HAMI_ALLOC_RACE_WINDOW_US="$WINDOW_US"
+export LIBCUDA_LOG_LEVEL="${LIBCUDA_LOG_LEVEL:-1}"
+
+echo "Running: $BIN $*"
+echo "  LD_PRELOAD=$LD_PRELOAD"
+echo "  LIMIT=$LIMIT ALLOC=$ALLOC ROUNDS=$ROUNDS WINDOW_US=$WINDOW_US"
+echo "  CACHE=$CACHE"
+exec "$BIN" "$@"

--- a/test/test_concurrent_oom_race.c
+++ b/test/test_concurrent_oom_race.c
@@ -37,12 +37,15 @@
 
 #include <cuda.h>
 #include <errno.h>
+#include <limits.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #ifndef TEST_DEVICE_ID
@@ -73,34 +76,73 @@ typedef struct {
     volatile int stop;
 } shm_state_t;
 
-static size_t parse_size_env(const char *name, size_t default_bytes) {
+/* Parse HAMI_RACE_ALLOC / HAMI_RACE_ROUNDS style values.
+ * On success writes *out and returns 0. Unset/empty → default.
+ * Malformed env (ERANGE, trailing junk, zero) → -1. */
+static int parse_size_env(const char *name, size_t default_bytes, size_t *out) {
     const char *v = getenv(name);
     char *end = NULL;
-    unsigned long long n;
+    uint64_t n;
+    size_t result;
 
     if (v == NULL || v[0] == '\0') {
-        return default_bytes;
+        *out = default_bytes;
+        return 0;
     }
-    n = strtoull(v, &end, 10);
-    if (end == v) {
-        return default_bytes;
+    errno = 0;
+    n = (uint64_t)strtoull(v, &end, 10);
+    if (end == v || errno == ERANGE) {
+        return -1;
     }
     if (*end == 'G' || *end == 'g') {
-        return (size_t)n << 30;
+        if (n > (SIZE_MAX >> 30)) {
+            return -1;
+        }
+        result = (size_t)n << 30;
+        end++;
+    } else if (*end == 'M' || *end == 'm') {
+        if (n > (SIZE_MAX >> 20)) {
+            return -1;
+        }
+        result = (size_t)n << 20;
+        end++;
+    } else if (*end == 'K' || *end == 'k') {
+        if (n > (SIZE_MAX >> 10)) {
+            return -1;
+        }
+        result = (size_t)n << 10;
+        end++;
+    } else {
+        result = (size_t)n;
     }
-    if (*end == 'M' || *end == 'm') {
-        return (size_t)n << 20;
+    if (*end != '\0' || result == 0) {
+        return -1;
     }
-    if (*end == 'K' || *end == 'k') {
-        return (size_t)n << 10;
-    }
-    return (size_t)n;
+    *out = result;
+    return 0;
 }
 
-static void wait_until(volatile int *p, int want) {
-    while (*p != want) {
-        usleep(100);
+#ifndef WAIT_UNTIL_TIMEOUT_SEC
+#define WAIT_UNTIL_TIMEOUT_SEC 60
+#endif
+
+/* Returns 0 when *p == want, -1 on timeout (avoids indefinite CI hangs). */
+static int wait_until(volatile int *p, int want) {
+    struct timespec start, now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+        return -1;
     }
+    while (*p != want) {
+        if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+            return -1;
+        }
+        if (now.tv_sec - start.tv_sec >= WAIT_UNTIL_TIMEOUT_SEC) {
+            return -1;
+        }
+        usleep(1000);
+    }
+    return 0;
 }
 
 static void child_init_cuda(CUcontext *ctx) {
@@ -126,25 +168,35 @@ static void child_main(int id, shm_state_t *st, size_t alloc_bytes) {
     __sync_fetch_and_add(&st->ready, 1);
 
     for (;;) {
-        wait_until(&st->go, 1);
+        if (wait_until(&st->go, 1) != 0) {
+            fprintf(stderr, "child %d: timed out waiting for go=1\n", id);
+            _exit(1);
+        }
         if (st->stop) {
             break;
         }
 
-        /* Release previous round's allocation if any. */
-        if (dptr != 0) {
-            cuMemFree(dptr);
-            dptr = 0;
-        }
-
+        /* Round starts with no outstanding allocation (freed in teardown). */
+        dptr = 0;
         __sync_synchronize();
         res = cuMemAlloc(&dptr, alloc_bytes);
+        if (res != CUDA_SUCCESS) {
+            dptr = 0;
+        }
         st->child_res[id] = (int)res;
         st->child_ok[id] = (res == CUDA_SUCCESS) ? 1 : 0;
         __sync_synchronize();
 
         __sync_fetch_and_add(&st->done, 1);
-        wait_until(&st->go, 0);
+        if (wait_until(&st->go, 0) != 0) {
+            fprintf(stderr, "child %d: timed out waiting for go=0\n", id);
+            _exit(1);
+        }
+        /* Teardown before ready++ so finish_round sees a clean slate. */
+        if (dptr != 0) {
+            cuMemFree(dptr);
+            dptr = 0;
+        }
         __sync_fetch_and_add(&st->ready, 1);
     }
 
@@ -193,11 +245,19 @@ static void start_round(shm_state_t *st) {
     st->go = 1;
 }
 
-static void finish_round(shm_state_t *st) {
-    wait_until(&st->done, 2);
-    st->go = 0;
+static int finish_round(shm_state_t *st) {
+    if (wait_until(&st->done, 2) != 0) {
+        return -1;
+    }
+    /* Zero ready before releasing children. If go=0 comes first, a child may
+     * ready++ and then parent clears it — lost increment → hang on ready==2. */
     st->ready = 0;
-    wait_until(&st->ready, 2);
+    __sync_synchronize();
+    st->go = 0;
+    if (wait_until(&st->ready, 2) != 0) {
+        return -1;
+    }
+    return 0;
 }
 
 static const char *cu_res_name(int res) {
@@ -238,8 +298,22 @@ int main(int argc, char **argv) {
     preload = getenv("LD_PRELOAD");
     limit_env = getenv("CUDA_DEVICE_MEMORY_LIMIT");
     cache_env = getenv("CUDA_DEVICE_MEMORY_SHARED_CACHE");
-    alloc_bytes = parse_size_env("HAMI_RACE_ALLOC", (size_t)600 << 20);
-    rounds = (int)parse_size_env("HAMI_RACE_ROUNDS", 30);
+    if (parse_size_env("HAMI_RACE_ALLOC", (size_t)600 << 20, &alloc_bytes) != 0) {
+        fprintf(stderr,
+                "ERROR: invalid HAMI_RACE_ALLOC (use e.g. 600m; no spaces; non-zero)\n");
+        return 1;
+    }
+    {
+        size_t rounds_sz;
+
+        if (parse_size_env("HAMI_RACE_ROUNDS", 30, &rounds_sz) != 0 ||
+            rounds_sz > (size_t)INT_MAX) {
+            fprintf(stderr,
+                    "ERROR: invalid HAMI_RACE_ROUNDS (positive integer required)\n");
+            return 1;
+        }
+        rounds = (int)rounds_sz;
+    }
 
     printf("=== HAMi-core concurrent oom_check race reproducer ===\n");
     printf("LD_PRELOAD=%s\n", preload ? preload : "(unset — libvgpu will not hook)");
@@ -329,12 +403,20 @@ int main(int argc, char **argv) {
             child_init_cuda(&ctx);
             CHECK_DRV(cuMemAlloc(&dptr, alloc_bytes));
             __sync_fetch_and_add(&st->ready, 1);
-            wait_until(&st->go, 1); /* hold until parent says release */
+            if (wait_until(&st->go, 1) != 0) {
+                fprintf(stderr, "hold-control A: timed out waiting for release\n");
+                _exit(1);
+            }
             cuMemFree(dptr);
             cuCtxDestroy(ctx);
             _exit(0);
         }
-        wait_until(&st->ready, 1);
+        if (wait_until(&st->ready, 1) != 0) {
+            fprintf(stderr, "ERROR: timed out waiting for hold-control A ready\n");
+            kill(a, SIGKILL);
+            waitpid(a, NULL, 0);
+            return 1;
+        }
 
         b = fork();
         if (b < 0) {
@@ -387,11 +469,24 @@ int main(int argc, char **argv) {
     if (spawn_children(kids, st, alloc_bytes) != 0) {
         return 1;
     }
-    wait_until(&st->ready, 2);
+    if (wait_until(&st->ready, 2) != 0) {
+        fprintf(stderr,
+                "ERROR: timed out waiting for race children ready "
+                "(ready=%d; child init/CUDA failure?)\n",
+                st->ready);
+        kill_children(kids);
+        return 1;
+    }
 
     for (i = 0; i < rounds; i++) {
         start_round(st);
-        finish_round(st);
+        if (finish_round(st) != 0) {
+            fprintf(stderr,
+                    "ERROR: timed out in round %d (done=%d ready=%d)\n", i,
+                    st->done, st->ready);
+            kill_children(kids);
+            return 1;
+        }
 
         if (st->child_ok[0] && st->child_ok[1]) {
             race_hits++;

--- a/test/test_concurrent_oom_race.c
+++ b/test/test_concurrent_oom_race.c
@@ -19,12 +19,11 @@
  *   export LD_PRELOAD=$PWD/build/libvgpu.so
  *   export CUDA_DEVICE_MEMORY_SHARED_CACHE="$CACHE"
  *   export CUDA_DEVICE_MEMORY_LIMIT=1024m
- *   export HAMI_ALLOC_RACE_WINDOW_US=20000   # widen race window (branch helper)
  *   export LIBCUDA_LOG_LEVEL=1
  *   ./build/test/test_concurrent_oom_race
  *
  * Or: ./test/run_concurrent_oom_race.sh
- *   (race-fix defaults to --expect-fixed)
+ *   (defaults to --expect-fixed)
  *
  * Suggested sizing: limit=1024m, alloc=600m so each request fits alone
  * (after two process contexts) but 2*alloc exceeds the limit.
@@ -320,10 +319,6 @@ int main(int argc, char **argv) {
     printf("CUDA_DEVICE_MEMORY_LIMIT=%s\n", limit_env ? limit_env : "(unset)");
     printf("CUDA_DEVICE_MEMORY_SHARED_CACHE=%s\n",
            cache_env ? cache_env : "(unset → fallback path)");
-    printf("HAMI_ALLOC_RACE_WINDOW_US=%s\n",
-           getenv("HAMI_ALLOC_RACE_WINDOW_US")
-               ? getenv("HAMI_ALLOC_RACE_WINDOW_US")
-               : "(unset)");
     printf("alloc_bytes=%zu rounds=%d expect_fixed=%d\n\n", alloc_bytes, rounds,
            expect_fixed);
 
@@ -535,8 +530,7 @@ int main(int argc, char **argv) {
         return 0;
     }
     printf("INCONCLUSIVE: no dual success in %d rounds.\n"
-           "  Retry with larger HAMI_ALLOC_RACE_WINDOW_US (e.g. 50000) or more "
-           "HAMI_RACE_ROUNDS.\n",
+           "  Retry with more HAMI_RACE_ROUNDS (e.g. 100).\n",
            rounds);
     return 2;
 }

--- a/test/test_concurrent_oom_race.c
+++ b/test/test_concurrent_oom_race.c
@@ -1,0 +1,446 @@
+/*
+ * Reproducer: cross-process cuMemAlloc TOCTOU against the shared memory limit.
+ *
+ * Vanilla add_chunk() (src/allocator/allocator.c):
+ *   1) oom_check(usage + size)   // no inter-process lock / reservation
+ *   2) real cuMemAlloc
+ *   3) pthread_mutex (process-local) + oom_check again + add_gpu_device_memory_usage
+ *
+ * When two processes each request less than the limit but the sum exceeds it,
+ * both can pass step 1 (and often step 3) before either commits usage, so both
+ * allocations succeed and tracked usage overshoots the limit.
+ *
+ * Build: discovered by test/CMakeLists.txt via ./build.sh
+ *
+ * Run (GPU + libvgpu required):
+ *   mkdir -p /tmp/vgpulock
+ *   CACHE=/tmp/hami_oom_race.cache
+ *   rm -f "$CACHE"
+ *   export LD_PRELOAD=$PWD/build/libvgpu.so
+ *   export CUDA_DEVICE_MEMORY_SHARED_CACHE="$CACHE"
+ *   export CUDA_DEVICE_MEMORY_LIMIT=1024m
+ *   export HAMI_ALLOC_RACE_WINDOW_US=20000   # widen race window (branch helper)
+ *   export LIBCUDA_LOG_LEVEL=1
+ *   ./build/test/test_concurrent_oom_race
+ *
+ * Or: ./test/run_concurrent_oom_race.sh
+ *
+ * Suggested sizing: limit=1024m, alloc=600m so each request fits alone
+ * (after two process contexts) but 2*alloc exceeds the limit.
+ * Exit codes:
+ *   0  race reproduced (both concurrent allocs succeeded)  OR  --expect-fixed
+ *      mode and limit held for all rounds
+ *   1  setup / sequential control failure
+ *   2  race not observed within rounds (inconclusive under default mode)
+ */
+
+#include <cuda.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef TEST_DEVICE_ID
+#define TEST_DEVICE_ID 0
+#endif
+
+#define CHECK_DRV(call)                                                        \
+    do {                                                                       \
+        CUresult _e = (call);                                                  \
+        if (_e != CUDA_SUCCESS) {                                              \
+            const char *_n = NULL;                                             \
+            cuGetErrorName(_e, &_n);                                           \
+            fprintf(stderr, "FATAL %s:%d: %s -> %d (%s)\n", __FILE__,          \
+                    __LINE__, #call, (int)_e, _n ? _n : "?");                  \
+            _exit(1);                                                          \
+        }                                                                      \
+    } while (0)
+
+typedef struct {
+    /* barrier: parent sets go; children increment ready / done */
+    volatile int ready;
+    volatile int go;
+    volatile int done;
+    volatile int child_ok[2];     /* 1 = cuMemAlloc succeeded */
+    volatile int child_res[2];    /* raw CUresult */
+    volatile int sequential_ok;   /* control: lone alloc under limit */
+    volatile int hold_ok;         /* control: second alloc while first holds */
+    volatile int stop;
+} shm_state_t;
+
+static size_t parse_size_env(const char *name, size_t default_bytes) {
+    const char *v = getenv(name);
+    char *end = NULL;
+    unsigned long long n;
+
+    if (v == NULL || v[0] == '\0') {
+        return default_bytes;
+    }
+    n = strtoull(v, &end, 10);
+    if (end == v) {
+        return default_bytes;
+    }
+    if (*end == 'G' || *end == 'g') {
+        return (size_t)n << 30;
+    }
+    if (*end == 'M' || *end == 'm') {
+        return (size_t)n << 20;
+    }
+    if (*end == 'K' || *end == 'k') {
+        return (size_t)n << 10;
+    }
+    return (size_t)n;
+}
+
+static void wait_until(volatile int *p, int want) {
+    while (*p != want) {
+        usleep(100);
+    }
+}
+
+static void child_init_cuda(CUcontext *ctx) {
+    CUdevice device;
+
+    CHECK_DRV(cuInit(0));
+    CHECK_DRV(cuDeviceGet(&device, TEST_DEVICE_ID));
+#if CUDA_VERSION >= 13000
+    CHECK_DRV(cuCtxCreate(ctx, NULL, 0, device));
+#else
+    CHECK_DRV(cuCtxCreate(ctx, 0, device));
+#endif
+}
+
+static void child_main(int id, shm_state_t *st, size_t alloc_bytes) {
+    CUcontext ctx;
+    CUdeviceptr dptr = 0;
+    CUresult res;
+
+    child_init_cuda(&ctx);
+
+    /* Signal ready for sequential control / race rounds. */
+    __sync_fetch_and_add(&st->ready, 1);
+
+    for (;;) {
+        wait_until(&st->go, 1);
+        if (st->stop) {
+            break;
+        }
+
+        /* Release previous round's allocation if any. */
+        if (dptr != 0) {
+            cuMemFree(dptr);
+            dptr = 0;
+        }
+
+        __sync_synchronize();
+        res = cuMemAlloc(&dptr, alloc_bytes);
+        st->child_res[id] = (int)res;
+        st->child_ok[id] = (res == CUDA_SUCCESS) ? 1 : 0;
+        __sync_synchronize();
+
+        __sync_fetch_and_add(&st->done, 1);
+        wait_until(&st->go, 0);
+        __sync_fetch_and_add(&st->ready, 1);
+    }
+
+    if (dptr != 0) {
+        cuMemFree(dptr);
+    }
+    cuCtxDestroy(ctx);
+    _exit(0);
+}
+
+static int spawn_children(pid_t kids[2], shm_state_t *st, size_t alloc_bytes) {
+    int i;
+
+    for (i = 0; i < 2; i++) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            perror("fork");
+            return -1;
+        }
+        if (pid == 0) {
+            child_main(i, st, alloc_bytes);
+        }
+        kids[i] = pid;
+    }
+    return 0;
+}
+
+static void kill_children(pid_t kids[2]) {
+    int i;
+    for (i = 0; i < 2; i++) {
+        if (kids[i] > 0) {
+            kill(kids[i], SIGKILL);
+            waitpid(kids[i], NULL, 0);
+            kids[i] = -1;
+        }
+    }
+}
+
+static void start_round(shm_state_t *st) {
+    st->child_ok[0] = 0;
+    st->child_ok[1] = 0;
+    st->child_res[0] = -1;
+    st->child_res[1] = -1;
+    st->done = 0;
+    __sync_synchronize();
+    st->go = 1;
+}
+
+static void finish_round(shm_state_t *st) {
+    wait_until(&st->done, 2);
+    st->go = 0;
+    st->ready = 0;
+    wait_until(&st->ready, 2);
+}
+
+static const char *cu_res_name(int res) {
+    switch ((CUresult)res) {
+        case CUDA_SUCCESS:
+            return "CUDA_SUCCESS";
+        case CUDA_ERROR_OUT_OF_MEMORY:
+            return "CUDA_ERROR_OUT_OF_MEMORY";
+        case CUDA_ERROR_INVALID_VALUE:
+            return "CUDA_ERROR_INVALID_VALUE";
+        case CUDA_ERROR_NOT_INITIALIZED:
+            return "CUDA_ERROR_NOT_INITIALIZED";
+        default:
+            return "CUresult(other)";
+    }
+}
+
+int main(int argc, char **argv) {
+    shm_state_t *st;
+    pid_t kids[2] = {-1, -1};
+    size_t alloc_bytes;
+    int rounds;
+    int expect_fixed = 0;
+    int i;
+    int race_hits = 0;
+    int both_fail = 0;
+    int one_ok = 0;
+    const char *limit_env;
+    const char *cache_env;
+    const char *preload;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--expect-fixed") == 0) {
+            expect_fixed = 1;
+        }
+    }
+
+    preload = getenv("LD_PRELOAD");
+    limit_env = getenv("CUDA_DEVICE_MEMORY_LIMIT");
+    cache_env = getenv("CUDA_DEVICE_MEMORY_SHARED_CACHE");
+    alloc_bytes = parse_size_env("HAMI_RACE_ALLOC", (size_t)600 << 20);
+    rounds = (int)parse_size_env("HAMI_RACE_ROUNDS", 30);
+
+    printf("=== HAMi-core concurrent oom_check race reproducer ===\n");
+    printf("LD_PRELOAD=%s\n", preload ? preload : "(unset — libvgpu will not hook)");
+    printf("CUDA_DEVICE_MEMORY_LIMIT=%s\n", limit_env ? limit_env : "(unset)");
+    printf("CUDA_DEVICE_MEMORY_SHARED_CACHE=%s\n",
+           cache_env ? cache_env : "(unset → fallback path)");
+    printf("HAMI_ALLOC_RACE_WINDOW_US=%s\n",
+           getenv("HAMI_ALLOC_RACE_WINDOW_US")
+               ? getenv("HAMI_ALLOC_RACE_WINDOW_US")
+               : "(unset)");
+    printf("alloc_bytes=%zu rounds=%d expect_fixed=%d\n\n", alloc_bytes, rounds,
+           expect_fixed);
+
+    if (preload == NULL || preload[0] == '\0') {
+        fprintf(stderr, "ERROR: LD_PRELOAD must point at libvgpu.so\n");
+        return 1;
+    }
+    if (limit_env == NULL || limit_env[0] == '\0') {
+        fprintf(stderr, "ERROR: set CUDA_DEVICE_MEMORY_LIMIT (e.g. 512m)\n");
+        return 1;
+    }
+
+    st = mmap(NULL, sizeof(*st), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
+              -1, 0);
+    if (st == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+    memset((void *)st, 0, sizeof(*st));
+
+    /*
+     * Sequential control (single process): alloc must succeed under limit.
+     * Proves the chosen size individually fits before we race.
+     */
+    {
+        pid_t p = fork();
+        if (p < 0) {
+            perror("fork");
+            return 1;
+        }
+        if (p == 0) {
+            CUcontext ctx;
+            CUdeviceptr dptr = 0;
+            CUresult res;
+
+            child_init_cuda(&ctx);
+            res = cuMemAlloc(&dptr, alloc_bytes);
+            st->sequential_ok = (res == CUDA_SUCCESS) ? 1 : 0;
+            if (res != CUDA_SUCCESS) {
+                fprintf(stderr, "sequential alloc failed: %s\n", cu_res_name(res));
+            }
+            if (dptr) {
+                cuMemFree(dptr);
+            }
+            cuCtxDestroy(ctx);
+            _exit(0);
+        }
+        waitpid(p, NULL, 0);
+    }
+    if (!st->sequential_ok) {
+        fprintf(stderr,
+                "ERROR: single-process alloc of %zu failed under limit=%s.\n"
+                "       Lower HAMI_RACE_ALLOC or raise CUDA_DEVICE_MEMORY_LIMIT.\n",
+                alloc_bytes, limit_env);
+        return 1;
+    }
+    printf("[control] single-process alloc OK (%zu bytes)\n", alloc_bytes);
+
+    /* Hold control: process A holds alloc; process B must be denied. */
+    {
+        pid_t a, b;
+
+        st->ready = 0;
+        st->go = 0;
+        st->done = 0;
+        st->hold_ok = 0;
+
+        a = fork();
+        if (a < 0) {
+            perror("fork");
+            return 1;
+        }
+        if (a == 0) {
+            CUcontext ctx;
+            CUdeviceptr dptr = 0;
+
+            child_init_cuda(&ctx);
+            CHECK_DRV(cuMemAlloc(&dptr, alloc_bytes));
+            __sync_fetch_and_add(&st->ready, 1);
+            wait_until(&st->go, 1); /* hold until parent says release */
+            cuMemFree(dptr);
+            cuCtxDestroy(ctx);
+            _exit(0);
+        }
+        wait_until(&st->ready, 1);
+
+        b = fork();
+        if (b < 0) {
+            perror("fork");
+            kill(a, SIGKILL);
+            waitpid(a, NULL, 0);
+            return 1;
+        }
+        if (b == 0) {
+            CUcontext ctx;
+            CUdeviceptr dptr = 0;
+            CUresult res;
+
+            child_init_cuda(&ctx);
+            res = cuMemAlloc(&dptr, alloc_bytes);
+            /* Expect OOM: A already holds ~alloc_bytes against the limit. */
+            st->hold_ok = (res == CUDA_ERROR_OUT_OF_MEMORY) ? 1 : 0;
+            if (res == CUDA_SUCCESS) {
+                fprintf(stderr,
+                        "hold-control: B unexpectedly succeeded (%s)\n",
+                        cu_res_name(res));
+                cuMemFree(dptr);
+            } else if (res != CUDA_ERROR_OUT_OF_MEMORY) {
+                fprintf(stderr, "hold-control: B got %s (want OOM)\n",
+                        cu_res_name(res));
+            }
+            cuCtxDestroy(ctx);
+            _exit(0);
+        }
+        waitpid(b, NULL, 0);
+        st->go = 1;
+        waitpid(a, NULL, 0);
+
+        if (!st->hold_ok) {
+            fprintf(stderr,
+                    "ERROR: when A holds %zu, B should get OOM under limit=%s.\n"
+                    "       Pick alloc so 2*alloc > limit (after context overhead).\n",
+                    alloc_bytes, limit_env);
+            return 1;
+        }
+        printf("[control] A holds + B denied (OOM) OK — limit enforcement works "
+               "when serialized\n\n");
+    }
+
+    /* Concurrent race rounds */
+    st->ready = 0;
+    st->go = 0;
+    st->done = 0;
+    st->stop = 0;
+    if (spawn_children(kids, st, alloc_bytes) != 0) {
+        return 1;
+    }
+    wait_until(&st->ready, 2);
+
+    for (i = 0; i < rounds; i++) {
+        start_round(st);
+        finish_round(st);
+
+        if (st->child_ok[0] && st->child_ok[1]) {
+            race_hits++;
+            printf("[round %d] RACE: both succeeded (res=%s / %s)\n", i,
+                   cu_res_name(st->child_res[0]), cu_res_name(st->child_res[1]));
+            if (!expect_fixed) {
+                /* One hit is enough to prove the bug. */
+                break;
+            }
+        } else if (!st->child_ok[0] && !st->child_ok[1]) {
+            both_fail++;
+            printf("[round %d] both failed (%s / %s)\n", i,
+                   cu_res_name(st->child_res[0]), cu_res_name(st->child_res[1]));
+        } else {
+            one_ok++;
+            printf("[round %d] correctly serialized: ok=%d/%d (%s / %s)\n", i,
+                   st->child_ok[0], st->child_ok[1],
+                   cu_res_name(st->child_res[0]), cu_res_name(st->child_res[1]));
+        }
+    }
+
+    st->stop = 1;
+    start_round(st);
+    /* Children exit on stop; do not wait on done==2 forever if one already died */
+    usleep(200000);
+    kill_children(kids);
+
+    printf("\n--- summary ---\n");
+    printf("race_hits(both success)=%d  one_ok=%d  both_fail=%d\n", race_hits,
+           one_ok, both_fail);
+
+    if (expect_fixed) {
+        if (race_hits == 0) {
+            printf("PASS (--expect-fixed): no dual success across %d rounds\n",
+                   rounds);
+            return 0;
+        }
+        printf("FAIL (--expect-fixed): observed %d dual-success race(s)\n",
+               race_hits);
+        return 1;
+    }
+
+    if (race_hits > 0) {
+        printf("BUG REPRODUCED: concurrent allocs both passed oom_check while "
+               "sum exceeds limit\n");
+        return 0;
+    }
+    printf("INCONCLUSIVE: no dual success in %d rounds.\n"
+           "  Retry with larger HAMI_ALLOC_RACE_WINDOW_US (e.g. 50000) or more "
+           "HAMI_RACE_ROUNDS.\n",
+           rounds);
+    return 2;
+}

--- a/test/test_concurrent_oom_race.c
+++ b/test/test_concurrent_oom_race.c
@@ -24,6 +24,7 @@
  *   ./build/test/test_concurrent_oom_race
  *
  * Or: ./test/run_concurrent_oom_race.sh
+ *   (race-fix defaults to --expect-fixed)
  *
  * Suggested sizing: limit=1024m, alloc=600m so each request fits alone
  * (after two process contexts) but 2*alloc exceeds the limit.


### PR DESCRIPTION
Two processes may race when calling cuMemAlloc through the libvgpu hook.

Currently, shared usage can be read using the seqlock, but the check-and-add operation is not protected by one lock across processes. Also, as I understand it, the pthread_mutex only protects request races between threads in the same process.

Because of this, **I thought that when allocations from multiple processes race, both processes might pass the OOM check and get CUDA_SUCCESS even if the total allocation exceeds the limit.** So I tried to reproduce this case.

```
Test Env:
Ubuntu 22.04 / NVIDIA A30 (24GB) ×1 / 16 vCPU / 48GB RAM /
256GB Storage / NVIDIA Driver 580.126.20

Reproduction conditions:
LIMIT=1024m
ALLOC=600m
HAMI_ALLOC_RACE_WINDOW_US=20000
same shared cache
```
**Note:** The initial reproduction used HAMI_ALLOC_RACE_WINDOW_US to make the race easier to reproduce. This test-only hook was later removed from the production code following review.

I used a barrier to send concurrent allocation requests for several rounds. In the first few rounds, only one allocation succeeded as expected. **However, in round 4, both allocations succeeded and the race was reproduced.**

```
[round 4] RACE: both succeeded (res=CUDA_SUCCESS / CUDA_SUCCESS)

Summary:
race_hits = 1 / 5 rounds

Result: BUG REPRODUCED
```

For the fix, I tried a reserve-then-alloc approach because I did not want to keep cuMemAlloc itself inside the lock for performance reasons.

**When the OOM check passes, the requested size is first added to usage as a reservation while holding lock_shrreg, and then the lock is released before the actual allocation. If the allocation fails, the reservation is rolled back.**

After this change, I tested the same race for 30 rounds.

```
alloc_bytes=629145600 rounds=30 expect_fixed=1

[round 0~29] correctly serialized: ok=1/0 (or ok=0/1)

race_hits(both success)=0
one_ok=30
both_fail=0

PASS (--expect-fixed): no dual success across 30 rounds
```

**There was no dual success in all 30 rounds.**

I also ran the container build from CONTRIBUTING.md with make build-in-docker (nvidia/cuda:13.3.0-cudnn-devel-ubi8). The build passed, including libvgpu.so and test_concurrent_oom_race.

In this PR, **I only changed the synchronous memory allocation paths:** cuMemAlloc, cuMemAllocManaged, cuMemAllocPitch, and cuMemCreate. **The asynchronous path is still unchanged.**

If this approach looks reasonable, I would like to handle the asynchronous path in a follow-up.

**Note:** I used Cursor and ChatGPT as supporting tools for parts of the coding and English translation. I reviewed the generated suggestions and supervised the overall implementation and testing myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device-memory allocation reliability during concurrent workloads.
  - Prevented multiple processes from exceeding shared memory limits during simultaneous allocations.
  - Ensured reserved memory is released when allocations or tracking operations fail.
  - Improved memory usage accounting across managed, pitched, and standard allocations.

- **Testing**
  - Added coverage for concurrent out-of-memory scenarios, allocation race conditions, and configurable test limits.
  - Added automated handling for environments without a usable NVIDIA GPU.
  - Added cleanup and timeout safeguards for concurrent allocation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->