### PR TITLE
fix: avoid SIGSEGV when set_task_pid() is bypassed due to lock failure (postInit)

### DIFF
--- a/src/include/libcuda_hook.h
+++ b/src/include/libcuda_hook.h
@@ -36,6 +36,7 @@ typedef CUresult (*cuda_sym_t)();
     cuda_sym_t _entry = (cuda_sym_t)CUDA_FIND_ENTRY(table, sym);               \
     if (_entry == NULL) {                                                      \
       LOG_ERROR("Hijack failed: %s is NULL", #sym);                            \
+      return CUDA_ERROR_NOT_FOUND;                                             \
     }                                                                          \
     _entry(__VA_ARGS__);                                                       \
   })

--- a/src/include/libnvml_hook.h
+++ b/src/include/libnvml_hook.h
@@ -28,13 +28,13 @@ typedef nvmlReturn_t (*driver_sym_t)();
   ({                                                                           \
     LOG_DEBUG("Hijacking %s", #sym);                                           \
     driver_sym_t _entry = NVML_FIND_ENTRY(table, sym);                         \
-    _entry(__VA_ARGS__);                                                       \
+    _entry ? _entry(__VA_ARGS__) : NVML_ERROR_FUNCTION_NOT_FOUND;              \
   })
 
 #define NVML_OVERRIDE_CALL_NO_LOG(table, sym, ...)                             \
   ({                                                                           \
     driver_sym_t _entry = NVML_FIND_ENTRY(table, sym);                         \
-    _entry(__VA_ARGS__);                                                       \
+    _entry ? _entry(__VA_ARGS__) : NVML_ERROR_FUNCTION_NOT_FOUND;              \
   })
 
 /**

--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -853,6 +853,7 @@ void postInit(){
     allocator_init();
     map_cuda_visible_devices();
 
+    nvmlInit();
     // Use the process-death-safe shared file lock to serialize host PID detection
     int lock_acquired = lock_postinit();
     nvmlReturn_t res = NVML_SUCCESS;


### PR DESCRIPTION
## Why

When `lock_postInit()` fails in `postInit()`, `set_task_pid()` is skipped, which bypasses `nvmlInit()`. This prevents `nvml_preInit()` → `load_nvml_libraries()` from executing, leaving `nvml_library_entry[]` uninitialized.

Later, `init_utilization_watcher()` → `nvmlDeviceGetCount()` dereferences the null function pointer and causes a SIGSEGV.

## Fix

1. Call `nvmlInit()` unconditionally in `postInit()` to ensure `load_nvml_libraries()` always runs.
2. Add null-check protection in `*_OVERRIDE_CALL()` macro for robustness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when CUDA or NVML driver functions are unavailable, returning clear error results instead of attempting invalid calls.
  * Enhanced stability when requested driver symbols cannot be resolved.
  * Ensured NVML initialization occurs during device setup for more reliable GPU monitoring and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->