### PR TITLE
chore: harden CI workflows and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -5,6 +5,9 @@ on: [push, pull_request, workflow_dispatch]
 
 concurrency: ci-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   hook-registry-check:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
     name: Hook static consistency check
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Run CUDA hook static consistency check
         run: python3 hack/check_cuda_hook_consistency.py
 
@@ -25,10 +28,10 @@ jobs:
     name: Build libvgpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Build
         run: |
           make build-in-docker

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -5,12 +5,18 @@ name: style
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   cpplint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
-    - uses: actions/checkout@master
-    - uses: reviewdog/action-cpplint@master
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: reviewdog/action-cpplint@9552c62f4bd516c1e3a6f84eae56bd864cc304c6 # v1.11.0
       with:
         github_token: ${{ secrets.github_token }}
         args: --linelength=120


### PR DESCRIPTION
Neither workflow declared `permissions`, so both jobs ran with a write-capable `GITHUB_TOKEN` (OSPS-AC-04.01), and `actions/checkout` plus `reviewdog/action-cpplint` were pinned to `@master`, a mutable ref, while the hook consistency job still used the deprecated `checkout@v2`. Adds a read-only default with `checks: write` only where reviewdog needs it, pins every action to a commit SHA, and adds `dependabot.yml` so the pins stay current.

Does not fix OSPS-QA-02.01 or OSPS-BR-07.01: both need repository settings, tracked in #299.