### PR TITLE
fix: pass the fan index and timestamps to the v2 hooks

### DIFF
--- a/src/nvml/nvml_entry.c
+++ b/src/nvml/nvml_entry.c
@@ -345,10 +345,10 @@ nvmlReturn_t nvmlDeviceGetFanSpeed(nvmlDevice_t device, unsigned int *speed) {
                          speed);
 }
 
-nvmlReturn_t nvmlDeviceGetFanSpeed_v2(nvmlDevice_t device,
+nvmlReturn_t nvmlDeviceGetFanSpeed_v2(nvmlDevice_t device, unsigned int fan,
                                       unsigned int *speed) {
   return NVML_OVERRIDE_CALL(nvml_library_entry, nvmlDeviceGetFanSpeed_v2, device,
-                         speed);
+                         fan, speed);
 }
 
 nvmlReturn_t nvmlDeviceGetFieldValues(nvmlDevice_t device, int valuesCount,
@@ -1212,9 +1212,10 @@ nvmlReturn_t nvmlDeviceGetGridLicensableFeatures_v2(
 nvmlReturn_t nvmlDeviceGetRetiredPages_v2(nvmlDevice_t device,
                                           nvmlPageRetirementCause_t cause,
                                           unsigned int *pageCount,
-                                          unsigned long long *addresses) {
+                                          unsigned long long *addresses,
+                                          unsigned long long *timestamps) {
   return NVML_OVERRIDE_CALL(nvml_library_entry, nvmlDeviceGetRetiredPages_v2,
-                         device, cause, pageCount, addresses);
+                         device, cause, pageCount, addresses, timestamps);
 }
 
 nvmlReturn_t nvmlDeviceResetGpuLockedClocks(nvmlDevice_t device) {

--- a/src/nvml/nvml_entry.c
+++ b/src/nvml/nvml_entry.c
@@ -1212,8 +1212,8 @@ nvmlReturn_t nvmlDeviceGetGridLicensableFeatures_v2(
 nvmlReturn_t nvmlDeviceGetRetiredPages_v2(nvmlDevice_t device,
                                           nvmlPageRetirementCause_t cause,
                                           unsigned int *pageCount,
-                                          unsigned long long *addresses,
-                                          unsigned long long *timestamps) {
+                                          unsigned long long *addresses,  // NOLINT(runtime/int)
+                                          unsigned long long *timestamps) {  // NOLINT(runtime/int)
   return NVML_OVERRIDE_CALL(nvml_library_entry, nvmlDeviceGetRetiredPages_v2,
                          device, cause, pageCount, addresses, timestamps);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,17 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
             -ffunction-sections -fdata-sections)
         set_target_properties(${TEST_TARGET_NAME} PROPERTIES
             LINK_FLAGS "-Wl,--no-export-dynamic,--gc-sections")
+    elseif (TEST_TARGET_NAME STREQUAL "test_nvml_v2_signatures")
+        # Links the production NVML pass-through wrappers and supplies its own
+        # entry table, so it needs no NVIDIA driver and no GPU at runtime.
+        add_executable(${TEST_TARGET_NAME}
+            ${TEST_SCRIPT}
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/nvml/nvml_entry.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/log_utils.c)
+        target_compile_options(${TEST_TARGET_NAME} PRIVATE
+            -ffunction-sections -fdata-sections)
+        set_target_properties(${TEST_TARGET_NAME} PROPERTIES
+            LINK_FLAGS "-Wl,--gc-sections")
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT})
     elseif (TEST_SCRIPT MATCHES ".*cu")
@@ -42,6 +53,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         target_link_libraries(${TEST_TARGET_NAME} -ldl)
+    elseif (TEST_TARGET_NAME STREQUAL "test_nvml_v2_signatures")
+        target_link_libraries(${TEST_TARGET_NAME} -lpthread)
     else()
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread
             -lnvidia-ml -lcuda -lcudart -L${CUDA_HOME}/lib64)
@@ -61,6 +74,15 @@ set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
 add_test(NAME dlsym_rtld_next
     COMMAND test_dlsym_rtld_next)
 set_tests_properties(dlsym_rtld_next PROPERTIES TIMEOUT 10)
+
+# Debug level is required: below it the LOG_DEBUG branch in NVML_OVERRIDE_CALL
+# is skipped, nothing clobbers the argument register, and a v1-arity wrapper
+# can forward the dropped argument by accident.
+add_test(NAME nvml_v2_signatures
+    COMMAND test_nvml_v2_signatures)
+set_tests_properties(nvml_v2_signatures PROPERTIES
+    ENVIRONMENT "LIBCUDA_LOG_LEVEL=4"
+    TIMEOUT 10)
 if (TARGET vgpu)
     add_test(NAME dlsym_rtld_next_preloaded
         COMMAND test_dlsym_rtld_next)

--- a/test/test_nvml_v2_signatures.c
+++ b/test/test_nvml_v2_signatures.c
@@ -28,14 +28,19 @@
 
 #include "include/libnvml_hook.h"
 
+/* nvml.h types the retired-page arrays as `nvml_ull`, so mirror it
+ * exactly.  cpplint's runtime/int rule asks for a fixed-width type; it does not
+ * apply when the type is dictated by an external ABI. */
+typedef unsigned long long nvml_ull;  // NOLINT(runtime/int)
+
 /* The production wrappers, declared the way NVIDIA's nvml.h declares them. */
 nvmlReturn_t nvmlDeviceGetFanSpeed_v2(nvmlDevice_t device, unsigned int fan,
                                       unsigned int *speed);
 nvmlReturn_t nvmlDeviceGetRetiredPages_v2(nvmlDevice_t device,
                                           nvmlPageRetirementCause_t cause,
                                           unsigned int *pageCount,
-                                          unsigned long long *addresses,
-                                          unsigned long long *timestamps);
+                                          nvml_ull *addresses,
+                                          nvml_ull *timestamps);
 
 /* Stands in for the loaded libnvidia-ml.so.1 entry table. */
 entry_t nvml_library_entry[NVML_ENTRY_END];
@@ -48,9 +53,9 @@ static unsigned int seen_fan;
 static unsigned int *seen_speed;
 static unsigned int *expect_speed;
 
-static unsigned long long *seen_timestamps;
-static unsigned long long *expect_timestamps;
-static unsigned long long *seen_addresses;
+static nvml_ull *seen_timestamps;
+static nvml_ull *expect_timestamps;
+static nvml_ull *seen_addresses;
 static unsigned int *seen_page_count;
 static nvmlPageRetirementCause_t seen_cause;
 
@@ -70,8 +75,8 @@ static nvmlReturn_t stub_fan_speed_v2(nvmlDevice_t device, unsigned int fan,
 static nvmlReturn_t stub_retired_pages_v2(nvmlDevice_t device,
                                           nvmlPageRetirementCause_t cause,
                                           unsigned int *pageCount,
-                                          unsigned long long *addresses,
-                                          unsigned long long *timestamps) {
+                                          nvml_ull *addresses,
+                                          nvml_ull *timestamps) {
     (void)device;
     seen_cause = cause;
     seen_page_count = pageCount;
@@ -111,8 +116,8 @@ static int test_fan_speed_v2(void) {
 
 static int test_retired_pages_v2(void) {
     unsigned int page_count = 1;
-    unsigned long long addresses[1] = {0};
-    unsigned long long timestamps[1] = {0};
+    nvml_ull addresses[1] = {0};
+    nvml_ull timestamps[1] = {0};
 
     expect_timestamps = timestamps;
     seen_timestamps = NULL;

--- a/test/test_nvml_v2_signatures.c
+++ b/test/test_nvml_v2_signatures.c
@@ -1,0 +1,163 @@
+/*
+ * GPU-free regression test for the versioned NVML pass-through wrappers.
+ *
+ * nvmlDeviceGetFanSpeed_v2 takes a fan index that nvmlDeviceGetFanSpeed does
+ * not, and nvmlDeviceGetRetiredPages_v2 takes a timestamps array that
+ * nvmlDeviceGetRetiredPages does not.  Both wrappers forward through
+ * driver_sym_t, an unprototyped function pointer, and this translation unit
+ * never sees NVIDIA's nvml.h, so a wrapper declared with the v1 arity
+ * compiles and links with no diagnostic.  The argument the wrapper never
+ * declared then reaches the driver as whatever the corresponding argument
+ * register happens to hold.
+ *
+ * The test installs its own nvml_library_entry table and calls the production
+ * wrappers through the real NVML prototypes, the way an application does.
+ * Recorded pointers are compared and never dereferenced unless they already
+ * match, so a wrong-arity build fails cleanly instead of writing through a
+ * stray address.
+ *
+ * LIBCUDA_LOG_LEVEL must be 4.  Below that the LOG_DEBUG branch inside
+ * NVML_OVERRIDE_CALL is not taken, nothing clobbers the argument register
+ * between the wrapper's entry and the forward, and a v1-arity wrapper can
+ * pass the dropped argument through by accident.  The test refuses to run at
+ * a lower level rather than report a pass it cannot justify.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "include/libnvml_hook.h"
+
+/* The production wrappers, declared the way NVIDIA's nvml.h declares them. */
+nvmlReturn_t nvmlDeviceGetFanSpeed_v2(nvmlDevice_t device, unsigned int fan,
+                                      unsigned int *speed);
+nvmlReturn_t nvmlDeviceGetRetiredPages_v2(nvmlDevice_t device,
+                                          nvmlPageRetirementCause_t cause,
+                                          unsigned int *pageCount,
+                                          unsigned long long *addresses,
+                                          unsigned long long *timestamps);
+
+/* Stands in for the loaded libnvidia-ml.so.1 entry table. */
+entry_t nvml_library_entry[NVML_ENTRY_END];
+
+#define FAN_SENTINEL 4242u
+#define TIMESTAMP_SENTINEL 0x5A5A5A5A5A5A5A5Aull
+#define TEST_DEVICE ((nvmlDevice_t)0xD1CEu)
+
+static unsigned int seen_fan;
+static unsigned int *seen_speed;
+static unsigned int *expect_speed;
+
+static unsigned long long *seen_timestamps;
+static unsigned long long *expect_timestamps;
+static unsigned long long *seen_addresses;
+static unsigned int *seen_page_count;
+static nvmlPageRetirementCause_t seen_cause;
+
+static nvmlReturn_t stub_fan_speed_v2(nvmlDevice_t device, unsigned int fan,
+                                      unsigned int *speed) {
+    (void)device;
+    seen_fan = fan;
+    seen_speed = speed;
+    /* Only written once the pointer is known good, so a broken build cannot
+     * turn this test into a wild store. */
+    if (speed == expect_speed && speed != NULL) {
+        *speed = FAN_SENTINEL;
+    }
+    return NVML_SUCCESS;
+}
+
+static nvmlReturn_t stub_retired_pages_v2(nvmlDevice_t device,
+                                          nvmlPageRetirementCause_t cause,
+                                          unsigned int *pageCount,
+                                          unsigned long long *addresses,
+                                          unsigned long long *timestamps) {
+    (void)device;
+    seen_cause = cause;
+    seen_page_count = pageCount;
+    seen_addresses = addresses;
+    seen_timestamps = timestamps;
+    if (timestamps == expect_timestamps && timestamps != NULL) {
+        timestamps[0] = TIMESTAMP_SENTINEL;
+    }
+    return NVML_SUCCESS;
+}
+
+static int failures;
+
+static void check(int ok, const char *what) {
+    printf("%-4s %s\n", ok ? "OK" : "FAIL", what);
+    if (!ok) {
+        failures++;
+    }
+}
+
+static int test_fan_speed_v2(void) {
+    unsigned int speed = 0;
+
+    expect_speed = &speed;
+    seen_fan = 0xEEEEEEEEu;
+    seen_speed = NULL;
+
+    printf("nvmlDeviceGetFanSpeed_v2: passing fan=1 speed=%p\n", (void *)&speed);
+    nvmlDeviceGetFanSpeed_v2(TEST_DEVICE, 1u, &speed);
+    printf("  driver received fan=%u speed=%p\n", seen_fan, (void *)seen_speed);
+
+    check(seen_fan == 1u, "fan index reaches the driver");
+    check(seen_speed == &speed, "speed pointer reaches the driver unchanged");
+    check(speed == FAN_SENTINEL, "driver's write lands in the caller's variable");
+    return 0;
+}
+
+static int test_retired_pages_v2(void) {
+    unsigned int page_count = 1;
+    unsigned long long addresses[1] = {0};
+    unsigned long long timestamps[1] = {0};
+
+    expect_timestamps = timestamps;
+    seen_timestamps = NULL;
+    seen_addresses = NULL;
+    seen_page_count = NULL;
+    seen_cause = (nvmlPageRetirementCause_t)0;
+
+    printf("nvmlDeviceGetRetiredPages_v2: passing timestamps=%p\n",
+           (void *)timestamps);
+    nvmlDeviceGetRetiredPages_v2(TEST_DEVICE,
+                                 NVML_PAGE_RETIREMENT_CAUSE_DOUBLE_BIT_ECC_ERROR,
+                                 &page_count, addresses, timestamps);
+    printf("  driver received timestamps=%p\n", (void *)seen_timestamps);
+
+    check(seen_cause == NVML_PAGE_RETIREMENT_CAUSE_DOUBLE_BIT_ECC_ERROR,
+          "cause reaches the driver");
+    check(seen_page_count == &page_count, "pageCount pointer reaches the driver");
+    check(seen_addresses == addresses, "addresses pointer reaches the driver");
+    check(seen_timestamps == timestamps,
+          "timestamps pointer reaches the driver unchanged");
+    check(timestamps[0] == TIMESTAMP_SENTINEL,
+          "driver's write lands in the caller's timestamps array");
+    return 0;
+}
+
+int main(void) {
+    log_utils_init();
+    if (g_log_level < 4) {
+        fprintf(stderr,
+                "refusing to run: LIBCUDA_LOG_LEVEL=%d, need 4.  Below debug "
+                "level the LOG_DEBUG branch is skipped, no call clobbers the "
+                "argument register, and a v1-arity wrapper can forward the "
+                "dropped argument by accident.\n",
+                g_log_level);
+        return 2;
+    }
+
+    nvml_library_entry[NVML_OVERRIDE_ENUM(nvmlDeviceGetFanSpeed_v2)].fn_ptr =
+        (void *)stub_fan_speed_v2;
+    nvml_library_entry[NVML_OVERRIDE_ENUM(nvmlDeviceGetRetiredPages_v2)].fn_ptr =
+        (void *)stub_retired_pages_v2;
+
+    test_fan_speed_v2();
+    test_retired_pages_v2();
+
+    printf("%s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

`nvmlDeviceGetFanSpeed_v2` and `nvmlDeviceGetRetiredPages_v2` in `src/nvml/nvml_entry.c` still use their v1 argument lists, so they drop `fan` and `timestamps`:

```c
nvmlReturn_t nvmlDeviceGetFanSpeed_v2(nvmlDevice_t device, unsigned int fan, unsigned int *speed);
nvmlReturn_t nvmlDeviceGetRetiredPages_v2(nvmlDevice_t device, nvmlPageRetirementCause_t cause,
    unsigned int *pageCount, unsigned long long *addresses, unsigned long long *timestamps);
```

nothing catches it. `driver_sym_t` is `nvmlReturn_t (*)()` with no prototype, and this file never includes `nvml.h`, so the hook is the only declaration around and there is nothing to disagree with it.

The earlier arguments still arrive. The dropped one reaches the driver as whatever its register holds, and the driver writes through it: the callers `speed` pointer in one case, the `timestamps` array in the other.

You won't see it at the default log level, where the code tail calls without touching `%rdx` and the pointer survives by luck. At `LIBCUDA_LOG_LEVEL >= 4` the `LOG_DEBUG` branch calls a cold path that uses `getpid`, `pthread_self` and `basename`, and the hook only restores the registers its signature mentions. `%r8` goes the same way in `nvmlDeviceGetRetiredPages_v2`. It breaks exactly when you turn on debug logging to find out what is wrong.

## Change

Declare the missing argument in both hooks and pass it on. 

I checked all 223 hooks here against `nvml.h` by argument count. One mismatch is left: `nvmlDeviceRemoveGpu` has the three arguments belonging to `nvmlDeviceRemoveGpu_v2`, while `nvml.h` declares `nvmlDeviceRemoveGpu(nvmlPciInfo_t *pciInfo)`. It's harmless, since the extras go to a function reading fewer, so I kept it out of here. Can send it separately.

## Test

`test/test_nvml_v2_signatures.c` is a CTest that needs no GPU and no driver. It builds the production `nvml_entry.c` into the test and gives it a stub `nvml_library_entry` table with the correct v2 signatures, then calls the hooks through the real prototypes and checks the stub got what the caller sent. Pointers are dereferenced only once they match, so a bad build fails cleanly instead of writing somewhere random.

It needs `LIBCUDA_LOG_LEVEL=4` and exits 2 below that. Without debug logging nothing clobbers the register, and the test would pass on the broken hook.

CI compiles this test but never runs it, since `build.sh` just runs `make`. It's a local guard until #277 lands.

On x86_64 AlmaLinux 9.7, gcc 11.5.0, GNU ld 2.35.2, cmake 3.26.5, CUDA 12.2 headers:

1. `bash ./build.sh` exits 0 and `libvgpu.so` links.
2. `ctest` passes 4 of 4.
3. `LIBCUDA_LOG_LEVEL=4 ./test/test_nvml_v2_signatures` passes all 8 checks.

Revert the two hunks and the same test will fail:

```
  driver received fan=1 speed=(nil)
  FAIL speed pointer reaches the driver unchanged
  FAIL timestamps pointer reaches the driver unchanged
```

These hooks only pass telemetry through, so I read gate 2 as not applying and didn't run a GPU cell. cpplint will flag `runtime/int` on the `unsigned long long` arguments; that type comes from the NVML prototype, so I left it.

---
I used deepseek v4 flash to write the code. The logic and the approach are mine, and I ran all the tests myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fan speed queries now correctly target the requested fan.
  * Retired-page queries now return associated timestamps.
  * Improved forwarding of query parameters and output data for more reliable NVML results.

* **Tests**
  * Added GPU-independent regression coverage for updated fan speed and retired-page queries.
  * Added automated validation of returned values without requiring a physical GPU.
  * Added focused test execution paths with timeouts for improved validation reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->