### PR TITLE
fix: make ctx_activate carry its own 0 <-> 1 transition

### DIFF
--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -2,7 +2,6 @@
 #include "multiprocess/multiprocess_memory_limit.h"
 
 extern size_t context_size;
-extern int ctx_activate[16];
 
 
 CUresult cuDevicePrimaryCtxGetState( CUdevice dev, unsigned int* flags, int* active ){
@@ -15,11 +14,8 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
     LOG_INFO("dev=%d context_size=%ld",dev,context_size);
     //for Initialization only
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuDevicePrimaryCtxRetain,pctx,dev);
-    if (ctx_activate[dev] == 0) {
-        add_gpu_device_memory_usage(getpid(),dev,context_size,0); 
-    }
-    if (context_size>0) {
-        ctx_activate[dev] = 1;
+    if (context_size > 0 && ctx_activate_acquire(dev)) {
+        add_gpu_device_memory_usage(getpid(), dev, context_size, 0);
     }
     return res;
 }
@@ -31,10 +27,9 @@ CUresult cuDevicePrimaryCtxSetFlags_v2( CUdevice dev, unsigned int  flags ){
 }
 
 CUresult cuDevicePrimaryCtxRelease_v2( CUdevice dev ){
-    if (ctx_activate[dev] == 1) {
-        rm_gpu_device_memory_usage(getpid(),dev,context_size,0);
+    if (ctx_activate_release(dev)) {
+        rm_gpu_device_memory_usage(getpid(), dev, context_size, 0);
     }
-    ctx_activate[dev] = 0;
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuDevicePrimaryCtxRelease_v2,dev);
     return res;
 }

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -44,7 +44,7 @@ _Static_assert(POSTINIT_FILE_LOCK_OFFSET > (off_t)sizeof(shared_region_t),
 
 int pidfound;
 
-int ctx_activate[32];
+_Atomic int ctx_activate[CUDA_DEVICE_MAX_COUNT];
 
 static shared_region_info_t region_info = {0, -1, PTHREAD_ONCE_INIT, NULL, 0, NULL};
 static atomic_flag postinit_local_lock = ATOMIC_FLAG_INIT;

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -154,6 +154,23 @@ int init_gpu_device_utilization();
 int add_gpu_device_memory_usage(int32_t pid,int dev,size_t usage,int type);
 int rm_gpu_device_memory_usage(int32_t pid,int dev,size_t usage,int type);
 
+// Tracks whether this process already accounted the primary context on a
+// device. The CUDA hooks run on any thread, so the flag has to carry the
+// 0 <-> 1 transition itself: only the thread that wins the exchange adds or
+// removes context_size, otherwise concurrent cuDevicePrimaryCtxRetain calls
+// double-count the process against its own memory limit.
+extern _Atomic int ctx_activate[CUDA_DEVICE_MAX_COUNT];
+
+static inline int ctx_activate_acquire(int dev) {
+    int expected = 0;
+    return atomic_compare_exchange_strong(&ctx_activate[dev], &expected, 1);
+}
+
+static inline int ctx_activate_release(int dev) {
+    int expected = 1;
+    return atomic_compare_exchange_strong(&ctx_activate[dev], &expected, 0);
+}
+
 shrreg_proc_slot_t *find_proc_by_hostpid(int hostpid);
 int active_oom_killer();
 void pre_launch_kernel();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     get_filename_component(TEST_TARGET_NAME ${RELATIVE_TEST_PATH} NAME_WE)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR})
 
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR
+        TEST_TARGET_NAME STREQUAL "test_ctx_activate_race")
         # Build this focused regression test with the production shared-region
         # implementation.  It does not invoke any CUDA/NVML entry point at
         # runtime.  Section garbage collection drops unrelated GPU-facing
@@ -38,7 +39,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     endif()
 
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR
+        TEST_TARGET_NAME STREQUAL "test_ctx_activate_race")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         target_link_libraries(${TEST_TARGET_NAME} -ldl)
@@ -57,6 +59,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME postinit_owner_death
     COMMAND test_postinit_owner_death)
 set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
+
+add_test(NAME ctx_activate_race
+    COMMAND test_ctx_activate_race)
+set_tests_properties(ctx_activate_race PROPERTIES TIMEOUT 30)
 
 add_test(NAME dlsym_rtld_next
     COMMAND test_dlsym_rtld_next)

--- a/test/test_ctx_activate_race.c
+++ b/test/test_ctx_activate_race.c
@@ -1,0 +1,80 @@
+/*
+ * GPU-free regression test for the ctx_activate primary-context flag.
+ *
+ * cuDevicePrimaryCtxRetain and cuDevicePrimaryCtxRelease_v2 run on any thread
+ * and charge context_size to the process once per device.  The flag that gates
+ * that accounting has to carry the 0 <-> 1 transition itself, so exactly one
+ * thread performs the add and exactly one performs the matching remove.
+ *
+ * The invariant checked here is that the two stay balanced.  Every add must be
+ * paired with a remove, otherwise the process accumulates charges for contexts
+ * it never held and starts failing allocations against memory it is not using.
+ *
+ * With a plain int and a separate test-then-set, four threads drift by
+ * thousands of unpaired adds over this many iterations.
+ */
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+
+#include "multiprocess/multiprocess_memory_limit.h"
+
+#define THREAD_COUNT 4
+#define ITERATIONS 200000
+#define TEST_DEV 0
+
+static _Atomic long adds;
+static _Atomic long removes;
+
+static void *worker(void *arg) {
+    (void)arg;
+    for (int i = 0; i < ITERATIONS; i++) {
+        /* Stands in for add_gpu_device_memory_usage(getpid(), dev, context_size, 0). */
+        if (ctx_activate_acquire(TEST_DEV)) {
+            atomic_fetch_add(&adds, 1);
+        }
+        /* Stands in for rm_gpu_device_memory_usage(getpid(), dev, context_size, 0). */
+        if (ctx_activate_release(TEST_DEV)) {
+            atomic_fetch_add(&removes, 1);
+        }
+    }
+    return NULL;
+}
+
+int main(void) {
+    pthread_t threads[THREAD_COUNT];
+
+    for (int i = 0; i < THREAD_COUNT; i++) {
+        if (pthread_create(&threads[i], NULL, worker, NULL) != 0) {
+            fprintf(stderr, "pthread_create failed\n");
+            return 1;
+        }
+    }
+    for (int i = 0; i < THREAD_COUNT; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    long a = atomic_load(&adds);
+    long r = atomic_load(&removes);
+    int failures = 0;
+
+    if (a != r) {
+        fprintf(stderr, "unbalanced context accounting: %ld add(s), %ld remove(s), drift %ld\n",
+                a, r, a - r);
+        failures++;
+    }
+    if (atomic_load(&ctx_activate[TEST_DEV]) != 0) {
+        fprintf(stderr, "ctx_activate[%d] ended set\n", TEST_DEV);
+        failures++;
+    }
+    if (a == 0) {
+        fprintf(stderr, "no transitions observed, test did not exercise the flag\n");
+        failures++;
+    }
+
+    if (failures != 0) {
+        return 1;
+    }
+    printf("ctx_activate race test passed (%ld paired add/remove)\n", a);
+    return 0;
+}


### PR DESCRIPTION
Second race from #269 — #282 covers the seqlock, not this one. I asked on the
issue whether you wanted a new issue or that one reopened and didn't hear back,
so here's the patch.

`cuDevicePrimaryCtxRetain` tested the flag and set it in two separate
statements:

```c
if (ctx_activate[dev] == 0) {
    add_gpu_device_memory_usage(getpid(),dev,context_size,0);
}
if (context_size>0) {
    ctx_activate[dev] = 1;
}
```

Nothing holds across those two ifs. Two threads retaining the same primary
context both read 0, both call `add_gpu_device_memory_usage`, and the process
gets charged twice for one context. Release has the same problem in reverse.

This one is process-local so it doesn't need the cross-process CAS from #282.
`_Atomic int` and a compare-exchange covers it — whoever wins 0 -> 1 does the
add, whoever wins 1 -> 0 does the remove.

I moved the declaration into the header behind
`ctx_activate_acquire`/`ctx_activate_release`, mostly so the test can call the
real thing. `context.c` won't link without the CUDA hooks, so a test that
included it couldn't build GPU-free.

While doing that I noticed `context.c` declares the array as
`extern int ctx_activate[16]` while `multiprocess_memory_limit.c` defines it as
`[32]`. Not compatible types across TUs. Both are `CUDA_DEVICE_MAX_COUNT` now,
which is what `dev` already indexes `used[]` with a line later.

One behaviour change worth flagging: the old code called
`add_gpu_device_memory_usage(..., context_size, 0)` even when `context_size`
was 0, which added nothing and left the flag clear. The new code skips the call.

Four threads, 200k iterations each, built in the CI image:

| | adds | removes | drift |
| --- | --- | --- | --- |
| before | 734,980 | 734,964 | 16 |
| before | 727,138 | 727,180 | -42 |
| before | 759,907 | 759,938 | -31 |
| after | 209,146 | 209,146 | 0 |

Drift is accounting the process never gets back, or a release for a charge it
never made. Small per run, but it doesn't wash out — a long-lived process keeps
collecting it. Five runs patched, all zero.

```bash
cmake --build build --target test_ctx_activate_race
./build/test/test_ctx_activate_race
```

To see it fail, put the two helpers back to a plain `int` with a separate
test-then-set and rebuild.

`make build-in-docker` is clean. Under ctest `ctx_activate_race`,
`postinit_owner_death` and `dlsym_rtld_next` pass. `dlsym_rtld_next_preloaded`
fails in my container because it LD_PRELOADs libvgpu and there's no driver
there. No multi-GPU box here either, but the race is in process-local
accounting and repros without a GPU at all.

Didn't touch anything else in `context.c`. It still doesn't check `res` from
the retain before accounting, which seemed like a separate question.
