### PR TITLE
fix repeated RTLD_NEXT lookups returning null

### DIFF
--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -25,7 +25,6 @@ void *vgpulib;
 
 pthread_once_t pre_cuinit_flag = PTHREAD_ONCE_INIT;
 pthread_once_t post_cuinit_flag = PTHREAD_ONCE_INIT;
-pthread_once_t dlsym_init_flag = PTHREAD_ONCE_INIT;
 
 /* pidfound is to enable core utilization, if we don't find hostpid in container, then we have no
  where to find its core utilization */
@@ -40,40 +39,8 @@ extern size_t context_size;
 /* This is the symbol search function */
 fp_dlsym real_dlsym = NULL;
 
-pthread_mutex_t dlsym_lock;
-typedef struct {
-    pthread_t tid;
-    void *pointer;
-}tid_dl_map;
-
-#define DLMAP_SIZE 100
-tid_dl_map dlmap[DLMAP_SIZE];
-int dlmap_count=0;
-
-void init_dlsym(){
-    LOG_DEBUG("init_dlsym\n");
-    pthread_mutex_init(&dlsym_lock,NULL);
-    dlmap_count=0;
-    memset(dlmap, 0, sizeof(tid_dl_map)*DLMAP_SIZE);
-}
-
-int check_dlmap(pthread_t tid, void *pointer){
-    int i;
-    int cursor = (dlmap_count < DLMAP_SIZE) ? dlmap_count : DLMAP_SIZE;
-    for (i=cursor-1; i>=0; i--) {
-        if ((dlmap[i].pointer == pointer) && pthread_equal(dlmap[i].tid, tid))
-            return 1;
-    }
-    cursor = dlmap_count % DLMAP_SIZE;
-    dlmap[cursor].tid = tid;
-    dlmap[cursor].pointer = pointer;
-    dlmap_count++;
-    return 0;
-}
-
 FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
     LOG_DEBUG("into dlsym %s",symbol);
-    pthread_once(&dlsym_init_flag,init_dlsym);
     if (real_dlsym == NULL) {
         const char* glibc_versions[] = {
                 "GLIBC_2.2.5",  // for amd64
@@ -109,15 +76,7 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
         }
     }
     if (handle == RTLD_NEXT) {
-        void *h = real_dlsym(RTLD_NEXT,symbol);
-        pthread_mutex_lock(&dlsym_lock);
-        pthread_t tid = pthread_self();
-        if (check_dlmap(tid,h)){
-            LOG_WARN("recursive dlsym : %s\n",symbol);
-            h = NULL;
-        }
-        pthread_mutex_unlock(&dlsym_lock);
-        return h;
+        return real_dlsym(RTLD_NEXT, symbol);
     }
     if (symbol[0] == 'c' && symbol[1] == 'u') {
         //Compatible with cuda 12.8+ fix

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
             -ffunction-sections -fdata-sections)
         set_target_properties(${TEST_TARGET_NAME} PROPERTIES
             LINK_FLAGS "-Wl,--no-export-dynamic,--gc-sections")
+    elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
+        add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT})
     elseif (TEST_SCRIPT MATCHES ".*cu")
         cuda_add_executable(${TEST_TARGET_NAME}  ${TEST_SCRIPT})
     else()
@@ -36,6 +38,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
     if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
+    elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
+        target_link_libraries(${TEST_TARGET_NAME} -ldl)
     else()
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread
             -lnvidia-ml -lcuda -lcudart -L${CUDA_HOME}/lib64)
@@ -51,6 +55,17 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME postinit_owner_death
     COMMAND test_postinit_owner_death)
 set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
+
+add_test(NAME dlsym_rtld_next
+    COMMAND test_dlsym_rtld_next)
+set_tests_properties(dlsym_rtld_next PROPERTIES TIMEOUT 10)
+if (TARGET vgpu)
+    add_test(NAME dlsym_rtld_next_preloaded
+        COMMAND test_dlsym_rtld_next)
+    set_tests_properties(dlsym_rtld_next_preloaded PROPERTIES
+        ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:vgpu>"
+        TIMEOUT 10)
+endif()
 
 
 add_custom_target(python_test ALL

--- a/test/test_dlsym_rtld_next.c
+++ b/test/test_dlsym_rtld_next.c
@@ -1,0 +1,31 @@
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+
+/*
+ * Repeated RTLD_NEXT lookups must return the same address. The old
+ * (thread, pointer) history map treated the second call as recursion
+ * and replaced a valid pointer with NULL.
+ */
+int main(void) {
+    void *first = dlsym(RTLD_NEXT, "open");
+    void *second = dlsym(RTLD_NEXT, "open");
+
+    if (first == NULL) {
+        fprintf(stderr, "first RTLD_NEXT open lookup failed: %s\n", dlerror());
+        return 1;
+    }
+    if (second == NULL) {
+        fprintf(stderr, "second RTLD_NEXT open lookup returned NULL\n");
+        return 1;
+    }
+    if (first != second) {
+        fprintf(stderr, "RTLD_NEXT open lookup changed: %p then %p\n",
+                first, second);
+        return 1;
+    }
+    printf("PASS %p\n", first);
+    return 0;
+}


### PR DESCRIPTION
## Why

repeated calls to dlsym(RTLD_NEXT, "open") return the same libc function. libvgpu.so is preloaded and the first lookup works but the second one returns null.

The wrapper keeps completed (thread, pointer) pairs in a global table. check_dlmap() considers it recursion if a later lookup returns the same pointer on the same thread. The table tracks completed calls so it cannot tell the difference between recursive entry and a normal repeated lookup.

This patch removes that table and it mutex. Now the path thru RTLD_NEXT returns the result from the resolved libc dlsym directly. It also adds a regression test for the failing case, both normal and with libvgpu.so preloaded.

 ## Testing

  1. main current reproduced second lookup failure in 5 of 5 runs. The patched library passes 5 out of 5 runs.
  2. The patched library completed 40,000 lookups on four symbols with eight threads
  3. Both focused CTests ran 20 times each successfully.
  4. A direct cuda driver api probe ran 9 of 9 cuLaunchKernel tests in bare, current and patched configurations

 The hardware tests were performed on a Nvidia a100 80gb PCIe with driver: 580.65.06 and CUDA toolkit 12.9. 

AI support: AI was used for a double check of the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of repeated dynamic symbol lookups using `RTLD_NEXT`.
  * Removed unnecessary per-thread lookup tracking that could affect symbol resolution.

* **Tests**
  * Added automated coverage verifying repeated lookups return consistent, valid results.
  * Added validation for both standard execution and execution with the virtual GPU library preloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->