### PR TITLE
fix(allocator): use tracked allocation device instead of current context in async free accounting (#310)

### DIFF
--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -244,12 +244,11 @@ int remove_chunk_async(
     for (val = a_list->head; val != NULL; val = val->next) {
         if (val->entry->address == dptr) {
             t_size=val->entry->length;
+            CUdevice t_dev = val->entry->dev;  /* capture before LIST_REMOVE frees entry */
             CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemFreeAsync,dptr,hStream);
             LIST_REMOVE(a_list,val);
             a_list->limit-=t_size;
-            CUdevice dev;
-            cuCtxGetDevice(&dev);
-            rm_gpu_device_memory_usage(getpid(),dev,t_size,2);
+            rm_gpu_device_memory_usage(getpid(),t_dev,t_size,2);
             return 0;
         }
     }

--- a/src/allocator/allocator.c
+++ b/src/allocator/allocator.c
@@ -248,7 +248,7 @@ int remove_chunk_async(
             CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemFreeAsync,dptr,hStream);
             LIST_REMOVE(a_list,val);
             a_list->limit-=t_size;
-            rm_gpu_device_memory_usage(getpid(),t_dev,t_size,2);
+            rm_gpu_device_memory_usage(getpid(), t_dev, t_size, 2);
             return 0;
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,24 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
             -ffunction-sections -fdata-sections)
         set_target_properties(${TEST_TARGET_NAME} PROPERTIES
             LINK_FLAGS "-Wl,--no-export-dynamic,--gc-sections")
+    elseif (TEST_TARGET_NAME STREQUAL "test_alloc_async_free_wrong_device")
+        # Needs get_gpu_memory_usage() from multiprocess_memory_limit.c linked
+        # directly into the test binary (same reasoning as
+        # test_postinit_owner_death above), on top of the normal CUDA driver
+        # link every allocation test needs. -ffunction-sections/--gc-sections
+        # let the linker drop the parts of multiprocess_memory_limit.c this
+        # test never calls, instead of requiring their own transitive deps
+        # (e.g. cuda_to_nvml_map from multiprocess_utilization_watcher.c).
+        add_executable(${TEST_TARGET_NAME}
+            ${TEST_SCRIPT}
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/multiprocess/multiprocess_memory_limit.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/log_utils.c)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE
+            _GNU_SOURCE)
+        target_compile_options(${TEST_TARGET_NAME} PRIVATE
+            -ffunction-sections -fdata-sections)
+        set_target_properties(${TEST_TARGET_NAME} PROPERTIES
+            LINK_FLAGS "-Wl,--no-export-dynamic,--gc-sections")
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT})
     elseif (TEST_SCRIPT MATCHES ".*cu")
@@ -46,6 +64,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         target_link_libraries(${TEST_TARGET_NAME} -ldl)
     else()
+        # test_alloc_async_free_wrong_device also lands here: it needs the
+        # same CUDA driver link as every other allocation test.
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread
             -lnvidia-ml -lcuda -lcudart -L${CUDA_HOME}/lib64)
     endif()
@@ -74,6 +94,17 @@ if (TARGET vgpu)
     set_tests_properties(dlsym_rtld_next_preloaded PROPERTIES
         ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:vgpu>"
         TIMEOUT 10)
+
+    # Needs >= 2 real GPUs to reproduce the cross-device free; the test
+    # itself detects a single-GPU environment and exits with
+    # SKIP_EXIT_CODE (125) instead of failing -- SKIP_RETURN_CODE tells
+    # CTest to report that as skipped rather than passed/failed.
+    add_test(NAME alloc_async_free_wrong_device
+        COMMAND test_alloc_async_free_wrong_device)
+    set_tests_properties(alloc_async_free_wrong_device PROPERTIES
+        ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:vgpu>"
+        SKIP_RETURN_CODE 125
+        TIMEOUT 30)
 endif()
 
 

--- a/test/test_alloc_async_free_wrong_device.c
+++ b/test/test_alloc_async_free_wrong_device.c
@@ -1,0 +1,254 @@
+// Regression test for Project-HAMi/HAMi-core issue #310: remove_chunk_async()
+// used cuCtxGetDevice() -- the CALLING THREAD's currently-bound context's
+// device -- to decide which device's tracked usage counter to decrement,
+// instead of val->entry->dev, the device the chunk was actually allocated on
+// and accounted against (see account_async_chunk() in
+// src/allocator/allocator.c, which stores it there via
+// INIT_ALLOCATED_LIST_ENTRY at allocation time).
+//
+// cuMemFreeAsync(dptr, hStream) takes an explicit stream, not an implicit
+// "current device" -- CUDA does not require the calling thread's current
+// context to match the stream's/allocation's device. A legitimate multi-GPU
+// caller (a worker pool that round-robins cuCtxSetCurrent, async cleanup
+// running with a different device's context current, etc.) can trip this,
+// corrupting device accounting for TWO devices in one call:
+//   - the real allocation's device is never decremented -> its tracked
+//     usage stays permanently inflated even though the memory was freed;
+//   - the wrong device is decremented for memory it never held -> its
+//     tracked usage underflows (these are unsigned counters), wrapping to a
+//     huge bogus value.
+//
+// Mechanism verified here: links src/multiprocess/multiprocess_memory_limit.c
+// directly into this test binary (the same pattern test_postinit_owner_death.c
+// already uses -- see test/CMakeLists.txt) so the test can call
+// get_gpu_memory_usage() itself to read the same tracked per-device usage
+// counters that account_async_chunk()/remove_chunk_async() mutate via
+// add_gpu_device_memory_usage()/rm_gpu_device_memory_usage(). That state
+// lives in a plain mmap'd file (see MULTIPROCESS_SHARED_REGION_CACHE_ENV),
+// so this directly-linked copy and libvgpu.so's own separately-linked copy
+// of the same source file (loaded via LD_PRELOAD) observe the SAME
+// underlying counters, despite being two separate static instances of the
+// same C code, as long as they agree on the cache file path -- which is why
+// CUDA_DEVICE_MEMORY_SHARED_CACHE is pinned below to a path unique to this
+// process, making the test hermetic against any file another test run left
+// at the default /tmp/cudevshr.cache.
+//
+// Needs >= 2 CUDA devices. If fewer are visible, the test SKIPs (CTest
+// SKIP_RETURN_CODE, see test/CMakeLists.txt) with a clear message rather
+// than failing, so it doesn't break single-GPU CI/dev runs.
+//
+// Reproduces the exact interleaving from the bug report:
+//   1. With device 0's context current, allocate on device 0's default pool
+//      via the real hooked cuMemAllocAsync (tracked in device_allocasync,
+//      entry->dev == 0).
+//   2. Switch the current context to device 1.
+//   3. Free that pointer via the real hooked cuMemFreeAsync, passing
+//      device 0's stream -- current context is device 1, the allocation's
+//      tracked device is device 0: exactly the mismatch
+//      remove_chunk_async() mishandled.
+//   4. Assert device 0's tracked usage dropped back to its pre-allocation
+//      baseline (pre-fix: it doesn't) and device 1's tracked usage is
+//      unchanged (pre-fix: it underflows to a huge value).
+//   5. Allocate again, this time on device 1 with device 1 current (the
+//      non-buggy pattern), and confirm device 1's usage now reflects a
+//      normal, uncorrupted increment from its baseline -- pre-fix, device 1
+//      never recovers from the earlier bogus underflow, so this also fails.
+//
+// To confirm this test actually exercises the fix: temporarily revert the
+// remove_chunk_async() change in src/allocator/allocator.c, rebuild, and
+// re-run -- it must fail.
+//
+// Run standalone (from a build directory with the vgpu target already
+// built):
+//   ctest -R alloc_async_free_wrong_device --output-on-failure
+
+#include <cuda.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "multiprocess/multiprocess_memory_limit.h"
+
+#define ALLOC_BYTES (32ull * 1024 * 1024) /* 32 MiB */
+
+/* Matches the CTest SKIP_RETURN_CODE configured in test/CMakeLists.txt for
+ * this test -- fewer than 2 GPUs is an environment limitation, not a test
+ * failure. */
+#define SKIP_EXIT_CODE 125
+
+/* Abort-on-error for setup calls that must succeed for the test to be valid. */
+#define CHECK_DRV(call)                                                        \
+    do {                                                                       \
+        CUresult _e = (call);                                                  \
+        if (_e != CUDA_SUCCESS) {                                              \
+            const char *_n = NULL;                                             \
+            cuGetErrorName(_e, &_n);                                           \
+            fprintf(stderr, "FATAL %s:%d: %s -> %d (%s)\n", __FILE__,          \
+                    __LINE__, #call, (int)_e, _n ? _n : "?");                  \
+            return 2;                                                          \
+        }                                                                      \
+    } while (0)
+
+static void describe(const char *label, CUresult res) {
+    const char *name = NULL;
+    CUresult q = cuGetErrorName(res, &name);
+    if (q != CUDA_SUCCESS || name == NULL)
+        printf("  %-40s -> %d  <unrecognized error code>\n", label, (int)res);
+    else
+        printf("  %-40s -> %d  (%s)\n", label, (int)res, name);
+}
+
+int main(void) {
+    /* Isolate this run's shared accounting state from anything another test
+     * run may have left at the default cache path, so the usage counters
+     * read below start from a known baseline. */
+    char cache_path[256];
+    snprintf(cache_path, sizeof(cache_path),
+             "/tmp/cudevshr_test_wrongdevice_%d.cache", (int)getpid());
+    setenv(MULTIPROCESS_SHARED_REGION_CACHE_ENV, cache_path, 1);
+
+    CHECK_DRV(cuInit(0));
+
+    int dev_count = 0;
+    CHECK_DRV(cuDeviceGetCount(&dev_count));
+    if (dev_count < 2) {
+        printf("SKIP: test_alloc_async_free_wrong_device needs >= 2 CUDA "
+               "devices to reproduce a cross-device free (found %d)\n",
+               dev_count);
+        return SKIP_EXIT_CODE;
+    }
+
+    CUdevice dev0, dev1;
+    CHECK_DRV(cuDeviceGet(&dev0, 0));
+    CHECK_DRV(cuDeviceGet(&dev1, 1));
+
+    CUcontext ctx0, ctx1;
+#if CUDA_VERSION >= 13000
+    CHECK_DRV(cuCtxCreate(&ctx0, NULL, 0, dev0));
+    CHECK_DRV(cuCtxCreate(&ctx1, NULL, 0, dev1));
+#else
+    CHECK_DRV(cuCtxCreate(&ctx0, 0, dev0));
+    CHECK_DRV(cuCtxCreate(&ctx1, 0, dev1));
+#endif
+
+    /* cuCtxCreate() makes the new context current; make device 0's current
+     * again before creating its stream. */
+    CHECK_DRV(cuCtxSetCurrent(ctx0));
+    CUstream stream0;
+    CHECK_DRV(cuStreamCreate(&stream0, CU_STREAM_NON_BLOCKING));
+
+    int failures = 0;
+
+    /* Baseline reads before any allocation. */
+    size_t usage0_before = get_gpu_memory_usage((int)dev0);
+    size_t usage1_before = get_gpu_memory_usage((int)dev1);
+
+    /* [1] Allocate on device 0 (device 0's context current) via the real
+     * hooked cuMemAllocAsync entry point. */
+    printf("[1] cuMemAllocAsync on device 0 (device 0 current)\n");
+    CUdeviceptr d = 0;
+    CHECK_DRV(cuMemAllocAsync(&d, ALLOC_BYTES, stream0));
+    CHECK_DRV(cuStreamSynchronize(stream0));
+
+    size_t usage0_after_alloc = get_gpu_memory_usage((int)dev0);
+    size_t alloc_delta = usage0_after_alloc - usage0_before;
+    printf("  device0 usage before=%zu after_alloc=%zu (delta=%zu)\n",
+           usage0_before, usage0_after_alloc, alloc_delta);
+    /* This is the very first async allocation in the process, so the
+     * default pool's reservation high-water mark cannot yet be below
+     * ALLOC_BYTES; account_async_chunk() must have tracked exactly
+     * ALLOC_BYTES. If it didn't, the accounting path this test exercises
+     * isn't behaving as expected in this environment -- fail loudly rather
+     * than silently passing on a vacuous (zero-delta) case. */
+    if (alloc_delta != ALLOC_BYTES) {
+        fprintf(stderr,
+                "FAIL: expected device0 usage to rise by exactly %llu after "
+                "the first allocation, got a delta of %zu -- the accounting "
+                "path is not behaving as this test assumes\n",
+                ALLOC_BYTES, alloc_delta);
+        failures++;
+    }
+
+    /* [2] Switch current context to device 1. */
+    printf("[2] cuCtxSetCurrent(device 1)\n");
+    CHECK_DRV(cuCtxSetCurrent(ctx1));
+
+    /* [3] Free the device-0 allocation via its own (device-0) stream, with
+     * device 1 current -- the exact mismatch remove_chunk_async() mishandled. */
+    printf("[3] cuMemFreeAsync(device-0 pointer, device-0 stream) with device 1 current\n");
+    CUresult fres = cuMemFreeAsync(d, stream0);
+    describe("cuMemFreeAsync", fres);
+    if (fres != CUDA_SUCCESS) {
+        fprintf(stderr, "FAIL: cross-device free was rejected by the driver "
+                        "(expected to succeed per the CUDA API contract)\n");
+        failures++;
+    }
+
+    /* Switch back to device 0's context to synchronize its stream. */
+    CHECK_DRV(cuCtxSetCurrent(ctx0));
+    CHECK_DRV(cuStreamSynchronize(stream0));
+
+    size_t usage0_after_free = get_gpu_memory_usage((int)dev0);
+    size_t usage1_after_free = get_gpu_memory_usage((int)dev1);
+    printf("  device0 usage after_free=%zu (expected %zu)\n",
+           usage0_after_free, usage0_before);
+    printf("  device1 usage after_free=%zu (expected %zu, unchanged)\n",
+           usage1_after_free, usage1_before);
+
+    /* [4] The real allocation's device (0) must be decremented back to
+     * baseline; the uninvolved device (1) must be untouched. */
+    if (usage0_after_free != usage0_before) {
+        fprintf(stderr,
+                "FAIL: device0 usage did not return to baseline after free "
+                "(%zu != %zu) -- the real allocation's device was not "
+                "decremented (issue #310)\n",
+                usage0_after_free, usage0_before);
+        failures++;
+    }
+    if (usage1_after_free != usage1_before) {
+        fprintf(stderr,
+                "FAIL: device1 usage changed from baseline after freeing a "
+                "device-0 allocation (%zu != %zu) -- the wrong device was "
+                "decremented (issue #310)\n",
+                usage1_after_free, usage1_before);
+        failures++;
+    }
+
+    /* [5] Allocate again, this time correctly on device 1 with device 1
+     * current, and confirm its usage now reflects a normal, uncorrupted
+     * increment -- proving device 1's counter recovered rather than staying
+     * permanently corrupted by the earlier wrong-device decrement. */
+    printf("[5] cuMemAllocAsync on device 1 (device 1 current)\n");
+    CUstream stream1;
+    CHECK_DRV(cuStreamCreate(&stream1, CU_STREAM_NON_BLOCKING));
+    CUdeviceptr d1 = 0;
+    CHECK_DRV(cuMemAllocAsync(&d1, ALLOC_BYTES, stream1));
+    CHECK_DRV(cuStreamSynchronize(stream1));
+
+    size_t usage1_after_second_alloc = get_gpu_memory_usage((int)dev1);
+    size_t second_alloc_delta = usage1_after_second_alloc - usage1_before;
+    printf("  device1 usage before=%zu after_second_alloc=%zu (delta=%zu, expected %llu)\n",
+           usage1_before, usage1_after_second_alloc, second_alloc_delta, ALLOC_BYTES);
+    if (second_alloc_delta != ALLOC_BYTES) {
+        fprintf(stderr,
+                "FAIL: device1 usage did not rise by exactly %llu from its "
+                "pre-test baseline after a clean allocation -- device1's "
+                "counter is still corrupted from the earlier wrong-device "
+                "decrement (issue #310)\n",
+                ALLOC_BYTES);
+        failures++;
+    }
+
+    /* Best-effort teardown. */
+    cuMemFreeAsync(d1, stream1);
+    cuStreamSynchronize(stream1);
+    cuStreamDestroy(stream1);
+    cuStreamDestroy(stream0);
+    cuCtxDestroy(ctx1);
+    cuCtxDestroy(ctx0);
+
+    printf("\nResult: %s\n",
+           failures ? "FAIL - device accounting corrupted by cross-device free (issue #310)"
+                    : "PASS - cross-device free accounted against the correct device");
+    return failures ? 1 : 0;
+}

--- a/test/test_alloc_async_free_wrong_device.c
+++ b/test/test_alloc_async_free_wrong_device.c
@@ -139,12 +139,9 @@ int main(void) {
 
     int failures = 0;
 
-    /* Baseline reads before any allocation. */
     size_t usage0_before = get_gpu_memory_usage((int)dev0);
     size_t usage1_before = get_gpu_memory_usage((int)dev1);
 
-    /* [1] Allocate on device 0 (device 0's context current) via the real
-     * hooked cuMemAllocAsync entry point. */
     printf("[1] cuMemAllocAsync on device 0 (device 0 current)\n");
     CUdeviceptr d = 0;
     CHECK_DRV(cuMemAllocAsync(&d, ALLOC_BYTES, stream0));
@@ -169,12 +166,9 @@ int main(void) {
         failures++;
     }
 
-    /* [2] Switch current context to device 1. */
     printf("[2] cuCtxSetCurrent(device 1)\n");
     CHECK_DRV(cuCtxSetCurrent(ctx1));
 
-    /* [3] Free the device-0 allocation via its own (device-0) stream, with
-     * device 1 current -- the exact mismatch remove_chunk_async() mishandled. */
     printf("[3] cuMemFreeAsync(device-0 pointer, device-0 stream) with device 1 current\n");
     CUresult fres = cuMemFreeAsync(d, stream0);
     describe("cuMemFreeAsync", fres);
@@ -195,8 +189,6 @@ int main(void) {
     printf("  device1 usage after_free=%zu (expected %zu, unchanged)\n",
            usage1_after_free, usage1_before);
 
-    /* [4] The real allocation's device (0) must be decremented back to
-     * baseline; the uninvolved device (1) must be untouched. */
     if (usage0_after_free != usage0_before) {
         fprintf(stderr,
                 "FAIL: device0 usage did not return to baseline after free "
@@ -214,10 +206,6 @@ int main(void) {
         failures++;
     }
 
-    /* [5] Allocate again, this time correctly on device 1 with device 1
-     * current, and confirm its usage now reflects a normal, uncorrupted
-     * increment -- proving device 1's counter recovered rather than staying
-     * permanently corrupted by the earlier wrong-device decrement. */
     printf("[5] cuMemAllocAsync on device 1 (device 1 current)\n");
     CUstream stream1;
     CHECK_DRV(cuStreamCreate(&stream1, CU_STREAM_NON_BLOCKING));


### PR DESCRIPTION
## Fixes
Closes #310

## Background
In `src/allocator/allocator.c`, `remove_chunk_async()` (used by the `cuMemFreeAsync` hook via `free_raw_async()`) determines which device's usage counter to decrement by calling `cuCtxGetDevice(&dev)` — the device of the calling thread's *currently-bound context* — instead of using `val->entry->dev`, the device the chunk was actually allocated on and accounted against.

`cuMemFreeAsync(dptr, hStream)` takes an explicit stream, not an implicit "current device," and CUDA does not require the calling thread's current context to match the device the stream or memory belongs to. In any multi-GPU process (worker threads round-robining `cuCtxSetCurrent`, pipelines that allocate on one device and free from a code path where another device happens to be current), this mismatch is fully reachable — nothing in HAMi-core's hook chain pins or validates the device before the call reaches `remove_chunk_async`.

`rm_gpu_device_memory_usage()` decrements `used[dev]` in the per-process, per-device shared-memory usage table that `get_gpu_memory_usage()`/`oom_check()` read to enforce the vGPU memory limit — the core mechanism this library exists to provide. A device mismatch here corrupts accounting for two devices at once: the real allocation device is never decremented (usage stays permanently inflated, eventually causing spurious OOM rejections), while the wrong device is decremented for memory it never held (usage under-counts real consumption, letting a process exceed its actual limit undetected).

The sibling synchronous function, `remove_chunk()`, already does this correctly via `t_dev = val->entry->dev`. `remove_chunk_async` diverged from that pattern.

Full details and impact analysis are in #310.

## Changes
- `src/allocator/allocator.c`: capture `t_dev = val->entry->dev` before `LIST_REMOVE` frees the entry, and pass that to `rm_gpu_device_memory_usage` instead of `cuCtxGetDevice()`. Removed the now-dead `CUdevice dev; cuCtxGetDevice(&dev);` lines. 3-line net diff.
- `test/test_alloc_async_free_wrong_device.c`: new regression test. Allocates on device 0, switches current context to device 1, frees via device 0's stream through the real hooked `cuMemFreeAsync` — the exact mismatch — then reads `get_gpu_memory_usage()` (linking `multiprocess_memory_limit.c` directly into the test binary, same pattern as `test_postinit_owner_death`) to assert device 0's usage returns to baseline, device 1's stays untouched, and a subsequent clean allocation on device 1 isn't affected by any lingering corruption. Skips gracefully via CTest's `SKIP_RETURN_CODE` on environments with fewer than 2 GPUs.
- `test/CMakeLists.txt`: registered the new test target, reusing the plain `LD_PRELOAD=libvgpu.so` setup — no fault-injection shim needed since this test exercises a genuine two-device code path rather than forcing a driver call to fail.

## Verification
- `cpplint --linelength=120 src/allocator/allocator.c`: no new warnings (diffed precisely against the pre-fix file; same 5 pre-existing warnings, unrelated, shifted by line number only — the new/changed lines are clean).
- `python3 hack/check_cuda_hook_consistency.py`: PASS.
- Traced the test's expected accounting deltas by hand against `add_gpu_device_memory_usage`/`rm_gpu_device_memory_usage` to confirm the assertions are deterministic and not dependent on driver-specific quirks.
- Could not compile or run anything in this sandbox — no CUDA toolchain, no GPU, and no `cuda.h` available (`gcc -fsyntax-only` fails immediately on the missing header). This PR has **not** been built or executed against a real CUDA driver or real multi-GPU hardware. Requesting CI/maintainer verification before merge, same as #307.

## AI disclosure
This issue, fix, and PR description were produced with substantial AI assistance (Claude): the bug was found via AI-driven source review of `allocator.c`, the fix and the new regression test were written by an AI coding agent, and this PR body was drafted by AI. All of it has been reviewed and is being submitted by me as the human author of record — I take responsibility for its correctness. Per the Verification section above, this fix is unvalidated against real CUDA hardware due to the sandboxed environment's lack of a CUDA toolchain/GPU; I'd appreciate maintainer/CI scrutiny on the multi-GPU test behavior in particular before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected asynchronous memory cleanup so usage tracking is updated for the device where memory was allocated, even when freed from another device context.
  - Prevented inaccurate device memory accounting when allocations are released from a different active device.

- **Tests**
  - Added regression coverage for freeing allocations across different device contexts.
  - Added safeguards for environments with fewer than two available CUDA devices, where the test is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->