### PR TITLE
fix(utils): prevent global buffer overflow in parse_cuda_visible_env

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -182,6 +182,10 @@ int parse_cuda_visible_env() {
     if (need_cuda_virtualize()) {
         for (int i = 0; i < strlen(s); i++) {
             if ((s[i] == ',') || (i == 0)) {
+                if (count >= CUDA_DEVICE_MAX_COUNT) {
+                    LOG_ERROR("CUDA_VISIBLE_DEVICES exceeds max count");
+                    break;
+                }
                 int tmp = (i==0) ? atoi(s) : atoi(s + i +1);
                 cuda_to_nvml_map_array[count] = tmp; 
                 count++;


### PR DESCRIPTION
### Description

**Fixes #266**

This PR fixes a global buffer overflow vulnerability in `parse_cuda_visible_env()` caused by missing array bounds checking.

**The Bug:**
In `libvgpu/src/utils.c`, `parse_cuda_visible_env()` iterates over the `CUDA_VISIBLE_DEVICES` environment variable string and stores parsed device IDs into `cuda_to_nvml_map_array`. 

Because `cuda_to_nvml_map_array` is defined globally with a strict capacity of `CUDA_DEVICE_MAX_COUNT` (16), parsing an environment variable containing more than 16 comma-separated items caused the loop to write past the end of the array, silently corrupting adjacent global memory.

**The Fix:**
Added a boundary check inside the loop to ensure the index `count` never exceeds `CUDA_DEVICE_MAX_COUNT`. If it hits the maximum allowed devices, it logs an error and breaks out of the loop safely.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

### Verification
- **Device Type:** NVIDIA RTX 4000 Ada Generation
- **Driver Version:** 580.173.02
- **Test Performed:** Compiled `libvgpu` with the patch on a RunPod instance. Exported `CUDA_VISIBLE_DEVICES` with 17 devices (`0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16`) and executed PyTorch to initialize CUDA with `LD_PRELOAD` active. Verified that the library initializes safely, limits itself gracefully, and exits cleanly without a segmentation fault or overflowing the 16-device global buffer.
- Verified that on the `main` branch without this patch, the exact same test consistently produces a `Segmentation fault (core dumped)` upon loading due to the global buffer overflow.

---
*Note: I used an AI assistant to help trace this global buffer overflow behavior, but the final solution and testing were authored and verified manually.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when more visible CUDA devices are configured than the supported limit.
  * Added clear error reporting and safely stops processing extra device entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->