### PR TITLE
fix: preserve caller for RTLD_NEXT dlsym

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 2.8.12)
 
 project(libvgpu)
 
+enable_language(ASM)
 enable_testing()
 
 # Set CUDA_HOME if not defined

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(cuda)
 add_subdirectory(nvml)
 
 set(LIBVGPU vgpu)
-add_library(${LIBVGPU} SHARED libvgpu.c utils.c log_utils.c $<TARGET_OBJECTS:nvml_mod> $<TARGET_OBJECTS:cuda_mod> $<TARGET_OBJECTS:allocator_mod> $<TARGET_OBJECTS:multiprocess_mod>)
+add_library(${LIBVGPU} SHARED libvgpu.c dlsym_entry.S utils.c log_utils.c $<TARGET_OBJECTS:nvml_mod> $<TARGET_OBJECTS:cuda_mod> $<TARGET_OBJECTS:allocator_mod> $<TARGET_OBJECTS:multiprocess_mod>)
 target_compile_options(${LIBVGPU} PUBLIC ${LIBRARY_COMPILE_FLAGS})
 target_link_libraries(${LIBVGPU} PUBLIC -lcuda -lnvidia-ml)
 

--- a/src/dlsym_entry.S
+++ b/src/dlsym_entry.S
@@ -1,0 +1,77 @@
+#if defined(__x86_64__)
+
+    .text
+    .globl dlsym
+    .type dlsym, @function
+dlsym:
+    .cfi_startproc
+    endbr64
+    cmpq $-1, %rdi
+    jne .Ldispatch_x86_64
+
+    /* Keep the original return address on the stack while resolving libc dlsym. */
+    pushq %rdi
+    .cfi_adjust_cfa_offset 8
+    pushq %rsi
+    .cfi_adjust_cfa_offset 8
+    subq $8, %rsp
+    .cfi_adjust_cfa_offset 8
+    call libvgpu_get_real_dlsym
+    addq $8, %rsp
+    .cfi_adjust_cfa_offset -8
+    popq %rsi
+    .cfi_adjust_cfa_offset -8
+    popq %rdi
+    .cfi_adjust_cfa_offset -8
+
+    testq %rax, %rax
+    je .Lreturn_null_x86_64
+    jmp *%rax
+
+.Lreturn_null_x86_64:
+    xorl %eax, %eax
+    ret
+
+.Ldispatch_x86_64:
+    jmp libvgpu_dlsym_dispatch
+    .cfi_endproc
+    .size dlsym, .-dlsym
+
+#elif defined(__aarch64__)
+
+    .text
+    .globl dlsym
+    .type dlsym, %function
+dlsym:
+    .cfi_startproc
+    .inst 0xd503245f  /* BTI c */
+    cmn x0, #1
+    b.ne .Ldispatch_aarch64
+
+    /* Preserve the original arguments and link register across initialization. */
+    stp x0, x1, [sp, #-32]!
+    .cfi_adjust_cfa_offset 32
+    str x30, [sp, #16]
+    .cfi_offset x30, -16
+    bl libvgpu_get_real_dlsym
+    mov x16, x0
+    ldr x30, [sp, #16]
+    .cfi_restore x30
+    ldp x0, x1, [sp], #32
+    .cfi_adjust_cfa_offset -32
+
+    cbz x16, .Lreturn_null_aarch64
+    br x16
+
+.Lreturn_null_aarch64:
+    mov x0, xzr
+    ret
+
+.Ldispatch_aarch64:
+    b libvgpu_dlsym_dispatch
+    .cfi_endproc
+    .size dlsym, .-dlsym
+
+#endif
+
+    .section .note.GNU-stack,"",%progbits

--- a/src/libvgpu.c
+++ b/src/libvgpu.c
@@ -39,8 +39,7 @@ extern size_t context_size;
 /* This is the symbol search function */
 fp_dlsym real_dlsym = NULL;
 
-FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
-    LOG_DEBUG("into dlsym %s",symbol);
+static void initialize_dlsym(void) {
     if (real_dlsym == NULL) {
         const char* glibc_versions[] = {
                 "GLIBC_2.2.5",  // for amd64
@@ -59,24 +58,47 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
                 break;
             }
         }
-        char *path_search=getenv("CUDA_REDIRECT");
-        if ((path_search!=NULL) && (strlen(path_search)>0)){
-            vgpulib = dlopen(path_search,RTLD_LAZY);
-        }else{
-            vgpulib = dlopen("/usr/local/vgpu/libvgpu.so",RTLD_LAZY);
-        }
         if (real_dlsym == NULL) {
             LOG_ERROR("real dlsym not found");
             void *libc_handle = dlopen("libc.so.6", RTLD_LAZY);
             if (libc_handle) {
-                real_dlsym = dlsym(libc_handle, "dlsym");
+                for (int i = 0; glibc_versions[i] != NULL; i++) {
+                    real_dlsym = dlvsym(libc_handle, "dlsym",
+                                        glibc_versions[i]);
+                    if (real_dlsym != NULL) {
+                        break;
+                    }
+                }
             }
             if (real_dlsym == NULL)
                 LOG_ERROR("real dlsym not found after trying libc.so.6");
         }
     }
-    if (handle == RTLD_NEXT) {
-        return real_dlsym(RTLD_NEXT, symbol);
+
+    if (vgpulib == NULL) {
+        char *path_search = getenv("CUDA_REDIRECT");
+        if (path_search != NULL && strlen(path_search) > 0) {
+            vgpulib = dlopen(path_search, RTLD_LAZY);
+        } else {
+            vgpulib = dlopen("/usr/local/vgpu/libvgpu.so", RTLD_LAZY);
+        }
+    }
+}
+
+/* Called by dlsym_entry.S before its caller-preserving RTLD_NEXT tail jump. */
+__attribute__((visibility("hidden")))
+fp_dlsym libvgpu_get_real_dlsym(void) {
+    initialize_dlsym();
+    return real_dlsym;
+}
+
+/* RTLD_NEXT is handled in dlsym_entry.S on supported architectures. */
+__attribute__((visibility("hidden")))
+void* libvgpu_dlsym_dispatch(void* handle, const char* symbol) {
+    LOG_DEBUG("into dlsym %s", symbol);
+    initialize_dlsym();
+    if (real_dlsym == NULL) {
+        return NULL;
     }
     if (symbol[0] == 'c' && symbol[1] == 'u') {
         //Compatible with cuda 12.8+ fix
@@ -97,6 +119,17 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
 #endif
     return real_dlsym(handle, symbol);
 }
+
+#if !defined(__x86_64__) && !defined(__aarch64__)
+/* Preserve the existing fallback on architectures without an assembly entry. */
+FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
+    if (handle == RTLD_NEXT) {
+        fp_dlsym next_dlsym = libvgpu_get_real_dlsym();
+        return next_dlsym == NULL ? NULL : next_dlsym(handle, symbol);
+    }
+    return libvgpu_dlsym_dispatch(handle, symbol);
+}
+#endif
 
 void* __dlsym_hook_section(void* handle, const char* symbol) {
     int it;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,11 @@ set(TEST_TARGET_NAMES_LIST)
 
 
 file(GLOB_RECURSE TEST_SCRIPTS "${TEST_CPP_SOURCE_DIR}/*.c" "${TEST_CPP_SOURCE_DIR}/*.cu")
+set(DLSYM_CALLER_SOURCE
+    "${TEST_CPP_SOURCE_DIR}/dlsym_rtld_next_caller.c")
+list(REMOVE_ITEM TEST_SCRIPTS ${DLSYM_CALLER_SOURCE})
+add_library(dlsym_rtld_next_caller SHARED ${DLSYM_CALLER_SOURCE})
+target_link_libraries(dlsym_rtld_next_caller -ldl)
 foreach(TEST_SCRIPT ${TEST_SCRIPTS}) 
     file(RELATIVE_PATH RELATIVE_TEST_PATH ${TEST_CPP_SOURCE_DIR} ${TEST_SCRIPT})
     get_filename_component(TEST_TARGET_DIR ${RELATIVE_TEST_PATH} DIRECTORY)
@@ -64,7 +69,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
             OR TEST_TARGET_NAME STREQUAL "test_pid_discovery")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
-        target_link_libraries(${TEST_TARGET_NAME} -ldl)
+        target_link_libraries(${TEST_TARGET_NAME}
+            -ldl dlsym_rtld_next_caller)
     elseif (TEST_TARGET_NAME STREQUAL "test_nvml_v2_signatures")
         target_link_libraries(${TEST_TARGET_NAME} -lpthread)
     else()

--- a/test/dlsym_rtld_next_caller.c
+++ b/test/dlsym_rtld_next_caller.c
@@ -1,0 +1,22 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <stddef.h>
+
+/* Matches the weak forwarding symbol exported by LLVM OpenMP. */
+__attribute__((weak, visibility("default"), noinline, used))
+void* ompt_start_tool(unsigned int omp_version, const char* runtime_version) {
+    (void)omp_version;
+    (void)runtime_version;
+    return NULL;
+}
+
+void* lookup_default_ompt(void) {
+    void* volatile result = dlsym(RTLD_DEFAULT, "ompt_start_tool");
+    return result;
+}
+
+void* lookup_next_ompt(void) {
+    void* volatile result = dlsym(RTLD_NEXT, "ompt_start_tool");
+    return result;
+}

--- a/test/test_dlsym_rtld_next.c
+++ b/test/test_dlsym_rtld_next.c
@@ -4,6 +4,9 @@
 #include <dlfcn.h>
 #include <stdio.h>
 
+void* lookup_default_ompt(void);
+void* lookup_next_ompt(void);
+
 /*
  * Repeated RTLD_NEXT lookups must return the same address. The old
  * (thread, pointer) history map treated the second call as recursion
@@ -26,6 +29,18 @@ int main(void) {
                 first, second);
         return 1;
     }
+
+    void *self = lookup_default_ompt();
+    void *next = lookup_next_ompt();
+    if (self == NULL) {
+        fprintf(stderr, "failed to resolve exported ompt_start_tool\n");
+        return 1;
+    }
+    if (next == self) {
+        fprintf(stderr, "RTLD_NEXT resolved ompt_start_tool back to its caller\n");
+        return 1;
+    }
+
     printf("PASS %p\n", first);
     return 0;
 }


### PR DESCRIPTION
## What

- Preserve the original caller for RTLD_NEXT lookups by tail-jumping to the real dlsym on x86_64 and ARM64.
- Keep the existing CUDA/NVML hook dispatch unchanged.
- Add an OMPT regression test matching LLVM OpenMP's weak ompt_start_tool forwarding.

## Why

PR #279 fixed repeated RTLD_NEXT lookups, but forwarding RTLD_NEXT through a normal C call changes the caller to libvgpu. LLVM OpenMP can then resolve ompt_start_tool back to itself and loop during import torch.

Fixes Project-HAMi/HAMi#2903

## Testing

- 6/6 CTests passed on x86_64 with CUDA 13.
- The original libvgpu fails the new OMPT regression; the fixed library passes.
- Conda PyTorch 2.1.2 import passed with the fixed library.
- vLLM 0.25.0 started and completed an actual OPT-125M inference request.
- UBI8/CUDA 13.3 release build passed.
- ARM64 assembly compile check passed; runtime validation was performed on x86_64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dynamic symbol lookup on supported 64-bit architectures.
  * Added fallback handling for resolving standard library symbols.
  * CUDA library loading now supports configurable redirect paths.

* **Bug Fixes**
  * Improved `RTLD_NEXT` symbol resolution and handling of missing symbols.

* **Tests**
  * Added coverage verifying default and next-scope symbol lookups resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->