### PR TITLE
fix: pass cpplint line length through a real action input

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -13,4 +13,4 @@ jobs:
     - uses: reviewdog/action-cpplint@master
       with:
         github_token: ${{ secrets.github_token }}
-        args: --linelength=120
+        flags: --linelength=120 --extensions=h,hpp,c,cpp,cc,cu,hh,ipp


### PR DESCRIPTION
reviewdog/action-cpplint has no `args` input, so `args: --linelength=120` has always been dropped and cpplint has been running at its default 80 columns. Over `src` and `test` that is 686 `whitespace/line_length` findings instead of 85.

Moves the setting to `flags`, carrying over the action default `--extensions=h,hpp,c,cpp,cc,cu,hh,ipp` since `flags` replaces that default rather than adding to it.