### PR TITLE
ci: run registered CTests in build-in-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ build-in-docker:
 		sh -c "dnf install -y cmake git && \
            git config --global --add safe.directory /libvgpu && \
            rm -rf /libvgpu/build && \
-           bash ./build.sh"
+           bash ./build.sh && \
+           echo /usr/local/cuda/lib64/stubs > /etc/ld.so.conf.d/zz-cuda-stubs.conf && \
+           ldconfig && \
+           ctest --test-dir /libvgpu/build --output-on-failure --no-tests=error"
 .PHONY: build-in-docker
 
 check-cuda-hook-consistency:


### PR DESCRIPTION
Fixes #277

CI builds the CTests but never runs them. Add a ctest run after the
build in the same container, no name filter, with --no-tests=error
so an empty test set also fails.

The ldconfig lines register the image's CUDA stubs. Without them the
LD_PRELOAD test can't load libvgpu.so in the driverless container
(DT_NEEDED on libcuda.so.1), ctest exits 8.

Validated in `nvidia/cuda:13.3.0-cudnn-devel-ubi8` without a driver:
`make build-in-docker` passes with 3/3 tests, and fails as expected
when a test fails. Makefile only, nothing shipped changes.

AI was used for validation runs and drafting; the change and results
were reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker build validation by running the test suite and surfacing failures.
  * Ensured required CUDA stub libraries are discoverable during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->