### PR TITLE
fix: scale utilization watcher correction step linearly with SM count

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -86,8 +86,11 @@ static void change_token(int64_t delta, int device_id) {
 static int64_t delta(int up_limit, int user_current, int64_t share, int device_id) {
   int utilization_diff =
       abs(up_limit - user_current) < 5 ? 5 : abs(up_limit - user_current);
+  /* Keep the correction step linear in the SM count so it scales like the
+   * token pool (sm_num * max_thread_per_sm * FACTOR) and the step-to-pool
+   * ratio is the same on every device size. */
   int64_t increment =
-      (int64_t)g_sm_num[device_id] * (int64_t)g_sm_num[device_id] *
+      (int64_t)g_sm_num[device_id] *
       (int64_t)g_max_thread_per_sm[device_id] * (int64_t)utilization_diff / 2560;
 
   /* Accelerate cuda cores allocation when utilization vary widely */
@@ -190,7 +193,7 @@ int setspec() {
             CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, cu_dev));
         CHECK_CU_RESULT(cuDeviceGetAttribute(&g_max_thread_per_sm[dev],
             CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR, cu_dev));
-        g_total_cuda_cores[dev] = g_max_thread_per_sm[dev] * g_sm_num[dev] * FACTOR;
+        g_total_cuda_cores[dev] = (int64_t)g_max_thread_per_sm[dev] * g_sm_num[dev] * FACTOR;
         LOG_INFO("setspec: device %d sm_num=%d max_threads_per_sm=%d total_cores=%ld FACTOR=%d",
                  dev, g_sm_num[dev], g_max_thread_per_sm[dev], g_total_cuda_cores[dev], FACTOR);
     }

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -88,7 +88,9 @@ static int64_t delta(int up_limit, int user_current, int64_t share, int device_i
       abs(up_limit - user_current) < 5 ? 5 : abs(up_limit - user_current);
   /* Keep the correction step linear in the SM count so it scales like the
    * token pool (sm_num * max_thread_per_sm * FACTOR) and the step-to-pool
-   * ratio is the same on every device size. */
+   * ratio is the same on every device size:
+   *   increment / pool = utilization_diff / (2560 * FACTOR) = diff / 81920
+   * per 120 ms tick, before the acceleration branch below. */
   int64_t increment =
       (int64_t)g_sm_num[device_id] *
       (int64_t)g_max_thread_per_sm[device_id] * (int64_t)utilization_diff / 2560;


### PR DESCRIPTION
Fixes #274

Supersedes #271, which was closed because the issue had not been filed first; #274 now documents the hardware, reproduction, and measurements.

## Problem

The utilization watcher regulates future CUDA kernel submissions from NVML utilization feedback: `delta()` computes a correction step each 120 ms tick, and kernel launches spend tokens from a pool of `g_total_cuda_cores = sm_num * max_thread_per_sm * 32`.

The correction step scales with `sm_num * sm_num`, while the pool scales linearly with `sm_num`:

```text
pool       ∝ SM
correction ∝ SM²

correction / pool ∝ SM
```

So the relative controller gain grows with the device SM count. On an RTX PRO 6000 Blackwell Server Edition (188 SMs, driver 580.173.02, CUDA 13) with `CUDA_DEVICE_SM_LIMIT=50` and `GPU_CORE_UTILIZATION_POLICY=FORCE`, a large utilization error refilled the ~9.2M-token pool in under a second while draining it under sustained load took minutes — the controller degenerated into a bang-bang cycle whose ON phase ran at 99-100% utilization for minutes. The limiter itself was engaged (hostPid discovered, limit cached, `rate_limiter()` reached from `cuLaunchKernelEx`); the problem was the gain. Full traces are in #274.

## Fix

Drop one `sm_num` factor so the correction step scales like the pool:

```text
pool       ∝ SM
correction ∝ SM

correction / pool = utilization_diff / 81920
```

(before the existing acceleration multiplier) — independent of the device SM count, so small and large GPUs get the same controller dynamics.

Also promote the `g_total_cuda_cores` multiplication to `int64_t` so the intermediate `int` product cannot overflow before the assignment to the `int64_t` destination (raised during review of #271). This is defensive only — no overflow occurs on current devices (the largest value here today is ~9.2M vs INT_MAX ~2.1B).

Compared to #271, the extra `g_total_cuda_cores / 10` per-step cap was dropped to keep the diff minimal: after linear normalization the pre-acceleration step is bounded by `utilization_diff / 81920` of the pool (≤ ~0.13% per tick), and the cap never engaged in the recorded hardware runs.

## Validation

Reproduced and measured on real hardware as documented in #274 (RTX PRO 6000 Blackwell Server Edition, 188 SMs, driver 580.173.02, CUDA 13, PyTorch 2.13).

Before: sustained matmul load stayed near 99-100% utilization for minutes at a time despite the configured 50% limit.

With the linear correction scaling, measured utilization converged around the configured 50% target within roughly 20 seconds and stayed in a narrow band (20 s samples in #274: userutil 45 / 49 / 52 / 51 / 41 / 50).

`make build-in-docker` passes.

Two additional A/B runs (240 s sustained matmul, both libs built from the same tree, standalone LD_PRELOAD):

- `CUDA_DEVICE_SM_LIMIT=10` on the same 188-SM device: main averages ~26% device utilization with userutil swinging 0-72; patched converges to a 9-12 band within ~20 s and averages ~11%.
- `CUDA_DEVICE_SM_LIMIT=50` on a GTX 1080 (20 SMs): main degenerates into sustained 100% phases and averages ~81%; patched holds a band around 50 from the first ~20 s and averages ~49%.

Convergence takes roughly the same ~20 s on 20 SMs and 188 SMs — the normalized controller dynamics carry across a 9.4x SM range.

This PR intentionally does not change the kernel-cost model, the sampling interval, launch-hook behavior, or any other limiter semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GPU utilization correction across devices with different numbers of streaming multiprocessors.
  - Fixed arithmetic handling during CUDA core pool initialization to improve accuracy and reliability on larger configurations.
  - Enhanced consistency of GPU resource calculations across a wider range of hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->