### PR TITLE
fix: compute total cuda cores in int64_t

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -190,7 +190,8 @@ int setspec() {
             CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, cu_dev));
         CHECK_CU_RESULT(cuDeviceGetAttribute(&g_max_thread_per_sm[dev],
             CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR, cu_dev));
-        g_total_cuda_cores[dev] = g_max_thread_per_sm[dev] * g_sm_num[dev] * FACTOR;
+        g_total_cuda_cores[dev] =
+            (int64_t)g_max_thread_per_sm[dev] * g_sm_num[dev] * FACTOR;
         LOG_INFO("setspec: device %d sm_num=%d max_threads_per_sm=%d total_cores=%ld FACTOR=%d",
                  dev, g_sm_num[dev], g_max_thread_per_sm[dev], g_total_cuda_cores[dev], FACTOR);
     }


### PR DESCRIPTION
`g_sm_num` and `g_max_thread_per_sm` are `int`, so the product was evaluated in `int` and only widened on assignment to the `int64_t` `g_total_cuda_cores`, while `delta()` in the same file already casts every operand for exactly this reason. No real GPU overflows (H100 8650752, B200 9699328, and `int` math only diverges past 32768 SMs), so this is consistency with `delta()` rather than a live bug.

Found by the CodeQL workflow in #302 as `cpp/integer-multiplication-cast-to-long`.