### PR TITLE
Fix inherited exit cleanup in clone children

### DIFF
--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -858,7 +858,18 @@ void exit_handler() {
         return;
     }
 
-    int32_t my_pid = region_info.pid;
+    /*
+     * Identity is the calling process, not the cached parent pid.  After
+     * clone()/fork paths that skip pthread_atfork, region_info.pid still
+     * belongs to the parent; using it here would drop the parent's slot
+     * and sem_post a lock the parent still holds.
+     */
+    int32_t my_pid = getpid();
+    if (region_info.pid != 0 && region_info.pid != my_pid) {
+        LOG_DEBUG("Skip inherited exit cleanup; cached pid %d != self %d",
+                  region_info.pid, my_pid);
+        return;
+    }
     LOG_MSG("Cleanup on exit for PID %d", my_pid);
 
     // ========================================================================
@@ -913,7 +924,7 @@ void lock_shrreg() {
 
         if (status == 0) {
             // TODO: irregular exit here will hang pending locks
-            region->owner_pid = region_info.pid;
+            region->owner_pid = (size_t)getpid();
             __sync_synchronize();
             SEQ_POINT_MARK(SEQ_UPDATE_OWNER_OK);
             trials = 0;
@@ -1143,8 +1154,9 @@ void print_all() {
 }
 
 void child_reinit_flag() {
-    LOG_DEBUG("Detect child pid: %d -> %d", region_info.pid, getpid());   
+    LOG_DEBUG("Detect child pid: %d -> %d", region_info.pid, getpid());
     region_info.init_status = PTHREAD_ONCE_INIT;
+    region_info.pid = getpid();
     postinit_lock_held = 0;
     atomic_flag_clear_explicit(&postinit_local_lock, memory_order_release);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     get_filename_component(TEST_TARGET_NAME ${RELATIVE_TEST_PATH} NAME_WE)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR})
 
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death"
+            OR TEST_TARGET_NAME STREQUAL "test_fork_child_exit_cleanup")
         # Build this focused regression test with the production shared-region
         # implementation.  It does not invoke any CUDA/NVML entry point at
         # runtime.  Section garbage collection drops unrelated GPU-facing
@@ -38,7 +39,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     endif()
 
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death"
+            OR TEST_TARGET_NAME STREQUAL "test_fork_child_exit_cleanup")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         target_link_libraries(${TEST_TARGET_NAME} -ldl)
@@ -57,6 +59,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME postinit_owner_death
     COMMAND test_postinit_owner_death)
 set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
+
+add_test(NAME fork_child_exit_cleanup
+    COMMAND test_fork_child_exit_cleanup)
+set_tests_properties(fork_child_exit_cleanup PROPERTIES TIMEOUT 20)
 
 add_test(NAME dlsym_rtld_next
     COMMAND test_dlsym_rtld_next)

--- a/test/test_fork_child_exit_cleanup.c
+++ b/test/test_fork_child_exit_cleanup.c
@@ -1,0 +1,279 @@
+/*
+ * GPU-free regression for inherited atexit(exit_handler) after a child is
+ * created without pthread_atfork.  glibc fork() runs the atfork reset, but
+ * clone(SIGCHLD) does not.  After that child exit(0)s, the parent must still
+ * own the shared-region lock and keep its process slot.
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "multiprocess/multiprocess_memory_limit.h"
+
+#define TEST_TIMEOUT_MS 5000.0
+
+typedef struct {
+    _Atomic int probe_entered;
+} test_state_t;
+
+static test_state_t *state;
+static shared_region_t *region;
+
+static double now_ms(void) {
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0.0;
+    }
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1000000.0;
+}
+
+static void sleep_ms(int milliseconds) {
+    struct timespec ts;
+
+    ts.tv_sec = milliseconds / 1000;
+    ts.tv_nsec = (milliseconds % 1000) * 1000000L;
+    while (nanosleep(&ts, &ts) != 0 && errno == EINTR) {
+    }
+}
+
+static int wait_for_counter(_Atomic int *counter, int expected,
+                            double timeout_ms) {
+    double deadline = now_ms() + timeout_ms;
+
+    while (atomic_load_explicit(counter, memory_order_acquire) < expected) {
+        if (now_ms() >= deadline) {
+            return -1;
+        }
+        sleep_ms(1);
+    }
+    return 0;
+}
+
+static int wait_child_bounded(pid_t child, double timeout_ms, int *status_out) {
+    double deadline = now_ms() + timeout_ms;
+    int status;
+    pid_t waited;
+
+    for (;;) {
+        do {
+            waited = waitpid(child, &status, WNOHANG);
+        } while (waited < 0 && errno == EINTR);
+        if (waited == child) {
+            if (status_out != NULL) {
+                *status_out = status;
+            }
+            return 0;
+        }
+        if (waited < 0) {
+            return -1;
+        }
+        if (now_ms() >= deadline) {
+            return -1;
+        }
+        sleep_ms(1);
+    }
+}
+
+static void kill_and_reap(pid_t child) {
+    int status;
+
+    if (child <= 0) {
+        return;
+    }
+    if (waitpid(child, &status, WNOHANG) == child) {
+        return;
+    }
+    kill(child, SIGKILL);
+    while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+    }
+}
+
+static pid_t clone_without_atfork(void) {
+    return (pid_t)syscall(SYS_clone, SIGCHLD, 0);
+}
+
+static int map_shared_region(const char *cache_path) {
+    int fd = open(cache_path, O_RDWR);
+
+    if (fd < 0) {
+        perror("open(shared-region cache)");
+        return -1;
+    }
+    region = mmap(NULL, SHARED_REGION_SIZE_MAGIC, PROT_READ | PROT_WRITE,
+                  MAP_SHARED, fd, 0);
+    close(fd);
+    if (region == MAP_FAILED) {
+        perror("mmap(shared-region cache)");
+        region = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+static int parent_slot_live(int32_t parent_pid) {
+    int proc_num = atomic_load_explicit(&region->proc_num, memory_order_acquire);
+    int i;
+
+    if (proc_num < 1 || proc_num > SHARED_REGION_MAX_PROCESS_NUM) {
+        return 0;
+    }
+    for (i = 0; i < proc_num; i++) {
+        if (atomic_load_explicit(&region->procs[i].pid, memory_order_acquire) ==
+            parent_pid) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int expect_parent_still_holds_lock(int32_t parent_pid, const char *when) {
+    int sem_value = -1;
+    size_t owner = atomic_load_explicit(&region->owner_pid, memory_order_acquire);
+
+    if (sem_getvalue(&region->sem, &sem_value) != 0) {
+        fprintf(stderr, "%s: sem_getvalue failed: %s\n", when, strerror(errno));
+        return -1;
+    }
+    if (sem_value != 0) {
+        fprintf(stderr, "%s: child posted parent's lock (sem=%d)\n", when,
+                sem_value);
+        return -1;
+    }
+    if (owner != (size_t)parent_pid) {
+        fprintf(stderr, "%s: owner_pid=%zu, want parent %d\n", when, owner,
+                parent_pid);
+        return -1;
+    }
+    if (!parent_slot_live(parent_pid)) {
+        fprintf(stderr, "%s: parent slot pid was cleared\n", when);
+        return -1;
+    }
+    return 0;
+}
+
+static int test_clone_child_exit_does_not_drop_parent_lock(void) {
+    pid_t clone_child;
+    pid_t probe = -1;
+    int32_t parent_pid = getpid();
+    int status;
+    int sem_value = -1;
+    int result = -1;
+
+    lock_shrreg();
+    if (expect_parent_still_holds_lock(parent_pid, "before clone") != 0) {
+        unlock_shrreg();
+        return -1;
+    }
+
+    clone_child = clone_without_atfork();
+    if (clone_child < 0) {
+        fprintf(stderr, "clone(SIGCHLD) failed: %s\n", strerror(errno));
+        unlock_shrreg();
+        return -1;
+    }
+    if (clone_child == 0) {
+        /* Inherited atexit must not impersonate the parent. */
+        exit(0);
+    }
+    if (wait_child_bounded(clone_child, TEST_TIMEOUT_MS, &status) != 0 ||
+        !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "clone child did not exit(0)\n");
+        unlock_shrreg();
+        return -1;
+    }
+
+    /* Direct invariants: no sleep.  The bug posts the sem and zeros the slot. */
+    if (expect_parent_still_holds_lock(parent_pid, "after clone-child exit") !=
+        0) {
+        unlock_shrreg();
+        return -1;
+    }
+
+    unlock_shrreg();
+    if (sem_getvalue(&region->sem, &sem_value) != 0 || sem_value != 1) {
+        fprintf(stderr, "parent unlock left sem=%d, want 1\n", sem_value);
+        return -1;
+    }
+
+    probe = fork();
+    if (probe < 0) {
+        fprintf(stderr, "fork(probe) failed: %s\n", strerror(errno));
+        return -1;
+    }
+    if (probe == 0) {
+        ensure_initialized();
+        atomic_fetch_add_explicit(&state->probe_entered, 1,
+                                  memory_order_release);
+        _exit(0);
+    }
+    if (wait_for_counter(&state->probe_entered, 1, TEST_TIMEOUT_MS) != 0 ||
+        wait_child_bounded(probe, TEST_TIMEOUT_MS, &status) != 0 ||
+        !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "probe could not initialize after parent unlocked\n");
+        goto cleanup;
+    }
+    probe = -1;
+    result = 0;
+
+cleanup:
+    kill_and_reap(probe);
+    return result;
+}
+
+int main(void) {
+    char cache_path[] = "/tmp/hami-fork-child-exit.XXXXXX";
+    int cache_fd;
+
+    cache_fd = mkstemp(cache_path);
+    if (cache_fd < 0) {
+        perror("mkstemp(shared-region cache)");
+        return 1;
+    }
+    close(cache_fd);
+    unlink(cache_path);
+    if (setenv(MULTIPROCESS_SHARED_REGION_CACHE_ENV, cache_path, 1) != 0 ||
+        setenv("LIBCUDA_LOG_LEVEL", "0", 1) != 0) {
+        perror("setenv");
+        return 1;
+    }
+
+    state = mmap(NULL, sizeof(*state), PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (state == MAP_FAILED) {
+        perror("mmap(test state)");
+        return 1;
+    }
+    memset(state, 0, sizeof(*state));
+    log_utils_init();
+    ensure_initialized();
+    if (map_shared_region(cache_path) != 0) {
+        unlink(cache_path);
+        munmap(state, sizeof(*state));
+        return 1;
+    }
+
+    if (test_clone_child_exit_does_not_drop_parent_lock() != 0) {
+        unlink(cache_path);
+        munmap(region, SHARED_REGION_SIZE_MAGIC);
+        munmap(state, sizeof(*state));
+        return 1;
+    }
+
+    unlink(cache_path);
+    munmap(region, SHARED_REGION_SIZE_MAGIC);
+    munmap(state, sizeof(*state));
+    puts("fork-child exit cleanup tests passed");
+    return 0;
+}

--- a/test/test_fork_child_exit_cleanup.c
+++ b/test/test_fork_child_exit_cleanup.c
@@ -218,13 +218,20 @@ static int test_clone_child_exit_does_not_drop_parent_lock(void) {
                                   memory_order_release);
         _exit(0);
     }
-    if (wait_for_counter(&state->probe_entered, 1, TEST_TIMEOUT_MS) != 0 ||
-        wait_child_bounded(probe, TEST_TIMEOUT_MS, &status) != 0 ||
-        !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+    if (wait_for_counter(&state->probe_entered, 1, TEST_TIMEOUT_MS) != 0) {
         fprintf(stderr, "probe could not initialize after parent unlocked\n");
         goto cleanup;
     }
+    if (wait_child_bounded(probe, TEST_TIMEOUT_MS, &status) != 0) {
+        fprintf(stderr, "probe could not initialize after parent unlocked\n");
+        goto cleanup;
+    }
+    /* Child already reaped; clear before any abnormal-status failure path. */
     probe = -1;
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "probe could not initialize after parent unlocked\n");
+        goto cleanup;
+    }
     result = 0;
 
 cleanup:


### PR DESCRIPTION
A child process created without running the `pthread_atfork` child handler can inherit the parent's initialized `region_info`, including `region_info.pid`.

For example, a child created with direct `clone()` does not run `child_reinit_flag`, so both the cached parent PID and initialized `region_info.init_status` remain in the child. If the child then exits with `exit()` without re-initializing, the inherited `exit_handler` runs.

Previously, `exit_handler` used:

```c id="82x1ue"
int32_t my_pid = region_info.pid;
```

Since `region_info.pid` can still contain the parent's PID, the child may treat the parent's state as its own. It can call `sem_post()` on a semaphore still owned by the parent and clear the parent's entry in `procs[]`. This could allow another process to enter the critical section or remove the parent's GPU usage/accounting state.

**Fix**

I changed `exit_handler` to use the actual PID of the running process:

```c id="zqkk11"
int32_t my_pid = getpid();
```

If the cached `region_info.pid` is set but does not match `getpid()`, the handler returns without modifying the inherited state.

I also changed `lock_shrreg()` to record `owner_pid` using `getpid()`, so the recorded lock owner is always the actual process holding the lock.

For the normal `fork()` path, `child_reinit_flag` already resets:

```c id="y45sw8"
region_info.init_status = PTHREAD_ONCE_INIT;
```

I additionally update `region_info.pid` with `getpid()` there, keeping the cached PID consistent for later initialization or shared-region work in the child.

**Test**

Tested on Ubuntu 26.04 (WSL2, x86_64, GCC 15.2.0) without GPU/CUDA. The new test fails on `main` (`sem=1`) and passes with this fix, and the existing `postinit_owner_death` test still passes.

I added `test/test_fork_child_exit_cleanup.c` to reproduce the issue.

The test uses `clone(SIGCHLD)` instead of `fork()` because a normal `fork()` runs `pthread_atfork(..., child_reinit_flag)`, which resets `init_status` and causes `exit_handler` to return early. Using `clone(SIGCHLD)` reproduces the path where the child inherits the initialized state without running the atfork handler.

With the original code, the child exits and incorrectly releases the parent's semaphore:

```text id="9b8t1v"
after clone-child exit: child posted parent's lock (sem=1)
exit:1
```

With the fix, the test verifies that after the child exits:

* `sem == 0`, so the parent's lock is still held.
* `owner_pid` is still the parent's PID.
* The parent's PID remains in `procs[]`.

The parent then releases the lock normally, and another process successfully initializes, checking that the lock is not left stuck.

```text id="vgv9j3"
fork-child exit cleanup tests passed
exit:0
```

The test follows the existing GPU-free test setup, so CUDA/NVML hardware is not required.

This fix is limited to inherited cleanup state in child processes that do not run the registered `pthread_atfork` child handler. The normal `fork()` path already resets the initialization state through `child_reinit_flag`.

**AI usage**

I used ChatGPT to help translate my PR description into English and Cursor for assistance while writing the code. I personally reviewed the code, reproduced the issue, ran the tests, and checked the overall behavior and results myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup and identity handling after fork and clone operations.
  * Prevented child processes from releasing a parent’s shared lock or clearing its process slot.
  * Improved reliability when child processes exit or reinitialize after creation.

* **Tests**
  * Added GPU-free regression coverage for fork and clone cleanup behavior.
  * Added automated validation for shared-region ownership and process reinitialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->