### PR TITLE
feat: add CodeQL C/C++ analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+---
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze C
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    # The build needs nvcc: test/CMakeLists.txt does find_package(CUDA REQUIRED)
+    # and cuda_add_executable() for the .cu tests. Same image as build-in-docker.
+    container:
+      image: nvidia/cuda:13.3.0-cudnn-devel-ubi8@sha256:e5b2b971730b6d0defd6d1bd7697630e0e599c359190cc4351e3032134e7b401
+    steps:
+      - name: Install build dependencies
+        run: dnf install -y cmake git tar gzip
+
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        with:
+          languages: c-cpp
+          build-mode: manual
+
+      - name: Build
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          bash ./build.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        with:
+          category: /language:c-cpp


### PR DESCRIPTION
HAMi runs CodeQL with `language: ["go"]`, so HAMi-core's C is never analysed, despite 16 memory safety fixes in the last 80 commits. Runs in the same CUDA image as `build-in-docker` since `test/CMakeLists.txt` needs nvcc, with `build-mode: manual` to trace the real `build.sh`; no `pull_request` trigger, because fork PRs would sit in `action_required` awaiting approval.

Verified end to end on a fork before opening this ([run 32965369166](https://github.com/mesutoezdil/HAMi-core/actions/runs/32965369166), all steps green), where it found the one issue fixed in #303.