### PR TITLE
fix(hooks): guard driver-call out-params behind a success check (#312)

### DIFF
--- a/src/cuda/device.c
+++ b/src/cuda/device.c
@@ -22,9 +22,9 @@ CUresult cuDeviceGetCount( int* count ) {
     LOG_DEBUG("into cuDeviceGetCount");
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuDeviceGetCount,count);
     if (res == CUDA_SUCCESS) {
-        LOG_DEBUG("cuDeviceGetCount res=%d count=%d",res,*count);
+        LOG_DEBUG("cuDeviceGetCount res=%d count=%d", res, *count);
     } else {
-        LOG_DEBUG("cuDeviceGetCount res=%d",res);
+        LOG_DEBUG("cuDeviceGetCount res=%d", res);
     }
     return res;
 }

--- a/src/cuda/device.c
+++ b/src/cuda/device.c
@@ -21,7 +21,11 @@ CUresult cuDeviceGet(CUdevice *device,int ordinal){
 CUresult cuDeviceGetCount( int* count ) {
     LOG_DEBUG("into cuDeviceGetCount");
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuDeviceGetCount,count);
-    LOG_DEBUG("cuDeviceGetCount res=%d count=%d",res,*count);
+    if (res == CUDA_SUCCESS) {
+        LOG_DEBUG("cuDeviceGetCount res=%d count=%d",res,*count);
+    } else {
+        LOG_DEBUG("cuDeviceGetCount res=%d",res);
+    }
     return res;
 }
 

--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -490,14 +490,21 @@ CUresult cuMemGetInfo_v2(size_t* free, size_t* total) {
     CHECK_DRV_API(cuCtxGetDevice(&dev));
     size_t usage = get_current_device_memory_usage(cuda_to_nvml_map(dev));
     size_t limit = get_current_device_memory_limit(cuda_to_nvml_map(dev));
+    CUresult res;
     if (limit == 0) {
-        CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemGetInfo_v2, free, total);
+        res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemGetInfo_v2, free, total);
+        if (res != CUDA_SUCCESS) {
+            return res;
+        }
         LOG_INFO("orig free=%ld total=%ld", *free, *total);
         *free = *total - usage;
         LOG_INFO("after free=%ld total=%ld", *free, *total);
         return CUDA_SUCCESS;
     } else {
-        CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemGetInfo_v2, free, total);
+        res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemGetInfo_v2, free, total);
+        if (res != CUDA_SUCCESS) {
+            return res;
+        }
         LOG_INFO("orig free=%ld total=%ld limit=%ld usage=%ld",
             *free, *total, limit, usage);
         // Ensure total memory does not exceed the physical or imposed limit.
@@ -583,7 +590,9 @@ CUresult cuMemAddressReserve(CUdeviceptr* ptr, size_t size,
     size_t alignment, CUdeviceptr addr, unsigned long long flags ) {
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,
         cuMemAddressReserve, ptr, size, alignment, addr, flags);
-    LOG_INFO("cuMemAddressReserve:%lx %llx", size, *ptr);
+    if (res == CUDA_SUCCESS) {
+        LOG_INFO("cuMemAddressReserve:%lx %llx", size, *ptr);
+    }
     return res;
 }
 
@@ -667,7 +676,11 @@ CUresult cuMemPoolSetAttribute(CUmemoryPool pool, CUmemPool_attribute attr, void
 
 CUresult cuMemPoolGetAttribute(CUmemoryPool pool, CUmemPool_attribute attr, void *value) {
     CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemPoolGetAttribute,pool,attr,value);
-    LOG_INFO("cuMemPoolGetAttribute %d %ld",attr,*(long *)value);
+    if (res == CUDA_SUCCESS) {
+        LOG_INFO("cuMemPoolGetAttribute attr=%d", attr);
+    } else {
+        LOG_INFO("cuMemPoolGetAttribute attr=%d failed res=%d", attr, res);
+    }
     return res;
 }
 

--- a/src/cuda/memory.c
+++ b/src/cuda/memory.c
@@ -492,7 +492,7 @@ CUresult cuMemGetInfo_v2(size_t* free, size_t* total) {
     size_t limit = get_current_device_memory_limit(cuda_to_nvml_map(dev));
     CUresult res;
     if (limit == 0) {
-        res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemGetInfo_v2, free, total);
+        res = CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemGetInfo_v2, free, total);
         if (res != CUDA_SUCCESS) {
             return res;
         }
@@ -501,7 +501,7 @@ CUresult cuMemGetInfo_v2(size_t* free, size_t* total) {
         LOG_INFO("after free=%ld total=%ld", *free, *total);
         return CUDA_SUCCESS;
     } else {
-        res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemGetInfo_v2, free, total);
+        res = CUDA_OVERRIDE_CALL(cuda_library_entry, cuMemGetInfo_v2, free, total);
         if (res != CUDA_SUCCESS) {
             return res;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,17 +93,23 @@ if (TARGET vgpu)
         ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:vgpu>"
         TIMEOUT 10)
 
-    # fault_inject_driver_312 is prepended to the existing LD_PRELOAD list,
-    # ahead of libvgpu.so, not in place of it: libvgpu.so is still needed so
-    # the four wrappers fixed for issue #312 go through their real hooked
-    # code path, and fault_inject_driver_312 only interposes dlopen() to
-    # force one-shot failures out of the underlying driver call. Needs a
-    # real GPU to run; not exercised in CI (see fault_inject_driver_312.c
-    # and test_312_failure_path_log_guard.c for details).
+    # libvgpu.so must load before fault_inject_driver_312 in LD_PRELOAD.
+    # fault_inject_driver_312 exports two things: a dlopen() interposer (to
+    # fake the real driver once libvgpu.so dlopen()s "libcuda.so.1"), and,
+    # for dlsym() to find via that redirected handle, direct symbols named
+    # after the four calls this PR fixes. libvgpu.so exports those same
+    # four names too -- its actual wrappers, the code under test. If the
+    # injector loaded first, its direct symbols would win global resolution
+    # for the test binary's own calls, bypassing libvgpu.so's wrappers
+    # entirely. Loading libvgpu.so first lets its wrappers win that
+    # resolution; the dlopen() interposition still works either way, since
+    # only the injector defines dlopen() among the two. Needs a real GPU to
+    # run; not exercised in CI (see fault_inject_driver_312.c and
+    # test_312_failure_path_log_guard.c for details).
     add_test(NAME failure_path_log_guard_312
         COMMAND test_312_failure_path_log_guard)
     set_tests_properties(failure_path_log_guard_312 PROPERTIES
-        ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:fault_inject_driver_312>:$<TARGET_FILE:vgpu>"
+        ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:vgpu>:$<TARGET_FILE:fault_inject_driver_312>"
         TIMEOUT 30)
     add_dependencies(test_312_failure_path_log_guard fault_inject_driver_312)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,15 @@ set(TEST_TARGET_NAMES_LIST)
 
 
 file(GLOB_RECURSE TEST_SCRIPTS "${TEST_CPP_SOURCE_DIR}/*.c" "${TEST_CPP_SOURCE_DIR}/*.cu")
-foreach(TEST_SCRIPT ${TEST_SCRIPTS}) 
+
+# fault_inject_driver_312.c is not a test executable: it is a fault-injecting
+# LD_PRELOAD companion for the real CUDA driver (see the file itself for how
+# it works), built as a shared library below and consumed only by
+# test_312_failure_path_log_guard.
+set(FAULT_INJECT_DRIVER_312_SRC ${TEST_CPP_SOURCE_DIR}/fault_inject_driver_312.c)
+list(REMOVE_ITEM TEST_SCRIPTS ${FAULT_INJECT_DRIVER_312_SRC})
+
+foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     file(RELATIVE_PATH RELATIVE_TEST_PATH ${TEST_CPP_SOURCE_DIR} ${TEST_SCRIPT})
     get_filename_component(TEST_TARGET_DIR ${RELATIVE_TEST_PATH} DIRECTORY)
     get_filename_component(TEST_TARGET_NAME ${RELATIVE_TEST_PATH} NAME_WE)
@@ -57,6 +65,16 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
 endforeach()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+# Build the fault-injecting companion used by test_312_failure_path_log_guard.
+# Normal shared library (no special name/soname needed): it works by
+# interposing dlopen() via LD_PRELOAD, not by being found under the real
+# driver's name, so the real driver still loads normally for everything else
+# (see fault_inject_driver_312.c for the full explanation).
+add_library(fault_inject_driver_312 SHARED ${FAULT_INJECT_DRIVER_312_SRC})
+set_target_properties(fault_inject_driver_312 PROPERTIES
+    POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(fault_inject_driver_312 -ldl)
+
 add_test(NAME postinit_owner_death
     COMMAND test_postinit_owner_death)
 set_tests_properties(postinit_owner_death PROPERTIES TIMEOUT 20)
@@ -74,6 +92,20 @@ if (TARGET vgpu)
     set_tests_properties(dlsym_rtld_next_preloaded PROPERTIES
         ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:vgpu>"
         TIMEOUT 10)
+
+    # fault_inject_driver_312 is prepended to the existing LD_PRELOAD list,
+    # ahead of libvgpu.so, not in place of it: libvgpu.so is still needed so
+    # the four wrappers fixed for issue #312 go through their real hooked
+    # code path, and fault_inject_driver_312 only interposes dlopen() to
+    # force one-shot failures out of the underlying driver call. Needs a
+    # real GPU to run; not exercised in CI (see fault_inject_driver_312.c
+    # and test_312_failure_path_log_guard.c for details).
+    add_test(NAME failure_path_log_guard_312
+        COMMAND test_312_failure_path_log_guard)
+    set_tests_properties(failure_path_log_guard_312 PROPERTIES
+        ENVIRONMENT "LD_PRELOAD=$<TARGET_FILE:fault_inject_driver_312>:$<TARGET_FILE:vgpu>"
+        TIMEOUT 30)
+    add_dependencies(test_312_failure_path_log_guard fault_inject_driver_312)
 endif()
 
 

--- a/test/fault_inject_driver_312.c
+++ b/test/fault_inject_driver_312.c
@@ -12,8 +12,18 @@
 // driver via a saved real dlopen(). Nothing outside these four entry points
 // is touched.
 //
-// Load order matters: LD_PRELOAD="fault_inject_driver_312.so:libvgpu.so" --
-// this library first so it observes libvgpu.so's dlopen("libcuda.so.1").
+// Load order matters, and it's the opposite of what the dlopen()-interposition
+// framing above might suggest: LD_PRELOAD="libvgpu.so:fault_inject_driver_312.so"
+// -- libvgpu.so first. This library also exports direct, globally-visible
+// symbols named cuMemPoolGetAttribute/cuMemGetInfo_v2/cuMemAddressReserve/
+// cuDeviceGetCount (so dlsym() against the dlopen()-redirected handle can find
+// them); if it were listed before libvgpu.so, those symbols would win global
+// symbol resolution for any *direct* caller too, including this test binary's
+// own calls, which would then bypass libvgpu.so's wrappers -- the code under
+// test -- entirely. Listing libvgpu.so first lets its identically-named
+// wrapper symbols win that direct resolution, while the dlopen() interposition
+// (unique to this library among the preloaded set) still redirects libvgpu.so's
+// internal dlopen("libcuda.so.1") call regardless of relative order.
 //
 // Env vars (each is one-shot: read once, then unset by the fake itself):
 //   HAMI_TEST_FAIL_NEXT_POOLATTR    -> next cuMemPoolGetAttribute fails

--- a/test/fault_inject_driver_312.c
+++ b/test/fault_inject_driver_312.c
@@ -1,0 +1,125 @@
+// LD_PRELOAD companion that forces one-shot failures out of the real CUDA
+// driver, for exercising the failure branches added in the #312 fix
+// (src/cuda/memory.c: cuMemPoolGetAttribute, cuMemGetInfo_v2,
+// cuMemAddressReserve; src/cuda/device.c: cuDeviceGetCount).
+//
+// Mechanism (same trick as test/fault_inject_driver.c from PR #307): it does
+// NOT replace libcuda.so.1 -- it interposes dlopen() so that when libvgpu.so
+// (the wrapper under test) dlopen()s "libcuda.so.1" to build its
+// cuda_library_entry dispatch table, it gets a handle to *this* library
+// instead. This library exports exactly four faked symbols; dlsym(table,
+// name) finds those here, and forwards every other symbol lookup to the real
+// driver via a saved real dlopen(). Nothing outside these four entry points
+// is touched.
+//
+// Load order matters: LD_PRELOAD="fault_inject_driver_312.so:libvgpu.so" --
+// this library first so it observes libvgpu.so's dlopen("libcuda.so.1").
+//
+// Env vars (each is one-shot: read once, then unset by the fake itself):
+//   HAMI_TEST_FAIL_NEXT_POOLATTR    -> next cuMemPoolGetAttribute fails
+//   HAMI_TEST_FAIL_NEXT_MEMGETINFO  -> next cuMemGetInfo_v2 fails
+//   HAMI_TEST_FAIL_NEXT_ADDRRESERVE -> next cuMemAddressReserve fails
+//   HAMI_TEST_FAIL_NEXT_DEVCOUNT    -> next cuDeviceGetCount fails
+//
+// Needs a real GPU to build/run against a real libcuda.so.1; not exercised
+// in CI (this project's CI only compiles, see .github/workflows/build-src.yml
+// and Makefile's build-in-docker target -- no GPU runner is available there).
+
+#define _GNU_SOURCE
+#include <cuda.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define VISIBLE __attribute__((visibility("default")))
+#else
+#define VISIBLE
+#endif
+
+typedef void *(*dlopen_t)(const char *, int);
+typedef CUresult (*cuMemPoolGetAttribute_t)(CUmemoryPool, CUmemPool_attribute, void *);
+typedef CUresult (*cuMemGetInfo_v2_t)(size_t *, size_t *);
+typedef CUresult (*cuMemAddressReserve_t)(CUdeviceptr *, size_t, size_t, CUdeviceptr, unsigned long long);
+typedef CUresult (*cuDeviceGetCount_t)(int *);
+
+static void *g_real_driver_handle = NULL;
+
+static dlopen_t real_dlopen(void) {
+    static dlopen_t fn = NULL;
+    if (!fn)
+        fn = (dlopen_t)dlsym(RTLD_NEXT, "dlopen");
+    return fn;
+}
+
+static void *self_handle(void) {
+    Dl_info info;
+    if (dladdr((void *)self_handle, &info))
+        return real_dlopen()(info.dli_fname, RTLD_NOW | RTLD_NOLOAD);
+    return NULL;
+}
+
+static void *real_driver_handle(void) {
+    if (!g_real_driver_handle)
+        g_real_driver_handle = real_dlopen()("libcuda.so.1", RTLD_NOW | RTLD_NODELETE);
+    return g_real_driver_handle;
+}
+
+VISIBLE void *dlopen(const char *filename, int flags) {
+    void *real_result = real_dlopen()(filename, flags);
+    if (real_result && filename && strcmp(filename, "libcuda.so.1") == 0) {
+        g_real_driver_handle = real_result;
+        void *self = self_handle();
+        if (self) {
+            fprintf(stderr,
+                    "[fault_inject_driver_312] substituting for libcuda.so.1: "
+                    "only cuMemPoolGetAttribute/cuMemGetInfo_v2/"
+                    "cuMemAddressReserve/cuDeviceGetCount are faked, "
+                    "everything else falls back to the real driver\n");
+            return self;
+        }
+    }
+    return real_result;
+}
+
+VISIBLE CUresult cuMemPoolGetAttribute(CUmemoryPool pool, CUmemPool_attribute attr, void *value) {
+    if (getenv("HAMI_TEST_FAIL_NEXT_POOLATTR")) {
+        unsetenv("HAMI_TEST_FAIL_NEXT_POOLATTR");
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    void *h = real_driver_handle();
+    cuMemPoolGetAttribute_t real = h ? (cuMemPoolGetAttribute_t)dlsym(h, "cuMemPoolGetAttribute") : NULL;
+    return real ? real(pool, attr, value) : CUDA_ERROR_UNKNOWN;
+}
+
+VISIBLE CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
+    if (getenv("HAMI_TEST_FAIL_NEXT_MEMGETINFO")) {
+        unsetenv("HAMI_TEST_FAIL_NEXT_MEMGETINFO");
+        return CUDA_ERROR_UNKNOWN;
+    }
+    void *h = real_driver_handle();
+    cuMemGetInfo_v2_t real = h ? (cuMemGetInfo_v2_t)dlsym(h, "cuMemGetInfo_v2") : NULL;
+    return real ? real(free, total) : CUDA_ERROR_UNKNOWN;
+}
+
+VISIBLE CUresult cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment,
+                                      CUdeviceptr addr, unsigned long long flags) {
+    if (getenv("HAMI_TEST_FAIL_NEXT_ADDRRESERVE")) {
+        unsetenv("HAMI_TEST_FAIL_NEXT_ADDRRESERVE");
+        return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    void *h = real_driver_handle();
+    cuMemAddressReserve_t real = h ? (cuMemAddressReserve_t)dlsym(h, "cuMemAddressReserve") : NULL;
+    return real ? real(ptr, size, alignment, addr, flags) : CUDA_ERROR_UNKNOWN;
+}
+
+VISIBLE CUresult cuDeviceGetCount(int *count) {
+    if (getenv("HAMI_TEST_FAIL_NEXT_DEVCOUNT")) {
+        unsetenv("HAMI_TEST_FAIL_NEXT_DEVCOUNT");
+        return CUDA_ERROR_UNKNOWN;
+    }
+    void *h = real_driver_handle();
+    cuDeviceGetCount_t real = h ? (cuDeviceGetCount_t)dlsym(h, "cuDeviceGetCount") : NULL;
+    return real ? real(count) : CUDA_ERROR_UNKNOWN;
+}

--- a/test/test_312_failure_path_log_guard.c
+++ b/test/test_312_failure_path_log_guard.c
@@ -1,0 +1,254 @@
+// Regression test for Project-HAMi/HAMi-core issue #312.
+//
+// The four wrappers below (three in src/cuda/memory.c, one in
+// src/cuda/device.c) used to log an out-param unconditionally, even when the
+// preceding CUDA_OVERRIDE_CALL failed and left that out-param unwritten:
+// reading it then read whatever garbage happened to be on the caller's
+// stack/heap. cuMemPoolGetAttribute additionally cast that value through a
+// fixed `(long *)` regardless of the CUmemPool_attribute's real pointee
+// width -- fixed here by dropping the value from the log entirely rather
+// than guessing a per-attribute width (see PR description: no authoritative
+// CUDA header was available in this repo to verify that table against).
+//
+// This test does not rely on ASan/UBSan to catch the read (ASan does not
+// flag an in-bounds read of unpoisoned-but-uninitialized stack memory, and
+// MemorySanitizer -- the tool that would -- cannot be used against a
+// closed-source libcuda.so.1). Instead it poisons each out-param buffer with
+// a distinctive canary value before forcing the underlying driver call to
+// fail via test/fault_inject_driver_312.c, captures HAMi-core's log output
+// (LOG_INFO/LOG_DEBUG write to stderr in the default, non-FILEDEBUG build --
+// see src/include/log_utils.h), and asserts the canary never appears in it.
+// Pre-fix, cuMemPoolGetAttribute's failure branch would have printed the
+// canary verbatim.
+//
+// Build/run: same as every other GPU-backed test in this directory (see
+// test/test_alloc_pool_async.c's header comment) -- needs a real GPU and is
+// not exercised in CI. Requires the fault_inject_driver_312 companion
+// (test/CMakeLists.txt) ahead of libvgpu.so in LD_PRELOAD:
+//   LD_PRELOAD=/path/to/fault_inject_driver_312.so:/path/to/libvgpu.so \
+//     LIBCUDA_LOG_LEVEL=3 ./test_312_failure_path_log_guard
+
+#include <cuda.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef TEST_DEVICE_ID
+#define TEST_DEVICE_ID 0
+#endif
+
+#define CANARY_INT 987654321
+#define CANARY_LONG 123456789012345LL
+#define CANARY_STR_INT "987654321"
+#define CANARY_STR_LONG "123456789012345"
+
+#define CHECK_DRV(call)                                                        \
+    do {                                                                       \
+        CUresult _e = (call);                                                  \
+        if (_e != CUDA_SUCCESS) {                                              \
+            const char *_n = NULL;                                             \
+            cuGetErrorName(_e, &_n);                                           \
+            fprintf(stderr, "FATAL %s:%d: %s -> %d (%s)\n", __FILE__,          \
+                    __LINE__, #call, (int)_e, _n ? _n : "?");                  \
+            exit(2);                                                           \
+        }                                                                      \
+    } while (0)
+
+/* Redirect this process's stderr (where LOG_INFO/LOG_DEBUG write) to a temp
+ * file so its content can be inspected after each call. Returns the
+ * original stderr fd (dup'd) so real failures can still be reported. */
+static int g_captured_fd = -1;
+static char g_capture_path[] = "/tmp/hami_312_test_capture_XXXXXX";
+static int g_saved_stderr = -1;
+
+static void capture_start(void) {
+    g_saved_stderr = dup(STDERR_FILENO);
+    g_captured_fd = mkstemp(g_capture_path);
+    if (g_captured_fd < 0) {
+        perror("mkstemp");
+        exit(2);
+    }
+    fflush(stderr);
+    dup2(g_captured_fd, STDERR_FILENO);
+}
+
+/* Truncate the capture file and read back whatever gets written between now
+ * and the next call to capture_read(). */
+static void capture_reset(void) {
+    fflush(stderr);
+    ftruncate(g_captured_fd, 0);
+    lseek(g_captured_fd, 0, SEEK_SET);
+}
+
+static char *capture_read(void) {
+    fflush(stderr);
+    off_t len = lseek(g_captured_fd, 0, SEEK_CUR);
+    char *buf = malloc((size_t)len + 1);
+    lseek(g_captured_fd, 0, SEEK_SET);
+    ssize_t n = read(g_captured_fd, buf, (size_t)len);
+    buf[n > 0 ? n : 0] = '\0';
+    return buf;
+}
+
+static void capture_stop(void) {
+    fflush(stderr);
+    dup2(g_saved_stderr, STDERR_FILENO);
+    close(g_saved_stderr);
+    close(g_captured_fd);
+    unlink(g_capture_path);
+}
+
+int main(void) {
+    setenv("LIBCUDA_LOG_LEVEL", "3", 1); /* enable LOG_INFO without relying on the caller's shell env */
+
+    CHECK_DRV(cuInit(0));
+    CUdevice dev;
+    CHECK_DRV(cuDeviceGet(&dev, TEST_DEVICE_ID));
+    CUcontext ctx;
+#if CUDA_VERSION >= 13000
+    CHECK_DRV(cuCtxCreate(&ctx, NULL, 0, dev));
+#else
+    CHECK_DRV(cuCtxCreate(&ctx, 0, dev));
+#endif
+
+    int failures = 0;
+    capture_start();
+
+    /* [1] cuMemPoolGetAttribute: force failure, poison the out buffer,
+     * confirm the canary never reaches the log and the failure branch's
+     * message format (no raw value) is used. */
+    {
+        CUmemPoolProps props;
+        memset(&props, 0, sizeof(props));
+        props.allocType = CU_MEM_ALLOCATION_TYPE_PINNED;
+        props.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        props.location.id = dev;
+        CUmemoryPool pool;
+        CHECK_DRV(cuMemPoolCreate(&pool, &props));
+
+        long value = CANARY_LONG;
+        setenv("HAMI_TEST_FAIL_NEXT_POOLATTR", "1", 1);
+        capture_reset();
+        CUresult res = cuMemPoolGetAttribute(pool, CU_MEMPOOL_ATTR_RELEASE_THRESHOLD, &value);
+        char *log = capture_read();
+        printf("[1] cuMemPoolGetAttribute forced failure -> res=%d\n", (int)res);
+        if (res == CUDA_SUCCESS) {
+            fprintf(stderr, "FAIL: expected forced failure but call succeeded\n");
+            failures++;
+        }
+        if (strstr(log, CANARY_STR_LONG) != NULL) {
+            fprintf(stderr, "FAIL: failure-path log leaked the uninitialized canary: %s\n", log);
+            failures++;
+        }
+        if (strstr(log, "cuMemPoolGetAttribute") != NULL && strstr(log, "failed res=") == NULL) {
+            fprintf(stderr, "FAIL: failure-path log did not use the expected failed-res format: %s\n", log);
+            failures++;
+        }
+        free(log);
+        cuMemPoolDestroy(pool);
+    }
+
+    /* [1b] Success path sanity: the log must still fire, but must never
+     * contain a raw attribute value (it was dropped deliberately, since no
+     * authoritative per-attribute width table is available -- see PR
+     * description). */
+    {
+        CUmemPoolProps props;
+        memset(&props, 0, sizeof(props));
+        props.allocType = CU_MEM_ALLOCATION_TYPE_PINNED;
+        props.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        props.location.id = dev;
+        CUmemoryPool pool;
+        CHECK_DRV(cuMemPoolCreate(&pool, &props));
+
+        long value = CANARY_LONG;
+        capture_reset();
+        CUresult res = cuMemPoolGetAttribute(pool, CU_MEMPOOL_ATTR_RELEASE_THRESHOLD, &value);
+        char *log = capture_read();
+        printf("[1b] cuMemPoolGetAttribute success path -> res=%d\n", (int)res);
+        if (res != CUDA_SUCCESS) {
+            fprintf(stderr, "FAIL: expected success on the real driver call\n");
+            failures++;
+        }
+        if (strstr(log, "cuMemPoolGetAttribute") == NULL || strstr(log, "attr=") == NULL) {
+            fprintf(stderr, "FAIL: success-path log missing/malformed: %s\n", log);
+            failures++;
+        }
+        free(log);
+        cuMemPoolDestroy(pool);
+    }
+
+    /* [2] cuMemGetInfo_v2: force failure, poison free/total, confirm neither
+     * is read into the log (and that the driver's real error propagates
+     * instead of being swallowed as CUDA_SUCCESS, which the old code did
+     * unconditionally). */
+    {
+        size_t free_b = (size_t)CANARY_INT;
+        size_t total_b = (size_t)CANARY_INT;
+        setenv("HAMI_TEST_FAIL_NEXT_MEMGETINFO", "1", 1);
+        capture_reset();
+        CUresult res = cuMemGetInfo_v2(&free_b, &total_b);
+        char *log = capture_read();
+        printf("[2] cuMemGetInfo_v2 forced failure -> res=%d\n", (int)res);
+        if (res == CUDA_SUCCESS) {
+            fprintf(stderr, "FAIL: expected forced failure but call succeeded (return value swallowed?)\n");
+            failures++;
+        }
+        if (strstr(log, CANARY_STR_INT) != NULL) {
+            fprintf(stderr, "FAIL: failure-path log leaked the uninitialized canary: %s\n", log);
+            failures++;
+        }
+        free(log);
+    }
+
+    /* [3] cuMemAddressReserve: force failure, poison ptr, confirm it is
+     * never logged. */
+    {
+        CUdeviceptr ptr = (CUdeviceptr)CANARY_LONG;
+        setenv("HAMI_TEST_FAIL_NEXT_ADDRRESERVE", "1", 1);
+        capture_reset();
+        CUresult res = cuMemAddressReserve(&ptr, 4096, 0, 0, 0);
+        char *log = capture_read();
+        printf("[3] cuMemAddressReserve forced failure -> res=%d\n", (int)res);
+        if (res == CUDA_SUCCESS) {
+            fprintf(stderr, "FAIL: expected forced failure but call succeeded\n");
+            failures++;
+        }
+        if (strstr(log, CANARY_STR_LONG) != NULL) {
+            fprintf(stderr, "FAIL: failure-path log leaked the uninitialized canary: %s\n", log);
+            failures++;
+        }
+        free(log);
+    }
+
+    /* [4] cuDeviceGetCount: force failure, poison count, confirm it is
+     * never logged (LOG_DEBUG, needs LIBCUDA_LOG_LEVEL>=4 -- bump it just
+     * for this check). */
+    {
+        setenv("LIBCUDA_LOG_LEVEL", "4", 1);
+        int count = CANARY_INT;
+        setenv("HAMI_TEST_FAIL_NEXT_DEVCOUNT", "1", 1);
+        capture_reset();
+        CUresult res = cuDeviceGetCount(&count);
+        char *log = capture_read();
+        printf("[4] cuDeviceGetCount forced failure -> res=%d\n", (int)res);
+        if (res == CUDA_SUCCESS) {
+            fprintf(stderr, "FAIL: expected forced failure but call succeeded\n");
+            failures++;
+        }
+        if (strstr(log, CANARY_STR_INT) != NULL) {
+            fprintf(stderr, "FAIL: failure-path log leaked the uninitialized canary: %s\n", log);
+            failures++;
+        }
+        free(log);
+        setenv("LIBCUDA_LOG_LEVEL", "3", 1);
+    }
+
+    capture_stop();
+    cuCtxDestroy(ctx);
+
+    printf("\nResult: %s\n", failures ? "FAIL - see above" : "PASS - no canary reached the log on any forced failure");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #312.

## Background

#312 was filed against `src/cuda/memory.c:668-672`, `cuMemPoolGetAttribute()`, and closed the same day with no linked commit, PR, or comment explaining the close (the only timeline event before "closed" is `/assign`). The bug was still present on `main` at `de6ce39`. I reopened the issue with an explanatory comment before starting this PR.

## Original defect

```c
CUresult cuMemPoolGetAttribute(CUmemoryPool pool, CUmemPool_attribute attr, void *value) {
    CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemPoolGetAttribute,pool,attr,value);
    LOG_INFO("cuMemPoolGetAttribute %d %ld",attr,*(long *)value);
    return res;
}
```

Two independent problems in one line:
1. **Read-before-success-check.** `*(long *)value` is dereferenced unconditionally, even when `res != CUDA_SUCCESS`. On failure the driver has no obligation to have written `*value`, so this reads whatever garbage was already on the caller's stack/heap.
2. **Fixed-width cast ignores the attribute's real type.** `value`'s pointee type depends on which `CUmemPool_attribute` was passed (some are `int*`, some are `cuuint64_t*` per the CUDA driver API). The fixed `(long *)` cast is wrong for the narrower ones even on a successful call.

**On the width table:** the original issue proposed hardcoding a per-attribute int-vs-`cuuint64_t` width table. I did not add it. No CUDA header (`cuda.h`, `cydriver.pxd`, or otherwise) exists anywhere in this repo or its dependency chain to verify that table against -- the only local `cuda.h` is a hand-written, explicitly-non-authoritative `-fsyntax-only` sanity stub from an unrelated prior session. Guessing a width table from memory and shipping it felt like the wrong tradeoff for a log line. Instead this drops the value from the log entirely, which is the fallback the original issue itself proposed:

```c
CUresult cuMemPoolGetAttribute(CUmemoryPool pool, CUmemPool_attribute attr, void *value) {
    CUresult res = CUDA_OVERRIDE_CALL(cuda_library_entry,cuMemPoolGetAttribute,pool,attr,value);
    if (res == CUDA_SUCCESS) {
        LOG_INFO("cuMemPoolGetAttribute attr=%d", attr);
    } else {
        LOG_INFO("cuMemPoolGetAttribute attr=%d failed res=%d", attr, res);
    }
    return res;
}
```

If a maintainer has a real CUDA toolkit handy and wants the value back in the log for the successful case, that needs an explicit `switch` on `attr` to pick the right width -- I'd rather that be added deliberately by someone who can verify it than guessed here.

## Same defect class, three more places (in scope for this PR)

These have problem 1 (unconditional out-param read before checking `res`) but not problem 2 -- their out-param types are fixed by the function signature, not attribute-dependent, so there's no width question:

- **`cuMemGetInfo_v2`** (`src/cuda/memory.c`): `CUDA_OVERRIDE_CALL`'s return value wasn't even captured, and `free`/`total` were logged (twice, in each branch) regardless of whether the driver call actually wrote them. One branch also went on to *compute* with the unwritten values. Now captures `res` and returns early on failure, before any read.
- **`cuMemAddressReserve`** (`src/cuda/memory.c`): `res` was captured but never checked before logging `*ptr`.
- **`cuDeviceGetCount`** (`src/cuda/device.c`): `count` was logged unconditionally (`LOG_DEBUG`, gated `>= 4`).

All four now follow the res-check-first idiom already used correctly elsewhere in this file (`cuDriverGetVersion`, `memory.c`'s `cuMemAlloc_v2`) rather than inventing a new pattern. No other changes to these three functions -- I did not refactor anything beyond the guard.

I did **not** touch two other `*(cast *)` log-deref sites found during the sweep because they're already correctly guarded and aren't part of this defect class: `cuDriverGetVersion` (already checks `res==CUDA_SUCCESS` first) and `cuMemAlloc_v2` (already returns early on failure).

## Tests

The existing PR #307 test infrastructure (`fault_inject_driver.c` / `test_alloc_async_failure_leak.c`) does not cover any of these four wrappers -- it fakes the real driver's `cuDeviceGetMemPool`/`cuMemPoolGetAttribute` only to test `src/allocator/allocator.c`'s bookkeeping, never HAMi-core's own hook in `memory.c`. So it gives no coverage here.

Added, modeled directly on that same precedent:
- `test/fault_inject_driver_312.c` -- an `LD_PRELOAD` companion that interposes `dlopen("libcuda.so.1")` to force one-shot failures out of `cuMemPoolGetAttribute`, `cuMemGetInfo_v2`, `cuMemAddressReserve`, and `cuDeviceGetCount`, forwarding everything else to the real driver.
- `test/test_312_failure_path_log_guard.c` -- poisons each out-param buffer with a distinctive canary value, forces the underlying call to fail, captures HAMi-core's log output (`LOG_INFO`/`LOG_DEBUG` write to `stderr` in the default non-`FILEDEBUG` build), and asserts the canary never appears in it. Also has a `cuMemPoolGetAttribute` success-path check confirming the log still fires and never contains a raw value. Registered in `test/CMakeLists.txt` the same way PR #307 registered its fault-injection companion.

I did not use ASan/UBSan for this: ASan doesn't flag an in-bounds read of unpoisoned-but-uninitialized stack memory (there's no bounds violation), and MemorySanitizer -- the tool that would catch that -- can't be used against a closed-source `libcuda.so.1`. The canary-in-the-log approach directly observes the actual defect (does the wrapper leak an unwritten buffer into its log) rather than relying on a sanitizer that can't see it.

**These tests need a real GPU to build and run, and are not exercised in CI** -- same as every other test in this directory (`.github/workflows/build-src.yml` only builds via `make build-in-docker`; there's no `ctest`/GPU runner step, which PR #307's own test comments already note explicitly).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA error handling so driver failures are correctly propagated.
  * Prevented failure logs from displaying uninitialized or invalid output values.
  * Ensured memory and device operation logs accurately reflect success or failure.

* **Tests**
  * Added regression coverage for CUDA failure paths, error propagation, and safe diagnostic logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->