### PR TITLE
call rate_limiter from cuLaunchCooperativeKernel

### DIFF
--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -565,6 +565,10 @@ CUresult cuLaunchCooperativeKernel ( CUfunction f, unsigned int  gridDimX, unsig
     ENSURE_RUNNING();
     ensure_post_init();
     pre_launch_kernel();
+    if (pidfound==1){
+        rate_limiter(gridDimX * gridDimY * gridDimZ,
+                   blockDimX * blockDimY * blockDimZ);
+    }
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuLaunchCooperativeKernel,f,gridDimX,gridDimY,gridDimZ,blockDimX,blockDimY,blockDimZ,sharedMemBytes,hStream,kernelParams);
     return res;
 }


### PR DESCRIPTION
cuLaunchKernel and cuLaunchKernelEx call rate_limiter when pidfound==1. cuLaunchCooperativeKernel runs ENSURE_RUNNING, ensure_post_init and pre_launch_kernel and then calls the real driver It never calls the limiter, so CUDA_DEVICE_SM_LIMIT does not apply for cooperative launches. This was added in #143 for cuLaunchKernelEx.

I tested it on two Nvidia A100 80GB PCIe, driver 580.65.06, cuda 12.9 with official debug DLSYM_HOOK and libvgpu.so. Env was CUDA_DEVICE_SM_LIMIT=50 and GPU_CORE_UTILIZATION_POLICY=FORCE host pid returned (pidfound=1) Direct cuLaunchCooperativeKernel, 2 warm up and 80 measured launches, grid 864 x 256

I printed from the wrapper and from the first line of rate_limiter:
| build | WRAP_LAUNCH_COOP | RATE_LIMITER_HIT |
| --- | --- | --- |
| current main | 82 | 0 |
| this patch | 82 | 82 |

cuLaunchKernel still hit the limiter 82 times for both builds.

the patch just adds that call. No changes to token refill in rate_limiter. 

I used AI assistance to double check the hook path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cooperative kernel launches now apply rate limiting based on the configured grid and block dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->