### PR TITLE
feat: account for CUDA context memory

### DIFF
--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(cuda_mod OBJECT context.c device.c hook.c event.c hook.c memory.c stream.c graph.c)
+add_library(cuda_mod OBJECT context.c context_accounting.c device.c hook.c event.c hook.c memory.c stream.c graph.c)
 target_compile_options(cuda_mod PUBLIC ${LIBRARY_COMPILE_FLAGS})
 target_link_libraries(cuda_mod PUBLIC nvidia-ml -lcuda)

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -210,9 +210,9 @@ CUresult cuDevicePrimaryCtxRelease_v2( CUdevice dev ){
                                   cuDevicePrimaryCtxRelease_v2, dev);
     }
     pthread_mutex_lock(&context_device_locks[dev]);
-    pthread_mutex_lock(&context_accounting_lock);
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuDevicePrimaryCtxRelease_v2,dev);
     if (res == CUDA_SUCCESS) {
+        pthread_mutex_lock(&context_accounting_lock);
         if (primary_context_record_release(&context_accounting[dev],
                                            &bytes_to_remove) != 0) {
             LOG_WARN("Unbalanced primary context release on device %d", dev);
@@ -224,8 +224,8 @@ CUresult cuDevicePrimaryCtxRelease_v2( CUdevice dev ){
             }
         }
         ctx_activate[dev] = (int)context_accounting[dev].retain_count;
+        pthread_mutex_unlock(&context_accounting_lock);
     }
-    pthread_mutex_unlock(&context_accounting_lock);
     pthread_mutex_unlock(&context_device_locks[dev]);
     return res;
 }

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+
 #include "include/libcuda_hook.h"
 #include "include/libvgpu.h"
 #include "cuda/context_accounting.h"
@@ -144,11 +146,22 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
         LOG_INFO("Measured primary context size lazily: "
                  "dev=%d size=%lu", dev, charge);
     }
-    if ((pidfound == 1
-             ? primary_context_record_accounted_retain(
-                   &context_accounting[dev], charge, &bytes_to_add)
-             : primary_context_record_retain(&context_accounting[dev], charge,
-                                             &bytes_to_add)) != 0) {
+    errno = 0;
+    int record_result =
+        (pidfound == 1)
+            ? primary_context_record_accounted_retain(
+                  &context_accounting[dev], charge, &bytes_to_add)
+            : primary_context_record_retain(&context_accounting[dev], charge,
+                                            &bytes_to_add);
+    /* The driver retain already succeeded.  An unknown context size must not
+     * fail the caller, so defer the charge to a later retain that knows it. */
+    if (record_result != 0 && errno == ENODATA) {
+        LOG_WARN("Primary context size unknown on device %d; charge is "
+                 "deferred to a later retain", dev);
+        record_result = primary_context_record_retain(
+            &context_accounting[dev], charge, &bytes_to_add);
+    }
+    if (record_result != 0) {
         LOG_ERROR("Cannot account primary context retain on device %d",
                   dev);
         res = rollback_unaccounted_retain(dev, 0, 0);

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -124,6 +124,12 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
     if (measure_context) {
         int attempt;
 
+        /* The delta is the process's own device memory across the retain, the
+         * same method set_task_pid() uses.  context_device_locks[dev] does not
+         * exclude cuMemAlloc, so an allocation by another thread of this
+         * process inside the window is charged as context memory and cached
+         * for the process lifetime.  Measuring once, on the first retain of a
+         * device, keeps the exposure to that one window. */
         for (attempt = 0; attempt < 10; attempt++) {
             if (get_used_gpu_memory_by_pid((unsigned int)hostpid, dev,
                                            &after) == NVML_SUCCESS &&

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -59,10 +59,10 @@ static size_t context_charge_for_device(CUdevice dev) {
         device_context_size[dev] > 0) {
         return device_context_size[dev];
     }
-    /* Nothing measured for this device yet.  Fall back to the size the
-     * host PID probe recorded, which is what main charges on every device.
-     * Charging nothing here would under-report devices 1 and up. */
-    return context_size;
+    /* Device 0 trusts the host PID probe, which measured it.  Other devices
+     * are measured on their first retain; if that fails, the retain path
+     * falls back to the probed size rather than charging nothing. */
+    return dev == 0 ? context_size : 0;
 }
 
 static CUresult rollback_unaccounted_retain(CUdevice dev,
@@ -148,6 +148,13 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
         charge = measured_charge;
         LOG_INFO("Measured primary context size lazily: "
                  "dev=%d size=%lu", dev, charge);
+    } else if (charge == 0 && context_size > 0) {
+        /* Measurement failed or was skipped.  Charge the probed size, as main
+         * does on every device.  Not cached in device_context_size, so a later
+         * fresh retain can still measure this device for real. */
+        charge = context_size;
+        LOG_INFO("Primary context size unmeasured on device %d; charging the "
+                 "probed size %lu", dev, charge);
     }
     errno = 0;
     int record_result =

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -59,7 +59,10 @@ static size_t context_charge_for_device(CUdevice dev) {
         device_context_size[dev] > 0) {
         return device_context_size[dev];
     }
-    return dev == 0 ? context_size : 0;
+    /* Nothing measured for this device yet.  Fall back to the size the
+     * host PID probe recorded, which is what main charges on every device.
+     * Charging nothing here would under-report devices 1 and up. */
+    return context_size;
 }
 
 static CUresult rollback_unaccounted_retain(CUdevice dev,

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -35,7 +35,8 @@ void context_accounting_fork_parent() {
 void context_accounting_fork_child() {
     int dev;
 
-    context_size = 0;
+    /* context_size is kept.  The parent's probe is a fair estimate for a
+     * child on the same GPU, and the child's own probe overwrites it. */
     primary_context_accounting_reset(context_accounting,
                                      CUDA_DEVICE_MAX_COUNT);
     for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -125,11 +125,9 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
         int attempt;
 
         /* The delta is the process's own device memory across the retain, the
-         * same method set_task_pid() uses.  context_device_locks[dev] does not
-         * exclude cuMemAlloc, so an allocation by another thread of this
-         * process inside the window is charged as context memory and cached
-         * for the process lifetime.  Measuring once, on the first retain of a
-         * device, keeps the exposure to that one window. */
+         * same method set_task_pid() uses.  This window is not exclusive
+         * against cuMemAlloc, so the result is checked below before it is
+         * trusted. */
         for (attempt = 0; attempt < 10; attempt++) {
             if (get_used_gpu_memory_by_pid((unsigned int)hostpid, dev,
                                            &after) == NVML_SUCCESS &&
@@ -140,6 +138,16 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
             usleep(1000);
         }
     }
+    if (measured_charge > 0 &&
+        !primary_context_size_is_plausible(measured_charge, context_size)) {
+        /* Another thread allocated inside the window.  Caching this would
+         * overcharge the device for the life of the process, so discard it and
+         * let a later retain measure again. */
+        LOG_WARN("Discarding an implausible primary context measurement on "
+                 "device %d: %lu against a probed %lu",
+                 dev, measured_charge, context_size);
+        measured_charge = 0;
+    }
     pthread_mutex_lock(&context_accounting_lock);
     if (measured_charge > 0) {
         device_context_size[dev] = measured_charge;
@@ -147,9 +155,9 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
         LOG_INFO("Measured primary context size lazily: "
                  "dev=%d size=%lu", dev, charge);
     } else if (charge == 0 && context_size > 0) {
-        /* Measurement failed or was skipped.  Charge the probed size, as main
-         * does on every device.  Not cached in device_context_size, so a later
-         * fresh retain can still measure this device for real. */
+        /* Not measured, or the measurement was discarded.  Charge the probed
+         * size, as main does on every device.  Not cached in
+         * device_context_size, so a later retain can still measure for real. */
         charge = context_size;
         LOG_INFO("Primary context size unmeasured on device %d; charging the "
                  "probed size %lu", dev, charge);

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -1,8 +1,49 @@
 #include "include/libcuda_hook.h"
+#include "include/libvgpu.h"
+#include "cuda/context_accounting.h"
 #include "multiprocess/multiprocess_memory_limit.h"
 
 extern size_t context_size;
-extern int ctx_activate[16];
+extern int ctx_activate[CUDA_DEVICE_MAX_COUNT];
+extern int pidfound;
+
+static size_t device_context_size[CUDA_DEVICE_MAX_COUNT];
+static primary_context_accounting_t
+    context_accounting[CUDA_DEVICE_MAX_COUNT];
+static pthread_mutex_t context_accounting_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t context_device_locks[CUDA_DEVICE_MAX_COUNT] = {
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_MUTEX_INITIALIZER,
+};
+
+void context_accounting_fork_prepare() {
+    pthread_mutex_lock(&context_accounting_lock);
+}
+
+void context_accounting_fork_parent() {
+    pthread_mutex_unlock(&context_accounting_lock);
+}
+
+void context_accounting_fork_child() {
+    int dev;
+
+    context_size = 0;
+    primary_context_accounting_reset(context_accounting,
+                                     CUDA_DEVICE_MAX_COUNT);
+    for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+        device_context_size[dev] = 0;
+        ctx_activate[dev] = 0;
+        context_device_locks[dev] =
+            (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+    }
+    pthread_mutex_unlock(&context_accounting_lock);
+}
 
 
 CUresult cuDevicePrimaryCtxGetState( CUdevice dev, unsigned int* flags, int* active ){
@@ -11,16 +52,123 @@ CUresult cuDevicePrimaryCtxGetState( CUdevice dev, unsigned int* flags, int* act
     return res;
 }
 
+static size_t context_charge_for_device(CUdevice dev) {
+    if (dev >= 0 && dev < CUDA_DEVICE_MAX_COUNT &&
+        device_context_size[dev] > 0) {
+        return device_context_size[dev];
+    }
+    return dev == 0 ? context_size : 0;
+}
+
+static CUresult rollback_unaccounted_retain(CUdevice dev,
+                                            int retain_recorded,
+                                            size_t bytes_to_add) {
+    CUresult release_result;
+
+    if (retain_recorded &&
+        primary_context_rollback_retain(&context_accounting[dev],
+                                        bytes_to_add) != 0) {
+        LOG_ERROR("Failed to roll back local context accounting on device %d",
+                  dev);
+    }
+    release_result = CUDA_OVERRIDE_CALL(cuda_library_entry,
+                                        cuDevicePrimaryCtxRelease_v2, dev);
+    if (release_result != CUDA_SUCCESS) {
+        LOG_ERROR("Failed to release an unaccounted primary context on "
+                  "device %d: %d", dev, release_result);
+    }
+    ctx_activate[dev] = (int)context_accounting[dev].retain_count;
+    return CUDA_ERROR_OUT_OF_MEMORY;
+}
+
 CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
-    LOG_INFO("dev=%d context_size=%ld",dev,context_size);
-    //for Initialization only
-    CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuDevicePrimaryCtxRetain,pctx,dev);
-    if (ctx_activate[dev] == 0) {
-        add_gpu_device_memory_usage(getpid(),dev,context_size,0); 
+    uint64_t before = 0;
+    uint64_t after = 0;
+    int hostpid;
+    int measure_context = 0;
+    size_t charge;
+    size_t measured_charge = 0;
+    size_t bytes_to_add = 0;
+
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        return CUDA_OVERRIDE_CALL(cuda_library_entry,
+                                  cuDevicePrimaryCtxRetain, pctx, dev);
     }
-    if (context_size>0) {
-        ctx_activate[dev] = 1;
+
+    pthread_mutex_lock(&context_device_locks[dev]);
+    pthread_mutex_lock(&context_accounting_lock);
+    charge = context_charge_for_device(dev);
+    hostpid = get_current_host_pid();
+    if (charge == 0 && pidfound == 1 && hostpid > 0 &&
+        context_accounting[dev].charged_bytes == 0) {
+        measure_context = 1;
     }
+    pthread_mutex_unlock(&context_accounting_lock);
+
+    if (measure_context) {
+        nvmlReturn_t result = get_used_gpu_memory_by_pid(
+            (unsigned int)hostpid, dev, &before);
+        if (result == NVML_SUCCESS || result == NVML_ERROR_NOT_FOUND) {
+            if (result == NVML_ERROR_NOT_FOUND) {
+                before = 0;
+            }
+        } else {
+            measure_context = 0;
+        }
+    }
+
+    CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,
+                                      cuDevicePrimaryCtxRetain, pctx, dev);
+    if (res != CUDA_SUCCESS) {
+        pthread_mutex_unlock(&context_device_locks[dev]);
+        return res;
+    }
+
+    if (measure_context) {
+        int attempt;
+
+        for (attempt = 0; attempt < 10; attempt++) {
+            if (get_used_gpu_memory_by_pid((unsigned int)hostpid, dev,
+                                           &after) == NVML_SUCCESS &&
+                after > before) {
+                measured_charge = after - before;
+                break;
+            }
+            usleep(1000);
+        }
+    }
+    pthread_mutex_lock(&context_accounting_lock);
+    if (measured_charge > 0) {
+        device_context_size[dev] = measured_charge;
+        charge = measured_charge;
+        LOG_INFO("Measured primary context size lazily: "
+                 "dev=%d size=%lu", dev, charge);
+    }
+    if ((pidfound == 1
+             ? primary_context_record_accounted_retain(
+                   &context_accounting[dev], charge, &bytes_to_add)
+             : primary_context_record_retain(&context_accounting[dev], charge,
+                                             &bytes_to_add)) != 0) {
+        LOG_ERROR("Cannot account primary context retain on device %d",
+                  dev);
+        res = rollback_unaccounted_retain(dev, 0, 0);
+        pthread_mutex_unlock(&context_accounting_lock);
+        pthread_mutex_unlock(&context_device_locks[dev]);
+        return res;
+    }
+    if (bytes_to_add > 0) {
+        if (add_gpu_device_memory_usage(getpid(), dev, bytes_to_add, 0) != 0) {
+            LOG_ERROR("Failed to charge primary context memory on device %d",
+                      dev);
+            res = rollback_unaccounted_retain(dev, 1, bytes_to_add);
+            pthread_mutex_unlock(&context_accounting_lock);
+            pthread_mutex_unlock(&context_device_locks[dev]);
+            return res;
+        }
+    }
+    ctx_activate[dev] = (int)context_accounting[dev].retain_count;
+    pthread_mutex_unlock(&context_accounting_lock);
+    pthread_mutex_unlock(&context_device_locks[dev]);
     return res;
 }
 
@@ -31,11 +179,30 @@ CUresult cuDevicePrimaryCtxSetFlags_v2( CUdevice dev, unsigned int  flags ){
 }
 
 CUresult cuDevicePrimaryCtxRelease_v2( CUdevice dev ){
-    if (ctx_activate[dev] == 1) {
-        rm_gpu_device_memory_usage(getpid(),dev,context_size,0);
+    size_t bytes_to_remove = 0;
+
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        return CUDA_OVERRIDE_CALL(cuda_library_entry,
+                                  cuDevicePrimaryCtxRelease_v2, dev);
     }
-    ctx_activate[dev] = 0;
+    pthread_mutex_lock(&context_device_locks[dev]);
+    pthread_mutex_lock(&context_accounting_lock);
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuDevicePrimaryCtxRelease_v2,dev);
+    if (res == CUDA_SUCCESS) {
+        if (primary_context_record_release(&context_accounting[dev],
+                                           &bytes_to_remove) != 0) {
+            LOG_WARN("Unbalanced primary context release on device %d", dev);
+        } else if (bytes_to_remove > 0) {
+            if (rm_gpu_device_memory_usage(getpid(), dev, bytes_to_remove,
+                                           0) != 0) {
+                primary_context_restore_charge(&context_accounting[dev],
+                                               bytes_to_remove);
+            }
+        }
+        ctx_activate[dev] = (int)context_accounting[dev].retain_count;
+    }
+    pthread_mutex_unlock(&context_accounting_lock);
+    pthread_mutex_unlock(&context_device_locks[dev]);
     return res;
 }
 
@@ -149,4 +316,3 @@ CUresult cuCtxSynchronize ( void ){
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuCtxSynchronize);
     return res;
 }
-

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -64,17 +64,11 @@ static size_t context_charge_for_device(CUdevice dev) {
     return dev == 0 ? context_size : 0;
 }
 
-static CUresult rollback_unaccounted_retain(CUdevice dev,
-                                            int retain_recorded,
-                                            size_t bytes_to_add) {
+/* Only reached when the retain could not be recorded at all, so there is no
+ * local accounting to undo: hand the context back and report the failure. */
+static CUresult release_unaccounted_retain(CUdevice dev) {
     CUresult release_result;
 
-    if (retain_recorded &&
-        primary_context_rollback_retain(&context_accounting[dev],
-                                        bytes_to_add) != 0) {
-        LOG_ERROR("Failed to roll back local context accounting on device %d",
-                  dev);
-    }
     release_result = CUDA_OVERRIDE_CALL(cuda_library_entry,
                                         cuDevicePrimaryCtxRelease_v2, dev);
     if (release_result != CUDA_SUCCESS) {
@@ -172,19 +166,26 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
     if (record_result != 0) {
         LOG_ERROR("Cannot account primary context retain on device %d",
                   dev);
-        res = rollback_unaccounted_retain(dev, 0, 0);
+        res = release_unaccounted_retain(dev);
         pthread_mutex_unlock(&context_accounting_lock);
         pthread_mutex_unlock(&context_device_locks[dev]);
         return res;
     }
-    if (bytes_to_add > 0) {
-        if (add_gpu_device_memory_usage(getpid(), dev, bytes_to_add, 0) != 0) {
-            LOG_ERROR("Failed to charge primary context memory on device %d",
-                      dev);
-            res = rollback_unaccounted_retain(dev, 1, bytes_to_add);
-            pthread_mutex_unlock(&context_accounting_lock);
-            pthread_mutex_unlock(&context_device_locks[dev]);
-            return res;
+    if (bytes_to_add > 0 &&
+        add_gpu_device_memory_usage(getpid(), dev, bytes_to_add, 0) != 0) {
+        size_t retried = 0;
+
+        /* The driver retain already succeeded.  A shared region that will not
+         * take the charge must not fail the caller, for the same reason an
+         * unknown size does not: drop the charge, keep the retain, and let a
+         * later retain try again. */
+        LOG_WARN("Cannot charge primary context memory on device %d; the "
+                 "retain is kept and the charge is deferred", dev);
+        if (primary_context_rollback_retain(&context_accounting[dev],
+                                            bytes_to_add) != 0 ||
+            primary_context_record_retain(&context_accounting[dev], 0,
+                                          &retried) != 0) {
+            LOG_ERROR("Cannot reconcile context accounting on device %d", dev);
         }
     }
     pthread_mutex_unlock(&context_accounting_lock);

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -229,6 +229,35 @@ CUresult cuDevicePrimaryCtxRelease_v2( CUdevice dev ){
     return res;
 }
 
+CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
+    size_t bytes_to_remove = 0;
+
+    if (dev < 0 || dev >= CUDA_DEVICE_MAX_COUNT) {
+        return CUDA_OVERRIDE_CALL(cuda_library_entry,
+                                  cuDevicePrimaryCtxReset_v2, dev);
+    }
+    pthread_mutex_lock(&context_device_locks[dev]);
+    CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,
+                                      cuDevicePrimaryCtxReset_v2, dev);
+    if (res == CUDA_SUCCESS) {
+        pthread_mutex_lock(&context_accounting_lock);
+        /* The driver destroys the context whatever the retain count, so
+         * every outstanding retain and the charge go with it. */
+        bytes_to_remove = context_accounting[dev].charged_bytes;
+        primary_context_accounting_reset(&context_accounting[dev], 1);
+        if (bytes_to_remove > 0 &&
+            rm_gpu_device_memory_usage(getpid(), dev, bytes_to_remove,
+                                       0) != 0) {
+            primary_context_restore_charge(&context_accounting[dev],
+                                           bytes_to_remove);
+        }
+        ctx_activate[dev] = 0;
+        pthread_mutex_unlock(&context_accounting_lock);
+    }
+    pthread_mutex_unlock(&context_device_locks[dev]);
+    return res;
+}
+
 CUresult cuCtxGetDevice(CUdevice* device) {
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuCtxGetDevice,device);
     return res;

--- a/src/cuda/context.c
+++ b/src/cuda/context.c
@@ -6,7 +6,6 @@
 #include "multiprocess/multiprocess_memory_limit.h"
 
 extern size_t context_size;
-extern int ctx_activate[CUDA_DEVICE_MAX_COUNT];
 extern int pidfound;
 
 static size_t device_context_size[CUDA_DEVICE_MAX_COUNT];
@@ -41,7 +40,6 @@ void context_accounting_fork_child() {
                                      CUDA_DEVICE_MAX_COUNT);
     for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
         device_context_size[dev] = 0;
-        ctx_activate[dev] = 0;
         context_device_locks[dev] =
             (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
     }
@@ -83,7 +81,6 @@ static CUresult rollback_unaccounted_retain(CUdevice dev,
         LOG_ERROR("Failed to release an unaccounted primary context on "
                   "device %d: %d", dev, release_result);
     }
-    ctx_activate[dev] = (int)context_accounting[dev].retain_count;
     return CUDA_ERROR_OUT_OF_MEMORY;
 }
 
@@ -190,7 +187,6 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev){
             return res;
         }
     }
-    ctx_activate[dev] = (int)context_accounting[dev].retain_count;
     pthread_mutex_unlock(&context_accounting_lock);
     pthread_mutex_unlock(&context_device_locks[dev]);
     return res;
@@ -223,7 +219,6 @@ CUresult cuDevicePrimaryCtxRelease_v2( CUdevice dev ){
                                                bytes_to_remove);
             }
         }
-        ctx_activate[dev] = (int)context_accounting[dev].retain_count;
         pthread_mutex_unlock(&context_accounting_lock);
     }
     pthread_mutex_unlock(&context_device_locks[dev]);
@@ -252,7 +247,6 @@ CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
             primary_context_restore_charge(&context_accounting[dev],
                                            bytes_to_remove);
         }
-        ctx_activate[dev] = 0;
         pthread_mutex_unlock(&context_accounting_lock);
     }
     pthread_mutex_unlock(&context_device_locks[dev]);

--- a/src/cuda/context_accounting.c
+++ b/src/cuda/context_accounting.c
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 The HAMi Authors.
+ */
+
+#include "cuda/context_accounting.h"
+
+#include <errno.h>
+#include <limits.h>
+
+static int record_retain(primary_context_accounting_t *state,
+                         size_t context_bytes, size_t *bytes_to_add,
+                         int require_charge) {
+    if (state == NULL || bytes_to_add == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (state->retain_count == UINT_MAX) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    if (require_charge && state->charged_bytes == 0 && context_bytes == 0) {
+        errno = ENODATA;
+        return -1;
+    }
+
+    *bytes_to_add = 0;
+    if (state->charged_bytes == 0 && context_bytes > 0) {
+        state->charged_bytes = context_bytes;
+        *bytes_to_add = context_bytes;
+    }
+    state->retain_count++;
+    return 0;
+}
+
+int primary_context_record_retain(primary_context_accounting_t *state,
+                                  size_t context_bytes,
+                                  size_t *bytes_to_add) {
+    return record_retain(state, context_bytes, bytes_to_add, 0);
+}
+
+int primary_context_record_accounted_retain(
+    primary_context_accounting_t *state, size_t context_bytes,
+    size_t *bytes_to_add) {
+    return record_retain(state, context_bytes, bytes_to_add, 1);
+}
+
+int primary_context_record_release(primary_context_accounting_t *state,
+                                   size_t *bytes_to_remove) {
+    if (state == NULL || bytes_to_remove == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (state->retain_count == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *bytes_to_remove = 0;
+    state->retain_count--;
+    if (state->retain_count == 0) {
+        *bytes_to_remove = state->charged_bytes;
+        state->charged_bytes = 0;
+    }
+    return 0;
+}
+
+int primary_context_rollback_retain(primary_context_accounting_t *state,
+                                    size_t bytes_to_add) {
+    if (state == NULL || state->retain_count == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (bytes_to_add > 0 && state->charged_bytes != bytes_to_add) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    state->retain_count--;
+    if (bytes_to_add > 0) {
+        state->charged_bytes = 0;
+    }
+    return 0;
+}
+
+void primary_context_restore_charge(primary_context_accounting_t *state,
+                                    size_t context_bytes) {
+    if (state != NULL && state->retain_count == 0 && context_bytes > 0) {
+        state->charged_bytes = context_bytes;
+    }
+}
+
+void primary_context_accounting_reset(primary_context_accounting_t *states,
+                                      size_t state_count) {
+    size_t i;
+
+    if (states == NULL) {
+        return;
+    }
+    for (i = 0; i < state_count; i++) {
+        states[i].retain_count = 0;
+        states[i].charged_bytes = 0;
+    }
+}

--- a/src/cuda/context_accounting.c
+++ b/src/cuda/context_accounting.c
@@ -1,9 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2026 The HAMi Authors.
- */
-
 #include "cuda/context_accounting.h"
 
 #include <errno.h>

--- a/src/cuda/context_accounting.c
+++ b/src/cuda/context_accounting.c
@@ -2,6 +2,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 
 static int record_retain(primary_context_accounting_t *state,
                          size_t context_bytes, size_t *bytes_to_add,
@@ -38,6 +39,20 @@ int primary_context_record_accounted_retain(
     primary_context_accounting_t *state, size_t context_bytes,
     size_t *bytes_to_add) {
     return record_retain(state, context_bytes, bytes_to_add, 1);
+}
+
+int primary_context_size_is_plausible(size_t measured, size_t probed) {
+    if (measured == 0) {
+        return 0;
+    }
+    if (probed == 0) {
+        /* No probed size to compare against, so nothing to reject on. */
+        return 1;
+    }
+    if (probed > SIZE_MAX / PRIMARY_CONTEXT_SIZE_PLAUSIBLE_FACTOR) {
+        return 1;
+    }
+    return measured <= probed * PRIMARY_CONTEXT_SIZE_PLAUSIBLE_FACTOR;
 }
 
 int primary_context_record_release(primary_context_accounting_t *state,

--- a/src/cuda/context_accounting.h
+++ b/src/cuda/context_accounting.h
@@ -34,6 +34,15 @@ int primary_context_rollback_retain(primary_context_accounting_t *state,
 void primary_context_restore_charge(primary_context_accounting_t *state,
                                     size_t context_bytes);
 
+/*
+ * A primary context costs about the same on one device as on another, so the
+ * size the host PID probe recorded bounds a plausible measurement.  The retain
+ * window is not exclusive against cuMemAlloc, so a delta far above that bound
+ * is another thread's allocation rather than context memory.
+ */
+#define PRIMARY_CONTEXT_SIZE_PLAUSIBLE_FACTOR 4
+int primary_context_size_is_plausible(size_t measured, size_t probed);
+
 /* Clear process-local accounting inherited across fork(). */
 void primary_context_accounting_reset(primary_context_accounting_t *states,
                                       size_t state_count);

--- a/src/cuda/context_accounting.h
+++ b/src/cuda/context_accounting.h
@@ -1,9 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2026 The HAMi Authors.
- */
-
 #ifndef SRC_CUDA_CONTEXT_ACCOUNTING_H_
 #define SRC_CUDA_CONTEXT_ACCOUNTING_H_
 

--- a/src/cuda/context_accounting.h
+++ b/src/cuda/context_accounting.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 The HAMi Authors.
+ */
+
+#ifndef SRC_CUDA_CONTEXT_ACCOUNTING_H_
+#define SRC_CUDA_CONTEXT_ACCOUNTING_H_
+
+#include <stddef.h>
+
+typedef struct {
+    unsigned int retain_count;
+    size_t charged_bytes;
+} primary_context_accounting_t;
+
+/*
+ * Record a successful retain or release. A known size is charged once and
+ * removed when the final retain is released.
+ */
+int primary_context_record_retain(primary_context_accounting_t *state,
+                                  size_t context_bytes,
+                                  size_t *bytes_to_add);
+
+/*
+ * Record a retain only when its context memory is already charged or a
+ * nonzero charge can be applied before the caller reports success.
+ */
+int primary_context_record_accounted_retain(
+    primary_context_accounting_t *state, size_t context_bytes,
+    size_t *bytes_to_add);
+int primary_context_record_release(primary_context_accounting_t *state,
+                                   size_t *bytes_to_remove);
+
+/* Undo the most recent retain after its external accounting step fails. */
+int primary_context_rollback_retain(primary_context_accounting_t *state,
+                                    size_t bytes_to_add);
+
+/* Restore a charge that could not be removed from shared accounting. */
+void primary_context_restore_charge(primary_context_accounting_t *state,
+                                    size_t context_bytes);
+
+/* Clear process-local accounting inherited across fork(). */
+void primary_context_accounting_reset(primary_context_accounting_t *states,
+                                      size_t state_count);
+
+#endif  // SRC_CUDA_CONTEXT_ACCOUNTING_H_

--- a/src/cuda/hook.c
+++ b/src/cuda/hook.c
@@ -36,6 +36,7 @@ cuda_entry_t cuda_library_entry[] = {
     {.name = "cuDevicePrimaryCtxRetain"},
     {.name = "cuDevicePrimaryCtxSetFlags_v2"},
     {.name = "cuDevicePrimaryCtxRelease_v2"},
+    {.name = "cuDevicePrimaryCtxReset_v2"},
     {.name = "cuCtxGetDevice"},
     {.name = "cuCtxCreate_v2"},
     {.name = "cuCtxCreate_v3"},

--- a/src/include/libcuda_hook.h
+++ b/src/include/libcuda_hook.h
@@ -68,6 +68,7 @@ typedef enum {
     CUDA_OVERRIDE_ENUM(cuDevicePrimaryCtxRetain),
     CUDA_OVERRIDE_ENUM(cuDevicePrimaryCtxSetFlags_v2),
     CUDA_OVERRIDE_ENUM(cuDevicePrimaryCtxRelease_v2),
+    CUDA_OVERRIDE_ENUM(cuDevicePrimaryCtxReset_v2),
     CUDA_OVERRIDE_ENUM(cuCtxGetDevice),
     CUDA_OVERRIDE_ENUM(cuCtxCreate_v2),
     CUDA_OVERRIDE_ENUM(cuCtxCreate_v3),

--- a/src/include/libvgpu.h
+++ b/src/include/libvgpu.h
@@ -69,4 +69,11 @@ nvmlReturn_t set_task_pid();
 int map_cuda_visible_devices();
 void ensure_post_init();
 
+nvmlReturn_t get_used_gpu_memory_by_pid(unsigned int process_pid, int cudadev,
+                                        uint64_t *used);
+
+void context_accounting_fork_prepare();
+void context_accounting_fork_parent();
+void context_accounting_fork_child();
+
 #endif  // SRC_INCLUDE_LIBVGPU_H_

--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -124,6 +124,7 @@ void* __dlsym_hook_section(void* handle, const char* symbol) {
     DLSYM_HOOK_FUNC(cuDevicePrimaryCtxRetain);
     DLSYM_HOOK_FUNC(cuDevicePrimaryCtxSetFlags_v2);
     DLSYM_HOOK_FUNC(cuDevicePrimaryCtxRelease_v2);
+    DLSYM_HOOK_FUNC(cuDevicePrimaryCtxReset_v2);
     DLSYM_HOOK_FUNC(cuDriverGetVersion);
     DLSYM_HOOK_FUNC(cuDeviceGetTexture1DLinearMaxWidth);
     DLSYM_HOOK_FUNC(cuDeviceSetMemPool);

--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -846,7 +846,11 @@ void preInit(){
     load_cuda_libraries();
     //nvmlInit();
     ENSURE_INITIALIZED();
-    pthread_atfork(NULL, NULL, childReinitPostInit);
+    if (pthread_atfork(context_accounting_fork_prepare,
+                       context_accounting_fork_parent,
+                       childReinitPostInit) != 0) {
+        LOG_WARN("Failed to register context accounting fork handlers");
+    }
 }
 
 void postInit(){
@@ -879,6 +883,7 @@ void postInit(){
 }
 
 void childReinitPostInit() {
+    context_accounting_fork_child();
     LOG_DEBUG("Reset postInit state after fork");
     post_cuinit_flag = PTHREAD_ONCE_INIT;
     pidfound = 0;

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -1392,6 +1392,21 @@ int update_host_pid() {
     return 0;
 }
 
+int get_current_host_pid(void) {
+    shrreg_proc_slot_t *slot;
+
+    if (region_info.shared_region == NULL ||
+        region_info.shared_region == MAP_FAILED) {
+        return 0;
+    }
+
+    slot = get_current_proc_slot();
+    if (slot == NULL) {
+        return 0;
+    }
+    return atomic_load_explicit(&slot->hostpid, memory_order_acquire);
+}
+
 int set_host_pid(int hostpid) {
     int i,j,found=0;
     for (i=0;i<region_info.shared_region->proc_num;i++){

--- a/src/multiprocess/multiprocess_memory_limit.c
+++ b/src/multiprocess/multiprocess_memory_limit.c
@@ -44,7 +44,6 @@ _Static_assert(POSTINIT_FILE_LOCK_OFFSET > (off_t)sizeof(shared_region_t),
 
 int pidfound;
 
-int ctx_activate[32];
 
 static shared_region_info_t region_info = {0, -1, PTHREAD_ONCE_INIT, NULL, 0, NULL};
 static atomic_flag postinit_local_lock = ATOMIC_FLAG_INIT;

--- a/src/multiprocess/multiprocess_memory_limit.h
+++ b/src/multiprocess/multiprocess_memory_limit.h
@@ -135,6 +135,7 @@ uint64_t get_current_device_memory_limit(const int dev);
 int set_current_device_memory_limit(const int dev,size_t newlimit);
 int set_current_device_sm_limit(int dev, int limit);
 int update_host_pid();
+int get_current_host_pid(void);
 int set_host_pid(int hostpid);
 
 uint64_t get_current_device_memory_monitor(const int dev);

--- a/src/utils.c
+++ b/src/utils.c
@@ -95,6 +95,70 @@ int getextrapid(unsigned int prev, unsigned int current, nvmlProcessInfo_t1 *pre
     return 0;
 }
 
+nvmlReturn_t get_used_gpu_memory_by_pid(unsigned int process_pid, int cudadev,
+                                        uint64_t *used) {
+    nvmlProcessInfo_v1_t *processes = NULL;
+    nvmlDevice_t device;
+    nvmlReturn_t result;
+    unsigned int count = SHARED_REGION_MAX_PROCESS_NUM;
+    unsigned int i;
+    int nvmldev;
+    unsigned int mapped_dev;
+
+    if (used == NULL || process_pid == 0 || cudadev < 0 ||
+        cudadev >= CUDA_DEVICE_MAX_COUNT) {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    *used = 0;
+    mapped_dev = cuda_to_nvml_map((unsigned int)cudadev);
+    if (mapped_dev >= CUDA_DEVICE_MAX_COUNT) {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    nvmldev = (int)mapped_dev;
+
+    result = nvmlDeviceGetHandleByIndex(nvmldev, &device);
+    if (result != NVML_SUCCESS) {
+        return result;
+    }
+
+    processes = calloc(count, sizeof(*processes));
+    if (processes == NULL) {
+        return NVML_ERROR_MEMORY;
+    }
+    result = nvmlDeviceGetComputeRunningProcesses(device, &count, processes);
+    if (result == NVML_ERROR_INSUFFICIENT_SIZE && count > 0) {
+        if ((size_t)count > SIZE_MAX / sizeof(*processes)) {
+            free(processes);
+            return NVML_ERROR_MEMORY;
+        }
+        nvmlProcessInfo_v1_t *larger =
+            realloc(processes, count * sizeof(*processes));
+        if (larger == NULL) {
+            free(processes);
+            return NVML_ERROR_MEMORY;
+        }
+        processes = larger;
+        result =
+            nvmlDeviceGetComputeRunningProcesses(device, &count, processes);
+    }
+    if (result != NVML_SUCCESS) {
+        free(processes);
+        return result;
+    }
+
+    result = NVML_ERROR_NOT_FOUND;
+    for (i = 0; i < count; i++) {
+        if (processes[i].pid == process_pid &&
+            processes[i].usedGpuMemory != NVML_VALUE_NOT_AVAILABLE) {
+            *used = processes[i].usedGpuMemory;
+            result = NVML_SUCCESS;
+            break;
+        }
+    }
+    free(processes);
+    return result;
+}
+
 nvmlReturn_t set_task_pid() {
     unsigned int running_processes=0,previous=0,merged_num=0;
     nvmlProcessInfo_v1_t tmp_pids_on_device[SHARED_REGION_MAX_PROCESS_NUM];

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,20 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
         # GPU-free: builds the production accounting unit into the test.
         add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT}
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/cuda/context_accounting.c)
+    elseif (TEST_TARGET_NAME STREQUAL "test_context_accounting_fork")
+        # GPU-free: links the production fork handlers from context.c and
+        # drives them through pthread_atfork.  Section garbage collection
+        # drops the CUDA hooks, which nothing here references.
+        add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT}
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/cuda/context.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/cuda/context_accounting.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/log_utils.c)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE
+            _GNU_SOURCE)
+        target_compile_options(${TEST_TARGET_NAME} PRIVATE
+            -ffunction-sections -fdata-sections)
+        set_target_properties(${TEST_TARGET_NAME} PROPERTIES
+            LINK_FLAGS "-Wl,--no-export-dynamic,--gc-sections")
     elseif (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR TEST_TARGET_NAME STREQUAL "test_pid_discovery")
         if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
             add_executable(${TEST_TARGET_NAME}
@@ -46,6 +60,7 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
 
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
     if (TEST_TARGET_NAME STREQUAL "test_context_accounting" OR
+        TEST_TARGET_NAME STREQUAL "test_context_accounting_fork" OR
         TEST_TARGET_NAME STREQUAL "test_postinit_owner_death" OR
         TEST_TARGET_NAME STREQUAL "test_pid_discovery")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
@@ -70,6 +85,10 @@ set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
 add_test(NAME context_accounting
     COMMAND test_context_accounting)
 set_tests_properties(context_accounting PROPERTIES TIMEOUT 20)
+
+add_test(NAME context_accounting_fork
+    COMMAND test_context_accounting_fork)
+set_tests_properties(context_accounting_fork PROPERTIES TIMEOUT 20)
 
 add_test(NAME dlsym_rtld_next
     COMMAND test_dlsym_rtld_next)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,11 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     get_filename_component(TEST_TARGET_NAME ${RELATIVE_TEST_PATH} NAME_WE)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TEST_TARGET_DIR})
 
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_context_accounting")
+        # GPU-free: builds the production accounting unit into the test.
+        add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT}
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/cuda/context_accounting.c)
+    elseif (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
         # Build this focused regression test with the production shared-region
         # implementation.  It does not invoke any CUDA/NVML entry point at
         # runtime.  Section garbage collection drops unrelated GPU-facing
@@ -38,7 +42,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     endif()
 
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
-    if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
+    if (TEST_TARGET_NAME STREQUAL "test_context_accounting" OR
+        TEST_TARGET_NAME STREQUAL "test_postinit_owner_death")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         target_link_libraries(${TEST_TARGET_NAME} -ldl)
@@ -57,6 +62,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME postinit_owner_death
     COMMAND test_postinit_owner_death)
 set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
+
+add_test(NAME context_accounting
+    COMMAND test_context_accounting)
+set_tests_properties(context_accounting PROPERTIES TIMEOUT 20)
 
 add_test(NAME dlsym_rtld_next
     COMMAND test_dlsym_rtld_next)

--- a/test/test_context_accounting.c
+++ b/test/test_context_accounting.c
@@ -71,6 +71,26 @@ static void test_required_charge_fails_without_size(void) {
     assert(bytes == 99);
 }
 
+static void test_unmeasured_context_defers_instead_of_failing(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 99;
+
+    /* Mirrors the retain path when the context size cannot be measured. */
+    errno = 0;
+    assert(primary_context_record_accounted_retain(&state, 0, &bytes) == -1);
+    assert(errno == ENODATA);
+    assert(primary_context_record_retain(&state, 0, &bytes) == 0);
+    assert(bytes == 0);
+    assert(state.retain_count == 1);
+    assert(state.charged_bytes == 0);
+
+    /* A later retain that knows the size still charges exactly once. */
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(state.retain_count == 2);
+    assert(state.charged_bytes == CONTEXT_BYTES);
+}
+
 static void test_accounted_nested_retain_reuses_existing_charge(void) {
     primary_context_accounting_t state = {0};
     size_t bytes = 0;
@@ -201,6 +221,7 @@ static void test_forked_child_resets_private_accounting(void) {
 int main(void) {
     test_nested_lifetime();
     test_size_can_be_charged_late();
+    test_unmeasured_context_defers_instead_of_failing();
     test_required_charge_fails_without_size();
     test_accounted_nested_retain_reuses_existing_charge();
     test_failed_add_rolls_back_retain();

--- a/test/test_context_accounting.c
+++ b/test/test_context_accounting.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -130,6 +131,27 @@ static void test_failed_remove_is_retried(void) {
     assert(bytes == 0);
     assert(primary_context_record_release(&state, &bytes) == 0);
     assert(bytes == CONTEXT_BYTES);
+}
+
+static void test_implausible_measurement_is_rejected(void) {
+    /* A context measured at about the probed size is trusted. */
+    assert(primary_context_size_is_plausible(CONTEXT_BYTES, CONTEXT_BYTES) == 1);
+    assert(primary_context_size_is_plausible(
+               CONTEXT_BYTES * PRIMARY_CONTEXT_SIZE_PLAUSIBLE_FACTOR,
+               CONTEXT_BYTES) == 1);
+
+    /* A delta beyond that carries another thread's allocation, not context
+     * memory, and must not be cached for the life of the process. */
+    assert(primary_context_size_is_plausible(
+               CONTEXT_BYTES * PRIMARY_CONTEXT_SIZE_PLAUSIBLE_FACTOR + 1,
+               CONTEXT_BYTES) == 0);
+
+    /* Nothing measured, and nothing to compare against. */
+    assert(primary_context_size_is_plausible(0, CONTEXT_BYTES) == 0);
+    assert(primary_context_size_is_plausible(CONTEXT_BYTES, 0) == 1);
+
+    /* A probed size near the top of the range must not overflow the bound. */
+    assert(primary_context_size_is_plausible(CONTEXT_BYTES, SIZE_MAX) == 1);
 }
 
 static void test_rejects_invalid_calls(void) {
@@ -268,6 +290,7 @@ int main(void) {
     test_rollback_rejects_mismatched_charge();
     test_restore_is_ignored_while_retained();
     test_failed_charge_keeps_the_retain();
+    test_implausible_measurement_is_rejected();
     test_nonzero_device_accounting_is_isolated();
     test_forked_child_resets_private_accounting();
     puts("context accounting tests passed");

--- a/test/test_context_accounting.c
+++ b/test/test_context_accounting.c
@@ -161,6 +161,30 @@ static void test_rejects_invalid_calls(void) {
     assert(errno == EINVAL);
 }
 
+static void test_rollback_rejects_mismatched_charge(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    errno = 0;
+    assert(primary_context_rollback_retain(&state, CONTEXT_BYTES + 1) == -1);
+    assert(errno == EINVAL);
+    assert(state.retain_count == 1);
+    assert(state.charged_bytes == CONTEXT_BYTES);
+}
+
+static void test_restore_is_ignored_while_retained(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+
+    /* restore_charge is only for a fully released context whose removal
+     * failed; with a retain outstanding it must not touch the charge. */
+    assert(primary_context_record_retain(&state, 0, &bytes) == 0);
+    primary_context_restore_charge(&state, CONTEXT_BYTES);
+    assert(state.charged_bytes == 0);
+    assert(state.retain_count == 1);
+}
+
 static void test_nonzero_device_accounting_is_isolated(void) {
     primary_context_accounting_t states[4] = {{0}};
     size_t bytes = 0;
@@ -227,6 +251,8 @@ int main(void) {
     test_failed_add_rolls_back_retain();
     test_failed_remove_is_retried();
     test_rejects_invalid_calls();
+    test_rollback_rejects_mismatched_charge();
+    test_restore_is_ignored_while_retained();
     test_nonzero_device_accounting_is_isolated();
     test_forked_child_resets_private_accounting();
     puts("context accounting tests passed");

--- a/test/test_context_accounting.c
+++ b/test/test_context_accounting.c
@@ -1,9 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2026 The HAMi Authors.
- */
-
 #ifdef NDEBUG
 #undef NDEBUG
 #endif

--- a/test/test_context_accounting.c
+++ b/test/test_context_accounting.c
@@ -1,0 +1,213 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 The HAMi Authors.
+ */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../src/cuda/context_accounting.h"
+
+#define CONTEXT_BYTES 436207616UL
+
+static void test_nested_lifetime(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(state.retain_count == 1);
+
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == 0);
+    assert(state.retain_count == 2);
+
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == 0);
+    assert(state.retain_count == 1);
+
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == 0);
+    assert(state.retain_count == 2);
+
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == 0);
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(state.retain_count == 0);
+}
+
+static void test_size_can_be_charged_late(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 99;
+
+    assert(primary_context_record_retain(&state, 0, &bytes) == 0);
+    assert(bytes == 0);
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == 0);
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+}
+
+static void test_required_charge_fails_without_size(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 99;
+
+    errno = 0;
+    assert(primary_context_record_accounted_retain(&state, 0, &bytes) == -1);
+    assert(errno == ENODATA);
+    assert(state.retain_count == 0);
+    assert(state.charged_bytes == 0);
+    assert(bytes == 99);
+}
+
+static void test_accounted_nested_retain_reuses_existing_charge(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+
+    assert(primary_context_record_accounted_retain(
+               &state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(primary_context_record_accounted_retain(&state, 0, &bytes) == 0);
+    assert(bytes == 0);
+    assert(state.retain_count == 2);
+    assert(state.charged_bytes == CONTEXT_BYTES);
+
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == 0);
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+}
+
+static void test_failed_add_rolls_back_retain(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+
+    assert(primary_context_record_accounted_retain(
+               &state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(primary_context_rollback_retain(&state, bytes) == 0);
+    assert(state.retain_count == 0);
+    assert(state.charged_bytes == 0);
+}
+
+static void test_failed_remove_is_retried(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+
+    primary_context_restore_charge(&state, bytes);
+    assert(state.charged_bytes == CONTEXT_BYTES);
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == 0);
+    assert(primary_context_record_release(&state, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+}
+
+static void test_rejects_invalid_calls(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+
+    errno = 0;
+    assert(primary_context_record_release(&state, &bytes) == -1);
+    assert(errno == EINVAL);
+
+    errno = 0;
+    assert(primary_context_record_retain(NULL, 1, &bytes) == -1);
+    assert(errno == EINVAL);
+
+    state.retain_count = UINT_MAX;
+    errno = 0;
+    assert(primary_context_record_retain(&state, 1, &bytes) == -1);
+    assert(errno == EOVERFLOW);
+
+    state.retain_count = 0;
+    errno = 0;
+    assert(primary_context_rollback_retain(&state, 0) == -1);
+    assert(errno == EINVAL);
+}
+
+static void test_nonzero_device_accounting_is_isolated(void) {
+    primary_context_accounting_t states[4] = {{0}};
+    size_t bytes = 0;
+    const int dev = 3;
+
+    assert(primary_context_record_accounted_retain(
+               &states[dev], CONTEXT_BYTES, &bytes) == 0);
+    assert(states[dev].retain_count == 1);
+    assert(states[dev].charged_bytes == CONTEXT_BYTES);
+    assert(states[0].retain_count == 0);
+    assert(states[0].charged_bytes == 0);
+}
+
+static void test_forked_child_resets_private_accounting(void) {
+    primary_context_accounting_t states[4] = {{0}};
+    primary_context_accounting_t child_states[4] = {{0}};
+    size_t bytes = 0;
+    int result_pipe[2];
+    pid_t child;
+    int status;
+
+    assert(primary_context_record_accounted_retain(
+               &states[0], CONTEXT_BYTES, &bytes) == 0);
+    assert(primary_context_record_accounted_retain(
+               &states[3], CONTEXT_BYTES, &bytes) == 0);
+    assert(pipe(result_pipe) == 0);
+
+    child = fork();
+    assert(child >= 0);
+    if (child == 0) {
+        close(result_pipe[0]);
+        primary_context_accounting_reset(states, 4);
+        if (write(result_pipe[1], states, sizeof(states)) !=
+            (ssize_t)sizeof(states)) {
+            _exit(2);
+        }
+        _exit(0);
+    }
+
+    close(result_pipe[1]);
+    assert(read(result_pipe[0], child_states, sizeof(child_states)) ==
+           (ssize_t)sizeof(child_states));
+    close(result_pipe[0]);
+    assert(waitpid(child, &status, 0) == child);
+    assert(WIFEXITED(status));
+    assert(WEXITSTATUS(status) == 0);
+
+    assert(child_states[0].retain_count == 0);
+    assert(child_states[0].charged_bytes == 0);
+    assert(child_states[3].retain_count == 0);
+    assert(child_states[3].charged_bytes == 0);
+    assert(states[0].retain_count == 1);
+    assert(states[0].charged_bytes == CONTEXT_BYTES);
+    assert(states[3].retain_count == 1);
+    assert(states[3].charged_bytes == CONTEXT_BYTES);
+}
+
+int main(void) {
+    test_nested_lifetime();
+    test_size_can_be_charged_late();
+    test_required_charge_fails_without_size();
+    test_accounted_nested_retain_reuses_existing_charge();
+    test_failed_add_rolls_back_retain();
+    test_failed_remove_is_retried();
+    test_rejects_invalid_calls();
+    test_nonzero_device_accounting_is_isolated();
+    test_forked_child_resets_private_accounting();
+    puts("context accounting tests passed");
+    return 0;
+}

--- a/test/test_context_accounting.c
+++ b/test/test_context_accounting.c
@@ -161,6 +161,26 @@ static void test_rejects_invalid_calls(void) {
     assert(errno == EINVAL);
 }
 
+static void test_failed_charge_keeps_the_retain(void) {
+    primary_context_accounting_t state = {0};
+    size_t bytes = 0;
+    size_t retried = 99;
+
+    /* Mirrors the retain path when the shared region refuses the charge. */
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(primary_context_rollback_retain(&state, bytes) == 0);
+    assert(primary_context_record_retain(&state, 0, &retried) == 0);
+    assert(retried == 0);
+    assert(state.retain_count == 1);
+    assert(state.charged_bytes == 0);
+
+    /* A later retain can still charge it once. */
+    assert(primary_context_record_retain(&state, CONTEXT_BYTES, &bytes) == 0);
+    assert(bytes == CONTEXT_BYTES);
+    assert(state.charged_bytes == CONTEXT_BYTES);
+}
+
 static void test_rollback_rejects_mismatched_charge(void) {
     primary_context_accounting_t state = {0};
     size_t bytes = 0;
@@ -253,6 +273,7 @@ int main(void) {
     test_rejects_invalid_calls();
     test_rollback_rejects_mismatched_charge();
     test_restore_is_ignored_while_retained();
+    test_failed_charge_keeps_the_retain();
     test_nonzero_device_accounting_is_isolated();
     test_forked_child_resets_private_accounting();
     puts("context accounting tests passed");

--- a/test/test_context_accounting_fork.c
+++ b/test/test_context_accounting_fork.c
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 The HAMi Authors.
+ */
+
+/*
+ * GPU-free test of the fork handlers in src/cuda/context.c, driven through a
+ * real pthread_atfork registration and a real fork(), the way libvgpu.c wires
+ * them.  test_context_accounting covers what primary_context_accounting_reset
+ * does to the state; this covers that the child handler actually runs after
+ * fork, that it leaves the accounting mutex usable in the child, and that the
+ * parent handler releases it again in the parent.
+ *
+ * The private arrays in context.c are static, so the handlers are observed
+ * through what they touch that is visible: ctx_activate, which the child
+ * handler clears for every device, and context_size, which it must keep.  A
+ * mutex left held would deadlock the next fork's prepare handler, so each
+ * process forks once more under an alarm that turns a hang into a failure.
+ */
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "multiprocess/multiprocess_memory_limit.h"
+
+/* The handlers under test.  libvgpu.c registers the same prepare and parent
+ * handlers, and its child handler calls context_accounting_fork_child first. */
+void context_accounting_fork_prepare(void);
+void context_accounting_fork_parent(void);
+void context_accounting_fork_child(void);
+
+/* Defined in multiprocess_memory_limit.c in production.  The handlers read
+ * and write these, so the test owns them here. */
+int ctx_activate[CUDA_DEVICE_MAX_COUNT];
+size_t context_size;
+
+#define PROBED_SIZE 436207616UL
+#define FORK_TIMEOUT_S 5
+
+typedef struct {
+    int activate[CUDA_DEVICE_MAX_COUNT];
+    size_t size;
+    int refork_ok;
+} child_view_t;
+
+static void on_alarm(int sig) {
+    (void)sig;
+    _exit(3);
+}
+
+/* A held accounting mutex deadlocks the prepare handler of the next fork.
+ * The alarm turns that into exit 3 instead of a hang. */
+static int fork_completes(void) {
+    pid_t pid;
+    int status;
+
+    alarm(FORK_TIMEOUT_S);
+    pid = fork();
+    if (pid == 0) {
+        _exit(0);
+    }
+    alarm(0);
+    if (pid < 0) {
+        return 0;
+    }
+    return waitpid(pid, &status, 0) == pid && WIFEXITED(status) &&
+           WEXITSTATUS(status) == 0;
+}
+
+int main(void) {
+    child_view_t seen;
+    int result_pipe[2];
+    pid_t child;
+    int status;
+    int dev;
+
+    signal(SIGALRM, on_alarm);
+    assert(pthread_atfork(context_accounting_fork_prepare,
+                          context_accounting_fork_parent,
+                          context_accounting_fork_child) == 0);
+
+    for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+        ctx_activate[dev] = dev + 1;
+    }
+    context_size = PROBED_SIZE;
+    assert(pipe(result_pipe) == 0);
+
+    alarm(FORK_TIMEOUT_S);
+    child = fork();
+    assert(child >= 0);
+    if (child == 0) {
+        alarm(0);
+        close(result_pipe[0]);
+        memcpy(seen.activate, ctx_activate, sizeof(seen.activate));
+        seen.size = context_size;
+        seen.refork_ok = fork_completes();
+        if (write(result_pipe[1], &seen, sizeof(seen)) !=
+            (ssize_t)sizeof(seen)) {
+            _exit(2);
+        }
+        _exit(0);
+    }
+    alarm(0);
+
+    close(result_pipe[1]);
+    assert(read(result_pipe[0], &seen, sizeof(seen)) == (ssize_t)sizeof(seen));
+    close(result_pipe[0]);
+    assert(waitpid(child, &status, 0) == child);
+    assert(WIFEXITED(status));
+    assert(WEXITSTATUS(status) == 0);
+
+    /* The child handler ran: every device cleared, the probed size kept, and
+     * the child could fork again, so its accounting mutex was released. */
+    for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+        assert(seen.activate[dev] == 0);
+    }
+    assert(seen.size == PROBED_SIZE);
+    assert(seen.refork_ok == 1);
+
+    /* The parent is untouched, and its handler released the mutex too. */
+    for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
+        assert(ctx_activate[dev] == dev + 1);
+    }
+    assert(context_size == PROBED_SIZE);
+    assert(fork_completes() == 1);
+
+    puts("context accounting fork wiring test passed");
+    return 0;
+}

--- a/test/test_context_accounting_fork.c
+++ b/test/test_context_accounting_fork.c
@@ -12,11 +12,11 @@
  * fork, that it leaves the accounting mutex usable in the child, and that the
  * parent handler releases it again in the parent.
  *
- * The private arrays in context.c are static, so the handlers are observed
- * through what they touch that is visible: ctx_activate, which the child
- * handler clears for every device, and context_size, which it must keep.  A
- * mutex left held would deadlock the next fork's prepare handler, so each
- * process forks once more under an alarm that turns a hang into a failure.
+ * The per-device state in context.c is static, so the child handler is
+ * observed through the accounting mutex it must release: a mutex left held
+ * deadlocks the next fork's prepare handler, so each process forks once more
+ * under an alarm that turns a hang into a failure.  context_size is checked
+ * separately because the child handler must leave it alone.
  */
 #ifdef NDEBUG
 #undef NDEBUG
@@ -26,7 +26,6 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -39,15 +38,13 @@ void context_accounting_fork_parent(void);
 void context_accounting_fork_child(void);
 
 /* Defined in multiprocess_memory_limit.c in production.  The handlers read
- * and write these, so the test owns them here. */
-int ctx_activate[CUDA_DEVICE_MAX_COUNT];
+ * and write this, so the test owns it here. */
 size_t context_size;
 
 #define PROBED_SIZE 436207616UL
 #define FORK_TIMEOUT_S 5
 
 typedef struct {
-    int activate[CUDA_DEVICE_MAX_COUNT];
     size_t size;
     int refork_ok;
 } child_view_t;
@@ -81,16 +78,12 @@ int main(void) {
     int result_pipe[2];
     pid_t child;
     int status;
-    int dev;
 
     signal(SIGALRM, on_alarm);
     assert(pthread_atfork(context_accounting_fork_prepare,
                           context_accounting_fork_parent,
                           context_accounting_fork_child) == 0);
 
-    for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
-        ctx_activate[dev] = dev + 1;
-    }
     context_size = PROBED_SIZE;
     assert(pipe(result_pipe) == 0);
 
@@ -100,7 +93,6 @@ int main(void) {
     if (child == 0) {
         alarm(0);
         close(result_pipe[0]);
-        memcpy(seen.activate, ctx_activate, sizeof(seen.activate));
         seen.size = context_size;
         seen.refork_ok = fork_completes();
         if (write(result_pipe[1], &seen, sizeof(seen)) !=
@@ -118,20 +110,14 @@ int main(void) {
     assert(WIFEXITED(status));
     assert(WEXITSTATUS(status) == 0);
 
-    /* The child handler ran: every device cleared, the probed size kept, and
-     * the child could fork again, so its accounting mutex was released. */
-    for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
-        assert(seen.activate[dev] == 0);
-    }
-    assert(seen.size == PROBED_SIZE);
+    /* The child could fork again, so its handler ran and released the
+     * accounting mutex, and it left the probed size alone. */
     assert(seen.refork_ok == 1);
+    assert(seen.size == PROBED_SIZE);
 
-    /* The parent is untouched, and its handler released the mutex too. */
-    for (dev = 0; dev < CUDA_DEVICE_MAX_COUNT; dev++) {
-        assert(ctx_activate[dev] == dev + 1);
-    }
-    assert(context_size == PROBED_SIZE);
+    /* The parent handler released the mutex too, and the parent is untouched. */
     assert(fork_completes() == 1);
+    assert(context_size == PROBED_SIZE);
 
     puts("context accounting fork wiring test passed");
     return 0;

--- a/test/test_context_accounting_fork.c
+++ b/test/test_context_accounting_fork.c
@@ -1,10 +1,4 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
- *
- * Copyright (c) 2026 The HAMi Authors.
- */
-
-/*
  * GPU-free test of the fork handlers in src/cuda/context.c, driven through a
  * real pthread_atfork registration and a real fork(), the way libvgpu.c wires
  * them.  test_context_accounting covers what primary_context_accounting_reset


### PR DESCRIPTION
Split out of #251 at @maverick-woo's request. This PR covers context accounting; the fallback lock is #316, and the broker client follows. Refs Project-HAMi/HAMi#1662.

## Problem

HAMi charges primary context memory using a 0/1 activation flag per device. That flag cannot track nested retains or distinguish an intermediate release from the final release. A fork child also inherits bookkeeping for contexts it did not create.

## Change

`context_accounting.c` keeps a retain count and the charged bytes for each device. It charges once and removes the charge after the final successful release. If a shared accounting update fails, it preserves the retain and defers the charge, or keeps the charge for a later removal attempt.

`cuDevicePrimaryCtxReset_v2` removes the resource charge while preserving retained references. CUDA reset does not release retained usage, so a release after reset must still account for those references when another retain has recreated the context.

Each device uses `context_size` from the existing host PID probe. The retain hook does not take a before/after NVML sample: allocation hooks do not share its mutex, so that delta can include unrelated application memory. This keeps main's existing size estimate. Exclusive measurement of a separate size for each device remains outside this PR.

The fork registration and child callback live in `context_fork.c`. `preInit()` calls that registration function. The child clears its private accounting, resets post-init state and keeps the probe estimate. `ctx_activate` is removed because the retain count replaces it.

The allocator and memory mapping hardening from #251 is separate and is not included here.

## Tests

Three tests build production code with no GPU or driver needed at runtime:

1. `context_accounting` covers retain/release bookkeeping, deferred charges, rollback and recovery.
2. `context_accounting_hooks` drives the production retain, release and reset hooks with simulated driver and accounting boundaries. It covers reset followed by retain/release, unrelated allocation during a retain, a refused charge followed by recovery, failed charge removal and driver errors.
3. `context_accounting_fork` calls the production registration function, seeds accounting on two devices and forks. It checks fresh child accounting, unchanged parent references, reset post-init state and another fork in each process.

The Docker build runs these tests with CTest. Its filter also includes `hostpid_fallback_lock` so this PR and #316 use the same command and can merge in either order. [Linux CI](https://github.com/Project-HAMi/HAMi-core/actions/runs/34756983125) passed all three at `7f99005`. Local checks also confirmed that the new regressions reject the corresponding defective implementations. These checks do not validate GPU behavior or a complete HAMi workload.

```sh
cmake --build build --target test_context_accounting test_context_accounting_hooks test_context_accounting_fork
ctest --test-dir build --output-on-failure -R context_accounting
```

---
I used AI assistance (deepseek v4 flash) for the original split and Codex for these fixes. The accounting design comes from #251.
