### PR TITLE
chore: pin CUDA base image by digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 current_dir := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
+# Keep in sync with dockerfiles/Dockerfile and Project-HAMi/HAMi's NVIDIA_IMAGE.
+CUDA_IMAGE ?= nvidia/cuda:13.3.0-cudnn-devel-ubi8@sha256:e5b2b971730b6d0defd6d1bd7697630e0e599c359190cc4351e3032134e7b401
+
 build:
 	sh ./build.sh
 .PHONY: build
@@ -10,7 +13,7 @@ build-in-docker:
 	docker run -i --rm \
 		-v $(current_dir):/libvgpu \
 		-w /libvgpu \
-		nvidia/cuda:13.3.0-cudnn-devel-ubi8 \
+		$(CUDA_IMAGE) \
 		sh -c "dnf install -y cmake git && \
            git config --global --add safe.directory /libvgpu && \
            rm -rf /libvgpu/build && \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:13.3.0-cudnn-devel-ubi8
+FROM nvidia/cuda:13.3.0-cudnn-devel-ubi8@sha256:e5b2b971730b6d0defd6d1bd7697630e0e599c359190cc4351e3032134e7b401
 
 WORKDIR /libvgpu
 COPY . /libvgpu


### PR DESCRIPTION
`nvidia/cuda:13.3.0-cudnn-devel-ubi8` was pulled by mutable tag in both `dockerfiles/Dockerfile` and the `build-in-docker` target, so rebuilding the same commit can land on different base image contents. `Project-HAMi/HAMi` already pins this exact image by digest in `docker/Dockerfile.hamicore`, the file that builds the released `projecthami/hamicore`.

Uses that same digest, which is what the tag resolves to today, so local and release builds stop drifting apart. #296 adds the `dependabot.yml` that keeps it moving.