### PR TITLE
Fix host PID detection when CUDA_VISIBLE_DEVICES doesn't start at device 0

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <dirent.h>
 #include <ctype.h>
 #include <time.h>
@@ -76,43 +77,69 @@ nvmlReturn_t set_task_pid() {
     unsigned int nvmlCounts;
     CHECK_NVML_API(nvmlDeviceGetCount(&nvmlCounts));
     
-    int cudaDev;
-    for (i=0;i<nvmlCounts;i++){
-        cudaDev=nvml_to_cuda_map(i);
-        if (cudaDev<0) {
-            continue;
-        }
-        CHECK_NVML_API(nvmlDeviceGetHandleByIndex(i, &device));
-        do{
-            res = nvmlDeviceGetComputeRunningProcesses(device, &previous, tmp_pids_on_device);
-            if ((res != NVML_SUCCESS) && (res != NVML_ERROR_INSUFFICIENT_SIZE)) {
-                LOG_ERROR("Device2GetComputeRunningProcesses failed %d,%d\n",res,i);
-                return res;
+    /*
+     * The probe context is created on CUDA device 0, so both process
+     * snapshots must be taken on the NVML device that is the same physical
+     * GPU, otherwise the probe PID never appears in the diff. The NVML
+     * device is resolved by UUID: cuda_to_nvml_map() cannot be used here,
+     * because nvml_preInit() - triggered by the nvmlInit() call above -
+     * resets the map to identity, which is only correct when
+     * CUDA_VISIBLE_DEVICES starts with the container's device 0.
+     */
+    int probeDev = 0;
+    int probeNvmlIndex = -1;
+    CUuuid cu_uuid;
+    char want_uuid[48];
+    char have_uuid[96];
+    if (CUDA_OVERRIDE_CALL(cuda_library_entry, cuDeviceGetUuid, &cu_uuid, probeDev) == CUDA_SUCCESS) {
+        const unsigned char *b = (const unsigned char *)cu_uuid.bytes;
+        snprintf(want_uuid, sizeof(want_uuid),
+            "GPU-%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+            b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]);
+        for (i = 0; i < nvmlCounts; i++) {
+            if (nvmlDeviceGetHandleByIndex(i, &device) != NVML_SUCCESS) {
+                continue;
             }
-        }while(res==NVML_ERROR_INSUFFICIENT_SIZE); 
-        mergepid(&previous,&merged_num,(nvmlProcessInfo_t1 *)tmp_pids_on_device,pre_pids_on_device);
-        break;
+            if (nvmlDeviceGetUUID(device, have_uuid, sizeof(have_uuid)) != NVML_SUCCESS) {
+                continue;
+            }
+            if (strcasecmp(want_uuid, have_uuid) == 0) {
+                probeNvmlIndex = i;
+                break;
+            }
+        }
     }
+    if (probeNvmlIndex < 0) {
+        LOG_WARN("could not match CUDA device %d to an NVML device by uuid, polling NVML device 0", probeDev);
+        probeNvmlIndex = 0;
+    }
+    CHECK_NVML_API(nvmlDeviceGetHandleByIndex(probeNvmlIndex, &device));
+    do {
+        res = nvmlDeviceGetComputeRunningProcesses(device, &previous, tmp_pids_on_device);
+        if ((res != NVML_SUCCESS) && (res != NVML_ERROR_INSUFFICIENT_SIZE)) {
+            LOG_ERROR("Device2GetComputeRunningProcesses failed %d,%d\n", res, probeNvmlIndex);
+            return res;
+        }
+    } while (res == NVML_ERROR_INSUFFICIENT_SIZE);
+    mergepid(&previous, &merged_num, (nvmlProcessInfo_t1 *)tmp_pids_on_device, pre_pids_on_device);
     previous = merged_num;
     merged_num = 0;
     memset(tmp_pids_on_device,0,sizeof(nvmlProcessInfo_v1_t)*SHARED_REGION_MAX_PROCESS_NUM);
-    CHECK_CU_RESULT(cuDevicePrimaryCtxRetain(&pctx,0));
-    for (i=0;i<nvmlCounts;i++) {
-        cudaDev=nvml_to_cuda_map(i);
-        if (cudaDev<0) {
-            continue;
-        }
-        CHECK_NVML_API(nvmlDeviceGetHandleByIndex (i, &device)); 
-        do{
-            res = nvmlDeviceGetComputeRunningProcesses(device, &running_processes, tmp_pids_on_device);
-            if ((res != NVML_SUCCESS) && (res != NVML_ERROR_INSUFFICIENT_SIZE)) {
-                LOG_ERROR("Device2GetComputeRunningProcesses failed %d\n",res);
-                return res;
-            }
-        }while(res == NVML_ERROR_INSUFFICIENT_SIZE);
-        mergepid(&running_processes,&merged_num,(nvmlProcessInfo_t1 *)tmp_pids_on_device,pids_on_device);
-        break;
+    CHECK_CU_RESULT(cuDevicePrimaryCtxRetain(&pctx, probeDev));
+    res = nvmlDeviceGetHandleByIndex(probeNvmlIndex, &device);
+    if (res != NVML_SUCCESS) {
+        LOG_WARN("NVML error at line %d: %d", __LINE__, res);
+        goto cleanup;
     }
+    do {
+        res = nvmlDeviceGetComputeRunningProcesses(device, &running_processes, tmp_pids_on_device);
+        if ((res != NVML_SUCCESS) && (res != NVML_ERROR_INSUFFICIENT_SIZE)) {
+            LOG_ERROR("Device2GetComputeRunningProcesses failed %d\n", res);
+            goto cleanup;
+        }
+    } while (res == NVML_ERROR_INSUFFICIENT_SIZE);
+    mergepid(&running_processes, &merged_num, (nvmlProcessInfo_t1 *)tmp_pids_on_device, pids_on_device);
     running_processes = merged_num;
     LOG_INFO("current processes num = %u %u",previous,running_processes);
     for (i=0;i<merged_num;i++){
@@ -122,7 +149,8 @@ nvmlReturn_t set_task_pid() {
     unsigned int hostpid = getextrapid(previous,running_processes,pre_pids_on_device,pids_on_device); 
     if (hostpid==0) {
         LOG_ERROR("host pid is error!");
-        return NVML_ERROR_DRIVER_NOT_LOADED;
+        res = NVML_ERROR_DRIVER_NOT_LOADED;
+        goto cleanup;
     }
     LOG_INFO("hostPid=%d",hostpid);
     if (set_host_pid(hostpid)==0) {
@@ -134,8 +162,12 @@ nvmlReturn_t set_task_pid() {
             }
         }
     }
-    CHECK_CU_RESULT(cuDevicePrimaryCtxRelease(0));
-    return NVML_SUCCESS; 
+    res = NVML_SUCCESS;
+cleanup:
+    if (cuDevicePrimaryCtxRelease(probeDev) != CUDA_SUCCESS) {
+        LOG_WARN("failed to release primary context on device %d", probeDev);
+    }
+    return res;
 }
 
 int parse_cuda_visible_env() {


### PR DESCRIPTION
Fixes #225 (closed by the lifecycle policy while the bug is still present on `main`).

## Changes?

- `set_task_pid()` now pairs the probe context and the polled NVML device by UUID: the probe context is created on CUDA device 0, and the NVML device whose UUID matches (`cuDeviceGetUuid` vs `nvmlDeviceGetUUID`) is used for both process snapshots.
- If no NVML device matches the UUID, it logs a warning and falls back to polling NVML device 0 (the previous behavior).
- Error paths now release the retained probe context; previously it leaked for the lifetime of the process whenever detection failed (the leak observed during the #230 testing).
- Not in scope: the `nvml_preInit()` map reset itself (see below). This PR only makes `set_task_pid()` independent of the map; other consumers of the map are unchanged.

## Why We Need?

- Whenever `CUDA_VISIBLE_DEVICES` does not start with the container's device 0, host-PID detection fails deterministically (`host pid is error!`), per-process accounting is merged into the wrong slot, and legal allocations trip spurious per-device OOMs. This is the failure analyzed in #225.
- Direct cause: the probe context is created with `cuDevicePrimaryCtxRetain(&pctx, 0)`, which is CUDA device 0, while the before/after NVML snapshots are taken on the first NVML device that has a valid entry in `cuda_to_nvml_map`. With such a `CUDA_VISIBLE_DEVICES`, those are different physical GPUs, so the probe PID never appears in the snapshot diff.
- Root cause of why the map cannot be used here: `nvml_preInit()` resets `cuda_to_nvml_map_array` to identity, and it is triggered via `pthread_once` by the `nvmlInit()` call at the top of `set_task_pid()` itself. By the time the polling loop consults the map, it is an identity map regardless of what `parse_cuda_visible_env()` computed earlier in `postInit()`.
- This is also why the approach in #230 (keep the probe on the `cudaDev` found through the map) did not resolve the failure when we tested it: with an identity map that `cudaDev` is always 0, which is behaviorally identical to the hardcoded value. It is consistent with the `current processes num = 0 0` runs reported in the #230 thread with that patch applied. The unresolved `SET_TASK_PID FAILED` case on driver 580.65.06 from that thread matches this root cause as well, but we could not verify on that exact driver.
- The UUID pairing holds regardless of the state of the map or of the initialization order.

## Tests?

Environment: Kubernetes + HAMi v2.7.1 (hami-scheduler), pod with `nvidia.com/gpu: 2`, `nvidia.com/gpumem: 5800`; node: 2x NVIDIA A100-PCIE-40GB, driver 580.173.02. Cases A-F are the reproduction matrix from #225, 3 repetitions each.

- Full path (torch 2.8.0+cu128), v2.7.1 code base:

| build | A `0` | B `1` | C `1,0` | D `1,0` + set_device(1) | E `0,1` + set_device(1) | F `0,1` |
|---|---|---|---|---|---|---|
| v2.7.1 official binary | ok 3/3 | host pid error 3/3 | host pid error 3/3 | host pid error 3/3 | ok 3/3 | ok 3/3 |
| v2.7.1 built from source (control) | ok 3/3 | host pid error 3/3 | host pid error 3/3 | host pid error 3/3 | ok 3/3 | ok 3/3 |
| v2.7.1 + this fix | ok 3/3 | ok 3/3 | ok 3/3 | ok 3/3 | ok 3/3 | ok 3/3 |

- Driver-API probe (ctypes `cuInit`, no CUDA runtime involved), `main`:

| build | A | B | C | D | E | F |
|---|---|---|---|---|---|---|
| main unpatched | ok 3/3 | host pid error 3/3 | host pid error 3/3 | host pid error 3/3 | ok 3/3 | ok 3/3 |
| main + this fix | ok 3/3 | ok 3/3 | ok 3/3 | ok 3/3 | ok 3/3 | ok 3/3 |

- Case C verbose with the fix: `current processes num = 1 2` -> `hostPid=581730` (v2.7.1 build) / `hostPid=1150676` (main build)
- Leak probe (holder process with `CVD=1,0`, 15 s): no lingering probe context during or after the run
- A clean clone of this branch builds in `nvidia/cuda:13.3.0-cudnn-devel-ubi8` (the `make build-in-docker` image)
- Why two validation paths: on our nodes, libvgpu built from current `main` (patched or not) fails CUDA runtime entry-point negotiation for every torch build we tried (cudart 12.6 / 12.8 / 13.0, all ending in `Found no NVIDIA driver`), while the official v2.7.1 binary works and direct driver-API calls also work. That regression is unrelated to this change (it reproduces on unpatched `main`) and we will report it separately. Because of it, the full-workload validation uses a v2.7.1 backport of this patch, and `main` is validated through the driver-API probe path. The probe path was cross-checked against the official v2.7.1 binary, where it reproduces the same B/C/D failures as the torch matrix.
