### PR TITLE
fix(cuda): preserve managed-memory state in cuPointerGetAttributes

### DIFF
--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -275,16 +275,15 @@ CUresult cuPointerGetAttributes ( unsigned int  numAttributes, CUpointer_attribu
     LOG_DEBUG("cuPointGetAttribute data=%p ptr=%llx", data, ptr);
     ENSURE_RUNNING();
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuPointerGetAttributes,numAttributes,attributes,data,ptr);
+    if (res != CUDA_SUCCESS) {
+        return res;
+    }
     int cur=0;
     for (cur=0;cur<numAttributes;cur++){
         if (attributes[cur]==CU_POINTER_ATTRIBUTE_MEMORY_TYPE){
             int j = check_memory_type(ptr);
             //*(int *)(data[cur])=1;
             LOG_DEBUG("check result = %d %d",j,*(int *)(data[cur]));
-        }else{
-            if (attributes[cur]==CU_POINTER_ATTRIBUTE_IS_MANAGED){
-                *(int *)(data[cur])=0;    
-            }
         }
     }
     return res;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 find_package(CUDA REQUIRED)
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+
 set(TEST_CPP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(TEST_TARGET_NAMES_LIST) 
 

--- a/test/test_pointer_attribute_managed.c
+++ b/test/test_pointer_attribute_managed.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <cuda.h>
+
+#include "test_utils.h"
+
+// Regression test for the managed-memory state reported by the two CUDA
+// pointer-attribute APIs.
+//
+// cuPointerGetAttribute and cuPointerGetAttributes must report the same
+// CU_POINTER_ATTRIBUTE_IS_MANAGED value for the same pointer, and a
+// cuMemAllocManaged allocation must be reported as managed.
+//
+// Run under the HAMi-core hooks, e.g.:
+//   LD_PRELOAD=./libvgpu.so ./test/test_pointer_attribute_managed
+
+int main() {
+    CHECK_DRV_API(cuInit(0));
+
+    CUdevice device;
+    CHECK_DRV_API(cuDeviceGet(&device, TEST_DEVICE_ID));
+
+    CUcontext ctx;
+#if CUDA_VERSION >= 13000
+    CHECK_DRV_API(cuCtxCreate(&ctx, NULL, 0, device));
+#else
+    CHECK_DRV_API(cuCtxCreate(&ctx, 0, device));
+#endif
+
+    CUdeviceptr dptr;
+    CHECK_DRV_API(cuMemAllocManaged(&dptr, 1 << 20, CU_MEM_ATTACH_GLOBAL));
+
+    int managed_single = -1;
+    CHECK_DRV_API(cuPointerGetAttribute(&managed_single,
+        CU_POINTER_ATTRIBUTE_IS_MANAGED, dptr));
+
+    int managed_multi = -1;
+    CUpointer_attribute attributes[1] = {CU_POINTER_ATTRIBUTE_IS_MANAGED};
+    void *data[1] = {&managed_multi};
+    CHECK_DRV_API(cuPointerGetAttributes(1, attributes, data, dptr));
+
+    printf("IS_MANAGED: cuPointerGetAttribute=%d cuPointerGetAttributes=%d\n",
+        managed_single, managed_multi);
+
+    if (managed_single != managed_multi) {
+        fprintf(stderr,
+            "cuPointerGetAttribute and cuPointerGetAttributes disagree on "
+            "IS_MANAGED: %d vs %d\n", managed_single, managed_multi);
+        return -1;
+    }
+
+    if (managed_multi != 1) {
+        fprintf(stderr,
+            "managed allocation reported as not managed: IS_MANAGED=%d\n",
+            managed_multi);
+        return -1;
+    }
+
+    cuMemFree(dptr);
+    CHECK_DRV_API(cuCtxDestroy(ctx));
+    printf("test_pointer_attribute_managed passed\n");
+    return 0;
+}

--- a/test/test_pointer_attribute_managed.c
+++ b/test/test_pointer_attribute_managed.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <cuda.h>
 
-#include "test_utils.h"
+#include "test/test_utils.h"
 
 // Regression test for the managed-memory state reported by the two CUDA
 // pointer-attribute APIs.
@@ -37,6 +37,33 @@ int main() {
     CUpointer_attribute attributes[1] = {CU_POINTER_ATTRIBUTE_IS_MANAGED};
     void *data[1] = {&managed_multi};
     CHECK_DRV_API(cuPointerGetAttributes(1, attributes, data, dptr));
+
+    CUcontext popped_ctx;
+    CHECK_DRV_API(cuCtxPopCurrent(&popped_ctx));
+
+    int memory_type = -1;
+    CUpointer_attribute error_attributes[1] = {
+        CU_POINTER_ATTRIBUTE_MEMORY_TYPE
+    };
+    void *error_data[1] = {&memory_type};
+    CUresult error_result = cuPointerGetAttributes(
+        1, error_attributes, error_data, dptr);
+
+    CHECK_DRV_API(cuCtxPushCurrent(popped_ctx));
+
+    if (error_result != CUDA_ERROR_INVALID_CONTEXT) {
+        fprintf(stderr,
+            "cuPointerGetAttributes returned %d without a current context, "
+            "expected %d\n", error_result, CUDA_ERROR_INVALID_CONTEXT);
+        return -1;
+    }
+
+    if (memory_type != -1) {
+        fprintf(stderr,
+            "cuPointerGetAttributes changed output after an error: %d\n",
+            memory_type);
+        return -1;
+    }
 
     printf("IS_MANAGED: cuPointerGetAttribute=%d cuPointerGetAttributes=%d\n",
         managed_single, managed_multi);


### PR DESCRIPTION
## Summary

This PR fixes inconsistent managed-memory reporting between `cuPointerGetAttribute` and `cuPointerGetAttributes`.

Previously, `cuPointerGetAttributes` overwrote `CU_POINTER_ATTRIBUTE_IS_MANAGED` with `0` after calling the CUDA driver. It also processed output values even when the driver returned an error.

This change preserves the CUDA driver result and returns immediately when the underlying call fails.

## Root cause

The `cuPointerGetAttributes` hook unconditionally post-processed requested attributes after the original CUDA call. That caused it to force managed memory to appear unmanaged and to access output buffers after an error.

## Related issue

Fixes #281

## Validation

- [x] `make check-cuda-hook-consistency`
- [x] `git diff --check upstream/main...HEAD`
- [ ] `make build-in-docker` — blocked by Docker Hub network connectivity
- [ ] Control run of `test_pointer_attribute_managed` on a real GPU
- [ ] `LD_PRELOAD` run of `test_pointer_attribute_managed` on a real GPU
- [ ] Error-path regression test

## Remaining validation

- Add regression coverage for the driver-error path.
- Complete the required Docker build.
- Run and record real-GPU validation, including GPU model, NVIDIA driver,
  CUDA version, operating system, and control/preloaded test results.

## User-facing impact

Yes. This corrects CUDA pointer-attribute results for managed memory.

## AI assistance disclosure

Codex assisted with source review or drafting this PR
description. I reviewed the change and take responsibility for its content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA pointer attribute handling when underlying queries fail.
  - Corrected managed-memory attribute reporting so related pointer queries return consistent results.
  - Prevented incomplete or misleading attribute processing after an unsuccessful CUDA operation.
  - Improved reliability when querying pointer attributes across different CUDA contexts and memory types.

- **Tests**
  - Added regression coverage for managed CUDA memory, pointer attribute consistency, invalid contexts, and CUDA-version-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
