### PR TITLE
fix: prevent OOB SIGSEGV from an undefined device id on context-less threads

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -316,10 +316,7 @@ int add_chunk_async(CUdeviceptr *address, size_t size, CUstream hStream) {
     size_t addr = 0;
     CUresult res = CUDA_SUCCESS;
     CUdevice dev;
-    if (cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
-        LOG_WARN("add_chunk_async: no current context, forwarding allocation without tracking");
-        return CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemAllocAsync, address, size, hStream);
-    }
+    cuCtxGetDevice(&dev);
     if (oom_check(dev, size))
         return CUDA_ERROR_OUT_OF_MEMORY;
 
@@ -345,10 +342,7 @@ int add_chunk_from_pool_async(CUdeviceptr *address, size_t size, CUmemoryPool po
     size_t addr = 0;
     CUresult res = CUDA_SUCCESS;
     CUdevice dev;
-    if (cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
-        LOG_WARN("add_chunk_from_pool_async: no current context, forwarding allocation without tracking");
-        return CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemAllocFromPoolAsync, address, size, pool, hStream);
-    }
+    cuCtxGetDevice(&dev);
     if (oom_check(dev, size))
         return CUDA_ERROR_OUT_OF_MEMORY;
 

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -254,18 +254,22 @@ int free_raw(CUdeviceptr dptr) {
 int remove_chunk_async(
     allocated_list *a_list, CUdeviceptr dptr, CUstream hStream) {
     size_t t_size;
+    CUdevice t_dev;
     allocated_list_entry *val;
     for (val = a_list->head; val != NULL; val = val->next) {
         if (val->entry->address == dptr) {
             t_size=val->entry->length;
+            /* Release against the device recorded when the allocation was
+             * charged, captured before LIST_REMOVE frees the entry. The
+             * freeing thread may have no current context, or a different
+             * current device, so asking cuCtxGetDevice here would skip or
+             * misattribute the release and leave the usage charged, which
+             * later surfaces as a spurious OOM. */
+            t_dev = val->entry->dev;
             CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemFreeAsync,dptr,hStream);
             LIST_REMOVE(a_list,val);
             a_list->limit-=t_size;
-            CUdevice dev;
-            if (cuCtxGetDevice(&dev) == CUDA_SUCCESS)
-                rm_gpu_device_memory_usage(getpid(), dev, t_size, 2);
-            else
-                LOG_WARN("remove_chunk_async: no current context, skipping accounting");
+            rm_gpu_device_memory_usage(getpid(), t_dev, t_size, 2);
             return 0;
         }
     }

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -35,10 +35,14 @@ size_t round_up(size_t size, size_t unit) {
 
 int oom_check(const int dev, size_t addon) {
     CUdevice d;
-    if (dev==-1)
-        cuCtxGetDevice(&d);
-    else
+    if (dev == -1) {
+        if (cuCtxGetDevice(&d) != CUDA_SUCCESS) {
+            LOG_WARN("oom_check: no current context, skipping enforcement");
+            return 0;
+        }
+    } else {
         d=dev;
+    }
     uint64_t limit = get_current_device_memory_limit(d);
     size_t _usage = get_gpu_memory_usage(d);
 
@@ -113,7 +117,17 @@ int add_chunk(CUdeviceptr *address, size_t size) {
     CUdevice dev;
     CUresult res;
 
-    cuCtxGetDevice(&dev);
+    if (cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
+        /* No current context on this thread (for example a worker thread that
+         * never bound one). We cannot attribute or bound this allocation to a
+         * device, so forward it to the driver rather than index per-device
+         * state with an undefined id. */
+        LOG_WARN("add_chunk: no current context, forwarding allocation without tracking");
+        if (size <= IPCSIZE) {
+            return CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemAlloc_v2, address, size);
+        }
+        return cuMemoryAllocate(address, size, NULL);
+    }
 
     /* OOM pre-check without lock */
     if (oom_check(dev, size))
@@ -248,8 +262,10 @@ int remove_chunk_async(
             LIST_REMOVE(a_list,val);
             a_list->limit-=t_size;
             CUdevice dev;
-            cuCtxGetDevice(&dev);
-            rm_gpu_device_memory_usage(getpid(),dev,t_size,2);
+            if (cuCtxGetDevice(&dev) == CUDA_SUCCESS)
+                rm_gpu_device_memory_usage(getpid(), dev, t_size, 2);
+            else
+                LOG_WARN("remove_chunk_async: no current context, skipping accounting");
             return 0;
         }
     }
@@ -296,7 +312,10 @@ int add_chunk_async(CUdeviceptr *address, size_t size, CUstream hStream) {
     size_t addr = 0;
     CUresult res = CUDA_SUCCESS;
     CUdevice dev;
-    cuCtxGetDevice(&dev);
+    if (cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
+        LOG_WARN("add_chunk_async: no current context, forwarding allocation without tracking");
+        return CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemAllocAsync, address, size, hStream);
+    }
     if (oom_check(dev, size))
         return CUDA_ERROR_OUT_OF_MEMORY;
 
@@ -322,7 +341,10 @@ int add_chunk_from_pool_async(CUdeviceptr *address, size_t size, CUmemoryPool po
     size_t addr = 0;
     CUresult res = CUDA_SUCCESS;
     CUdevice dev;
-    cuCtxGetDevice(&dev);
+    if (cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
+        LOG_WARN("add_chunk_from_pool_async: no current context, forwarding allocation without tracking");
+        return CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemAllocFromPoolAsync, address, size, pool, hStream);
+    }
     if (oom_check(dev, size))
         return CUDA_ERROR_OUT_OF_MEMORY;
 

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -289,6 +289,10 @@ int shrreg_minor_version() {
 size_t get_gpu_memory_monitor(const int dev) {
     LOG_DEBUG("get_gpu_memory_monitor_lockfree dev=%d", dev);
     ensure_initialized();
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        LOG_ERROR("Illegal device id: %d", dev);
+        return 0;
+    }
     int i=0;
     size_t total=0;
 
@@ -310,6 +314,10 @@ size_t get_gpu_memory_monitor(const int dev) {
 size_t get_gpu_memory_usage(const int dev) {
     LOG_INFO("get_gpu_memory_usage_lockfree dev=%d", dev);
     ensure_initialized();
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        LOG_ERROR("Illegal device id: %d", dev);
+        return 0;
+    }
     int i=0;
     size_t total=0;
 
@@ -482,6 +490,10 @@ int add_gpu_device_memory_usage(int32_t pid, int cudadev, size_t usage, int type
 
     int dev = cuda_to_nvml_map(cudadev);
     ensure_initialized();
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        LOG_ERROR("Illegal device id: %d (cudadev=%d)", dev, cudadev);
+        return -1;
+    }
 
     // Fast path: use the validated cached slot for our own process
     shrreg_proc_slot_t* self_slot = NULL;
@@ -557,6 +569,10 @@ int rm_gpu_device_memory_usage(int32_t pid, int cudadev, size_t usage, int type)
     LOG_INFO("rm_gpu_device_memory_lockfree:%d %d->%d %d:%lu", pid, cudadev, cuda_to_nvml_map(cudadev), type, usage);
     int dev = cuda_to_nvml_map(cudadev);
     ensure_initialized();
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        LOG_ERROR("Illegal device id: %d (cudadev=%d)", dev, cudadev);
+        return -1;
+    }
 
     // Fast path: use the validated cached slot for our own process
     shrreg_proc_slot_t* self_slot = NULL;
@@ -1451,6 +1467,7 @@ int get_current_device_sm_limit(int dev) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return -1;
     }
     return region_info.shared_region->sm_limit[dev];
 }
@@ -1459,6 +1476,7 @@ int set_current_device_memory_limit(const int dev,size_t newlimit) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return -1;
     }
     LOG_INFO("dev %d new limit set to %ld",dev,newlimit);
     region_info.shared_region->limit[dev]=newlimit;
@@ -1469,6 +1487,7 @@ uint64_t get_current_device_memory_limit(const int dev) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return 0;
     }
     return region_info.shared_region->limit[dev];       
 }
@@ -1477,6 +1496,7 @@ uint64_t get_current_device_memory_monitor(const int dev) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return 0;
     }
     uint64_t result = get_gpu_memory_monitor(dev);
 //    result= nvml_get_device_memory_usage(dev);
@@ -1490,6 +1510,7 @@ uint64_t get_current_device_memory_usage(const int dev) {
     ensure_initialized();
     if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
         LOG_ERROR("Illegal device id: %d", dev);
+        return 0;
     }
     result = get_gpu_memory_usage(dev);
 //    result= nvml_get_device_memory_usage(dev);

--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -118,6 +118,10 @@ unsigned int nvml_to_cuda_map(unsigned int nvmldev){
 }
 
 unsigned int cuda_to_nvml_map(unsigned int cudadev){
+    if (cudadev >= CUDA_DEVICE_MAX_COUNT) {
+        LOG_ERROR("Illegal cuda device id: %u", cudadev);
+        return CUDA_DEVICE_MAX_COUNT;
+    }
     return cuda_to_nvml_map_array[cudadev];
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     get_filename_component(TEST_TARGET_NAME ${RELATIVE_TEST_PATH} NAME_WE)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR})
 
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR TEST_TARGET_NAME STREQUAL "test_device_id_guard")
         # Build this focused regression test with the production shared-region
         # implementation.  It does not invoke any CUDA/NVML entry point at
         # runtime.  Section garbage collection drops unrelated GPU-facing
@@ -38,7 +38,7 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     endif()
 
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR TEST_TARGET_NAME STREQUAL "test_device_id_guard")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         target_link_libraries(${TEST_TARGET_NAME} -ldl)
@@ -57,6 +57,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME postinit_owner_death
     COMMAND test_postinit_owner_death)
 set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
+
+add_test(NAME device_id_guard
+    COMMAND test_device_id_guard)
+set_tests_properties(device_id_guard PROPERTIES TIMEOUT 20)
 
 add_test(NAME dlsym_rtld_next
     COMMAND test_dlsym_rtld_next)

--- a/test/test_device_id_guard.c
+++ b/test/test_device_id_guard.c
@@ -1,0 +1,133 @@
+/*
+ * GPU-free regression test for device-id bounds checking in the shared-region
+ * accessors.
+ *
+ * On a thread with no current CUDA context, cuCtxGetDevice() returns
+ * CUDA_ERROR_INVALID_CONTEXT and leaves its output parameter unwritten, so an
+ * undefined device id can reach the per-device shared-region arrays (limit[],
+ * sm_limit[], used[], ...), each sized [CUDA_DEVICE_MAX_COUNT].  Indexing those
+ * arrays with an out-of-range id is an out-of-bounds read or write and crashes
+ * with SIGSEGV.  Every accessor must reject an id outside
+ * [0, CUDA_DEVICE_MAX_COUNT) and return a safe value instead of indexing.
+ *
+ * This test feeds a battery of out-of-range ids (including the exact garbage
+ * value observed in the field) into every guarded accessor and asserts a safe
+ * return with no crash.  It also confirms the guard leaves the normal in-range
+ * path untouched.  It invokes no CUDA/NVML entry point; section garbage
+ * collection drops the GPU-facing production code at link time.
+ */
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "multiprocess/multiprocess_memory_limit.h"
+
+/*
+ * A device id observed in a field crash report when cuCtxGetDevice() left its
+ * output unwritten: uninitialized stack garbage reused as an array index.
+ */
+#define FIELD_GARBAGE_DEV 1716861768
+
+static const int kIllegalDevs[] = {
+    -1,
+    -1000000,
+    CUDA_DEVICE_MAX_COUNT,
+    CUDA_DEVICE_MAX_COUNT + 1,
+    1000,
+    FIELD_GARBAGE_DEV,
+};
+#define ILLEGAL_DEV_COUNT ((int)(sizeof(kIllegalDevs) / sizeof(kIllegalDevs[0])))
+
+static int failures;
+
+static void expect_eq(const char *what, int dev, int64_t got, int64_t want) {
+    if (got != want) {
+        fprintf(stderr, "%s(dev=%d): got %" PRId64 ", expected %" PRId64 "\n",
+                what, dev, got, want);
+        failures++;
+    }
+}
+
+static void check_illegal_dev(int dev) {
+    /* int-returning accessor: -1 error sentinel. */
+    expect_eq("get_current_device_sm_limit", dev,
+              get_current_device_sm_limit(dev), -1);
+    /*
+     * Write path: must refuse with -1 and not store into limit[dev].  This is
+     * the out-of-bounds *write* that corrupts memory in the field.
+     */
+    expect_eq("set_current_device_memory_limit", dev,
+              set_current_device_memory_limit(dev, 4096), -1);
+    /* uint64_t / size_t getters: 0 == "no limit / no usage", safe downstream. */
+    expect_eq("get_current_device_memory_limit", dev,
+              (int64_t)get_current_device_memory_limit(dev), 0);
+    /* Exercises get_gpu_memory_monitor() transitively. */
+    expect_eq("get_current_device_memory_monitor", dev,
+              (int64_t)get_current_device_memory_monitor(dev), 0);
+    /* Exercises get_gpu_memory_usage() transitively. */
+    expect_eq("get_current_device_memory_usage", dev,
+              (int64_t)get_current_device_memory_usage(dev), 0);
+    expect_eq("get_gpu_memory_usage", dev,
+              (int64_t)get_gpu_memory_usage(dev), 0);
+}
+
+static void check_valid_dev(void) {
+    /* The guard must not disturb the normal in-range path. */
+    const int dev = 0;
+    const uint64_t limit = 123456789;
+
+    if (set_current_device_memory_limit(dev, limit) != 0) {
+        fprintf(stderr,
+                "set_current_device_memory_limit(dev=0) failed on the valid path\n");
+        failures++;
+    }
+    if (get_current_device_memory_limit(dev) != limit) {
+        fprintf(stderr,
+                "get_current_device_memory_limit(dev=0) did not read back the stored limit\n");
+        failures++;
+    }
+    /* These must return without crashing for a valid id. */
+    (void)get_current_device_sm_limit(dev);
+    (void)get_current_device_memory_monitor(dev);
+    (void)get_current_device_memory_usage(dev);
+    (void)get_gpu_memory_usage(dev);
+}
+
+int main(void) {
+    char cache_path[] = "/tmp/hami-device-id-guard.XXXXXX";
+    int cache_fd;
+    int i;
+
+    cache_fd = mkstemp(cache_path);
+    if (cache_fd < 0) {
+        perror("mkstemp(shared-region cache)");
+        return 1;
+    }
+    close(cache_fd);
+    unlink(cache_path);
+    if (setenv(MULTIPROCESS_SHARED_REGION_CACHE_ENV, cache_path, 1) != 0 ||
+        setenv("LIBCUDA_LOG_LEVEL", "0", 1) != 0) {
+        perror("setenv");
+        return 1;
+    }
+
+    log_utils_init();
+    ensure_initialized();
+
+    for (i = 0; i < ILLEGAL_DEV_COUNT; i++) {
+        check_illegal_dev(kIllegalDevs[i]);
+    }
+    check_valid_dev();
+
+    unlink(cache_path);
+    if (failures != 0) {
+        fprintf(stderr, "%d device-id guard assertion(s) failed\n", failures);
+        return 1;
+    }
+    puts("device-id guard tests passed");
+    return 0;
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix.

**What this PR does / why we need it**:

On a thread with no current CUDA context, `cuCtxGetDevice()` returns `CUDA_ERROR_INVALID_CONTEXT` and does not write its output parameter. The uninitialized value was then used as a device id to index the fixed-size `[CUDA_DEVICE_MAX_COUNT]` per-device arrays in the mmap'd shared region, an out-of-bounds access that crashes the process with SIGSEGV. This reproduces deterministically on multi-rank torchrun workers and is the root cause behind #276 and #234.

The fix hardens device-id handling in three layers, none of which changes behavior for valid ids:

1. Allocator sources (`src/allocator/allocator.c`): `add_chunk`, `add_chunk_async`, `add_chunk_from_pool_async`, and `oom_check` now check the `cuCtxGetDevice` return code. On failure they forward the allocation to the driver or skip enforcement rather than indexing per-device state with an undefined id. They never fall back to device 0. `remove_chunk_async` no longer consults the current context at all: it releases against the device recorded on the allocation entry, captured before `LIST_REMOVE` frees that entry, which stays correct even when the freeing thread has no context or a different current device.
2. Shared-region accessors (`src/multiprocess/multiprocess_memory_limit.c`): each accessor bounds-checks the id and returns a safe sentinel. Five getters already had the guard condition but were missing the early return, so they logged the illegal id and then indexed the array anyway; this adds the missing returns (-1 for the int helpers, 0 for the size and usage getters).
3. NVML mapping (`src/multiprocess/multiprocess_utilization_watcher.c`): `cuda_to_nvml_map()` rejects an out-of-range id and returns a sentinel instead of indexing its lookup array.

A GPU-free regression test (`test/test_device_id_guard.c`) feeds a battery of out-of-range ids, including the exact value seen in the field, into every guarded accessor and asserts a safe return with no crash, and confirms the valid in-range path is untouched.

**Which issue(s) this PR fixes**:

Fixes #289

**Special notes for your reviewer**:

Related to #276 and #234, which report the same SIGSEGV with large or nonsensical device ids.

Validation performed locally:
- CI-parity build in the nvidia/cuda:13.3.0-cudnn-devel-ubi8 image (matches the repo build workflow): clean, no new warnings.
- New `device_id_guard` test passes, as do `postinit_owner_death` and `dlsym_rtld_next`. `dlsym_rtld_next_preloaded` fails locally because the container has no NVIDIA driver and cannot load `libcuda.so.1`; it fails identically on a pristine `origin/main` build, so it is pre-existing and environmental.
- Hook static consistency check passes (entries 211, wrappers 217).
- cpplint (linelength 120) reports no findings on any changed line.
- Deterministic before/after: the same harness crashes with SIGSEGV (exit 139) against `main` and exits cleanly against this branch. It also demonstrates the silent out-of-bounds write on `main`, where `set_current_device_memory_limit(-1, 4096)` stores into `limit[-1]` and a subsequent read returns 4096.

I do not have multi-GPU hardware, so I could not add a live end-to-end torchrun repro; the regression test reproduces the crash path without a GPU.

Review follow-up: the second commit reworks `remove_chunk_async`. An earlier revision of this PR skipped the usage release when the freeing thread had no context, which would have left the allocation charged and produced a spurious OOM later. Thanks to the automated review for spotting that. The device has to be read before `LIST_REMOVE`, since that macro frees the entry.

One related observation I deliberately left alone, happy to fold it in if you would prefer: when an allocation is forwarded untracked, a later `cuMemFree_v2` reaches `remove_chunk`, which returns -1 for an unknown pointer. That path looks unreachable in practice, since a context-less `cuMemAlloc_v2` fails at the driver and nothing is allocated to free. The async free path already handles the untracked case by forwarding the free to the driver, so making the synchronous path symmetric would be a small follow-up.

AI assistance disclosure: I used AI (Claude) to help analyze the crash and draft this change. I reviewed, edited, and validated the code and wrote the commit messages myself.

**Does this PR introduce a user-facing change?**:

```release-note
Fix a SIGSEGV caused by an undefined device id from a context-less thread being used to index per-device shared-region arrays.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory allocation accounting to prevent concurrent allocations from exceeding device memory limits.
  * Ensured failed allocations roll back reserved capacity safely.
  * Improved handling of allocations when no CUDA context is active.
  * Ensured asynchronous memory removal uses the allocation’s device for accurate accounting.
  * Added safeguards for invalid GPU device IDs across memory tracking and monitoring operations.
  * Prevented unsafe device mapping access and provided appropriate error handling.

* **Tests**
  * Added regression coverage for concurrent allocation limits, process cleanup, device validation, and utilization monitoring.
  * Added GPU-free tests for invalid and valid device ID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->