### PR TITLE
feat: add a node wide host pid fallback lock

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(cuda)
 add_subdirectory(nvml)
 
 set(LIBVGPU vgpu)
-add_library(${LIBVGPU} SHARED libvgpu.c utils.c log_utils.c $<TARGET_OBJECTS:nvml_mod> $<TARGET_OBJECTS:cuda_mod> $<TARGET_OBJECTS:allocator_mod> $<TARGET_OBJECTS:multiprocess_mod>)
+add_library(${LIBVGPU} SHARED libvgpu.c utils.c log_utils.c hostpid_fallback_lock.c $<TARGET_OBJECTS:nvml_mod> $<TARGET_OBJECTS:cuda_mod> $<TARGET_OBJECTS:allocator_mod> $<TARGET_OBJECTS:multiprocess_mod>)
 target_compile_options(${LIBVGPU} PUBLIC ${LIBRARY_COMPILE_FLAGS})
 target_link_libraries(${LIBVGPU} PUBLIC -lcuda -lnvidia-ml)
 

--- a/src/hostpid_fallback_lock.c
+++ b/src/hostpid_fallback_lock.c
@@ -249,6 +249,18 @@ static int open_directory_without_symlinks(const char *path,
 }
 
 #ifdef __linux__
+/*
+ * ZFS is out of tree, so <linux/magic.h> never defines its magic and the
+ * check below would be compiled away.  OVERLAYFS_SUPER_MAGIC only arrived in
+ * 4.6, so an older build host drops overlay support the same way.
+ */
+#ifndef OVERLAYFS_SUPER_MAGIC
+#define OVERLAYFS_SUPER_MAGIC 0x794c7630
+#endif
+#ifndef ZFS_SUPER_MAGIC
+#define ZFS_SUPER_MAGIC 0x2fc12fc1
+#endif
+
 static int filesystem_type_supported(uint64_t filesystem_type) {
 #ifdef EXT4_SUPER_MAGIC
     if (filesystem_type == (uint64_t)EXT4_SUPER_MAGIC) {

--- a/src/hostpid_fallback_lock.c
+++ b/src/hostpid_fallback_lock.c
@@ -528,6 +528,10 @@ static int acquire_at_until(const char *path, uid_t trusted_owner,
     return 0;
 }
 
+#ifdef HOSTPID_FALLBACK_LOCK_TESTING
+/* Tests point the lock at a fixture directory.  Nothing else does, and the
+ * fixtures live under /tmp, whose ancestors are not owned by the test user,
+ * so the ancestor checks stay off here. */
 int hostpid_fallback_lock_acquire_at(const char *path, uid_t trusted_owner,
                                      unsigned int timeout_ms) {
     struct timespec deadline;
@@ -542,6 +546,7 @@ int hostpid_fallback_lock_acquire_at_until(
     const char *path, uid_t trusted_owner, const struct timespec *deadline) {
     return acquire_at_until(path, trusted_owner, deadline, 0, 0);
 }
+#endif
 
 int hostpid_fallback_lock_acquire_until(const struct timespec *deadline) {
     return acquire_at_until(HOSTPID_FALLBACK_LOCK_PATH, 0, deadline, 1, 1);

--- a/src/hostpid_fallback_lock.c
+++ b/src/hostpid_fallback_lock.c
@@ -117,6 +117,271 @@ static int sleep_before_retry(unsigned int delay_us,
     return 0;
 }
 
+static int validate_directory_metadata(const struct stat *directory_stat,
+                                       uid_t trusted_owner) {
+    mode_t writable = S_IWGRP | S_IWOTH;
+
+    if (!S_ISDIR(directory_stat->st_mode) ||
+        directory_stat->st_uid != trusted_owner) {
+        errno = EACCES;
+        return -1;
+    }
+    if ((directory_stat->st_mode & writable) != 0 &&
+        (directory_stat->st_mode & S_ISVTX) == 0) {
+        errno = EACCES;
+        return -1;
+    }
+    return 0;
+}
+
+static int validate_supported_filesystem(int fd);
+
+#ifdef __linux__
+static int validate_path_component(int fd,
+                                   const struct stat *component_stat,
+                                   uid_t trusted_owner) {
+    if (validate_directory_metadata(component_stat, trusted_owner) != 0) {
+        return -1;
+    }
+    return validate_supported_filesystem(fd);
+}
+#endif
+
+static int open_directory_without_symlinks(const char *path,
+                                           uid_t trusted_owner,
+                                           int validate_components) {
+#ifdef __linux__
+    const char *cursor;
+    int directory_fd;
+
+    if (path == NULL || path[0] != '/') {
+        errno = EINVAL;
+        return -1;
+    }
+    directory_fd = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (directory_fd < 0) {
+        return -1;
+    }
+    if (validate_components) {
+        struct stat root_stat;
+
+        if (fstat(directory_fd, &root_stat) != 0 ||
+            validate_path_component(directory_fd, &root_stat,
+                                    trusted_owner) != 0) {
+            int saved_errno = errno;
+
+            close(directory_fd);
+            errno = saved_errno;
+            return -1;
+        }
+    }
+    cursor = path;
+    while (*cursor == '/') {
+        cursor++;
+    }
+    while (*cursor != '\0') {
+        char component[NAME_MAX + 1U];
+        const char *end = cursor;
+        size_t length;
+        int next_fd;
+
+        while (*end != '\0' && *end != '/') {
+            end++;
+        }
+        length = (size_t)(end - cursor);
+        if (length == 0U || length > NAME_MAX) {
+            close(directory_fd);
+            errno = ENAMETOOLONG;
+            return -1;
+        }
+        memcpy(component, cursor, length);
+        component[length] = '\0';
+        if (strcmp(component, ".") == 0 || strcmp(component, "..") == 0) {
+            close(directory_fd);
+            errno = EINVAL;
+            return -1;
+        }
+        next_fd = openat(directory_fd, component,
+                         O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+        if (next_fd < 0) {
+            int saved_errno = errno;
+
+            close(directory_fd);
+            errno = saved_errno;
+            return -1;
+        }
+        if (validate_components) {
+            struct stat component_stat;
+
+            if (fstat(next_fd, &component_stat) != 0 ||
+                validate_path_component(next_fd, &component_stat,
+                                        trusted_owner) != 0) {
+                int saved_errno = errno;
+
+                close(next_fd);
+                close(directory_fd);
+                errno = saved_errno;
+                return -1;
+            }
+        }
+        close(directory_fd);
+        directory_fd = next_fd;
+        cursor = end;
+        while (*cursor == '/') {
+            cursor++;
+        }
+    }
+    return directory_fd;
+#else
+    (void)trusted_owner;
+    (void)validate_components;
+    return open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+#endif
+}
+
+#ifdef __linux__
+static int filesystem_type_supported(uint64_t filesystem_type) {
+#ifdef EXT4_SUPER_MAGIC
+    if (filesystem_type == (uint64_t)EXT4_SUPER_MAGIC) {
+        return 1;
+    }
+#endif
+#ifdef XFS_SUPER_MAGIC
+    if (filesystem_type == (uint64_t)XFS_SUPER_MAGIC) {
+        return 1;
+    }
+#endif
+#ifdef TMPFS_MAGIC
+    if (filesystem_type == (uint64_t)TMPFS_MAGIC) {
+        return 1;
+    }
+#endif
+#ifdef BTRFS_SUPER_MAGIC
+    if (filesystem_type == (uint64_t)BTRFS_SUPER_MAGIC) {
+        return 1;
+    }
+#endif
+#ifdef F2FS_SUPER_MAGIC
+    if (filesystem_type == (uint64_t)F2FS_SUPER_MAGIC) {
+        return 1;
+    }
+#endif
+#ifdef OVERLAYFS_SUPER_MAGIC
+    if (filesystem_type == (uint64_t)OVERLAYFS_SUPER_MAGIC) {
+        return 1;
+    }
+#endif
+#ifdef RAMFS_MAGIC
+    if (filesystem_type == (uint64_t)RAMFS_MAGIC) {
+        return 1;
+    }
+#endif
+#ifdef ZFS_SUPER_MAGIC
+    if (filesystem_type == (uint64_t)ZFS_SUPER_MAGIC) {
+        return 1;
+    }
+#endif
+    return 0;
+}
+#endif
+
+static int validate_supported_filesystem(int fd) {
+#ifdef __linux__
+    struct statfs filesystem_stat;
+
+    if (fstatfs(fd, &filesystem_stat) != 0) {
+        return -1;
+    }
+    if (filesystem_type_supported((uint64_t)filesystem_stat.f_type)) {
+        return 0;
+    }
+    errno = EOPNOTSUPP;
+    return -1;
+#else
+    (void)fd;
+    return 0;
+#endif
+}
+
+static int validate_readonly_filesystem(int fd) {
+    struct statvfs filesystem_stat;
+
+    if (fstatvfs(fd, &filesystem_stat) != 0) {
+        return -1;
+    }
+    if ((filesystem_stat.f_flag & ST_RDONLY) == 0) {
+        errno = EACCES;
+        return -1;
+    }
+    return validate_supported_filesystem(fd);
+}
+
+static int validate_lock_object(int fd, const char *path,
+                                uid_t trusted_owner,
+                                const struct stat *opened_stat,
+                                int require_readonly) {
+    struct stat current_stat;
+    struct stat descriptor_stat;
+    int current_fd;
+
+    if (validate_directory_metadata(opened_stat, trusted_owner) != 0) {
+        return -1;
+    }
+    if (fstat(fd, &descriptor_stat) != 0) {
+        return -1;
+    }
+    if (descriptor_stat.st_dev != opened_stat->st_dev ||
+        descriptor_stat.st_ino != opened_stat->st_ino) {
+        errno = ESTALE;
+        return -1;
+    }
+    if (validate_directory_metadata(&descriptor_stat, trusted_owner) != 0) {
+        return -1;
+    }
+    if (fcntl(fd, F_GETFD) < 0) {
+        return -1;
+    }
+    current_fd = open_directory_without_symlinks(path, trusted_owner,
+                                                  require_readonly);
+    if (current_fd < 0) {
+        return -1;
+    }
+    if (fstat(current_fd, &current_stat) != 0) {
+        int saved_errno = errno;
+
+        close(current_fd);
+        errno = saved_errno;
+        return -1;
+    }
+    if (current_stat.st_dev != opened_stat->st_dev ||
+        current_stat.st_ino != opened_stat->st_ino) {
+        close(current_fd);
+        errno = ESTALE;
+        return -1;
+    }
+    if (validate_directory_metadata(&current_stat, trusted_owner) != 0) {
+        int saved_errno = errno;
+
+        close(current_fd);
+        errno = saved_errno;
+        return -1;
+    }
+    if (require_readonly) {
+        if (validate_readonly_filesystem(fd) != 0 ||
+            validate_readonly_filesystem(current_fd) != 0) {
+            int saved_errno = errno;
+
+            close(current_fd);
+            errno = saved_errno;
+            return -1;
+        }
+    }
+    if (close(current_fd) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
 static void discard_active_fd(int fd) {
     int expected = fd;
 
@@ -129,12 +394,12 @@ static void discard_active_fd(int fd) {
 static int acquire_at_until(const char *path, uid_t trusted_owner,
                             const struct timespec *deadline,
                             int require_readonly) {
+    struct stat opened_stat;
     unsigned int retry_us = HOSTPID_FALLBACK_LOCK_INITIAL_RETRY_US;
     int expected = -1;
+    int descriptor_flags;
     int fd;
 
-    (void)trusted_owner;
-    (void)require_readonly;
     if (path == NULL || path[0] != '/' || deadline == NULL) {
         errno = EINVAL;
         return -1;
@@ -142,8 +407,34 @@ static int acquire_at_until(const char *path, uid_t trusted_owner,
     if (deadline_expired(deadline) != 0) {
         return -1;
     }
-    fd = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    fd = open_directory_without_symlinks(path, trusted_owner,
+                                         require_readonly);
     if (fd < 0) {
+        return -1;
+    }
+    descriptor_flags = fcntl(fd, F_GETFD);
+    if (descriptor_flags < 0 ||
+        fcntl(fd, F_SETFD, descriptor_flags | FD_CLOEXEC) != 0) {
+        int saved_errno = errno;
+
+        close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+    if (fstat(fd, &opened_stat) != 0) {
+        int saved_errno = errno;
+
+        close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+    if (validate_lock_object(fd, path, trusted_owner, &opened_stat,
+                             require_readonly) != 0 ||
+        deadline_expired(deadline) != 0) {
+        int saved_errno = errno;
+
+        close(fd);
+        errno = saved_errno;
         return -1;
     }
     if (!atomic_compare_exchange_strong_explicit(

--- a/src/hostpid_fallback_lock.c
+++ b/src/hostpid_fallback_lock.c
@@ -340,6 +340,7 @@ static int validate_readonly_filesystem(int fd) {
 static int validate_lock_object(int fd, const char *path,
                                 uid_t trusted_owner,
                                 const struct stat *opened_stat,
+                                int validate_components,
                                 int require_readonly) {
     struct stat current_stat;
     struct stat descriptor_stat;
@@ -363,7 +364,7 @@ static int validate_lock_object(int fd, const char *path,
         return -1;
     }
     current_fd = open_directory_without_symlinks(path, trusted_owner,
-                                                  require_readonly);
+                                                  validate_components);
     if (current_fd < 0) {
         return -1;
     }
@@ -414,6 +415,7 @@ static void discard_active_fd(int fd) {
 
 static int acquire_at_until(const char *path, uid_t trusted_owner,
                             const struct timespec *deadline,
+                            int validate_components,
                             int require_readonly) {
     struct stat opened_stat;
     unsigned int retry_us = HOSTPID_FALLBACK_LOCK_INITIAL_RETRY_US;
@@ -429,7 +431,7 @@ static int acquire_at_until(const char *path, uid_t trusted_owner,
         return -1;
     }
     fd = open_directory_without_symlinks(path, trusted_owner,
-                                         require_readonly);
+                                         validate_components);
     if (fd < 0) {
         return -1;
     }
@@ -450,7 +452,7 @@ static int acquire_at_until(const char *path, uid_t trusted_owner,
         return -1;
     }
     if (validate_lock_object(fd, path, trusted_owner, &opened_stat,
-                             require_readonly) != 0 ||
+                             validate_components, require_readonly) != 0 ||
         deadline_expired(deadline) != 0) {
         int saved_errno = errno;
 
@@ -514,7 +516,7 @@ static int acquire_at_until(const char *path, uid_t trusted_owner,
     }
 
     if (validate_lock_object(fd, path, trusted_owner, &opened_stat,
-                             require_readonly) != 0 ||
+                             validate_components, require_readonly) != 0 ||
         deadline_expired(deadline) != 0) {
         int saved_errno = errno;
 
@@ -533,16 +535,16 @@ int hostpid_fallback_lock_acquire_at(const char *path, uid_t trusted_owner,
     if (hostpid_fallback_lock_deadline_after_ms(&deadline, timeout_ms) != 0) {
         return -1;
     }
-    return acquire_at_until(path, trusted_owner, &deadline, 0);
+    return acquire_at_until(path, trusted_owner, &deadline, 0, 0);
 }
 
 int hostpid_fallback_lock_acquire_at_until(
     const char *path, uid_t trusted_owner, const struct timespec *deadline) {
-    return acquire_at_until(path, trusted_owner, deadline, 0);
+    return acquire_at_until(path, trusted_owner, deadline, 0, 0);
 }
 
 int hostpid_fallback_lock_acquire_until(const struct timespec *deadline) {
-    return acquire_at_until(HOSTPID_FALLBACK_LOCK_PATH, 0, deadline, 1);
+    return acquire_at_until(HOSTPID_FALLBACK_LOCK_PATH, 0, deadline, 1, 1);
 }
 
 int hostpid_fallback_lock_acquire(void) {

--- a/src/hostpid_fallback_lock.c
+++ b/src/hostpid_fallback_lock.c
@@ -22,6 +22,15 @@
 
 static _Atomic int active_lock_fd = -1;
 
+#ifdef HOSTPID_FALLBACK_LOCK_TESTING
+static hostpid_fallback_lock_test_hook before_flock_hook;
+
+void hostpid_fallback_lock_set_before_flock_hook(
+    hostpid_fallback_lock_test_hook hook) {
+    before_flock_hook = hook;
+}
+#endif
+
 static int monotonic_now(struct timespec *now) {
     if (clock_gettime(CLOCK_MONOTONIC, now) != 0) {
         return -1;
@@ -134,9 +143,9 @@ static int validate_directory_metadata(const struct stat *directory_stat,
     return 0;
 }
 
+#ifdef __linux__
 static int validate_supported_filesystem(int fd);
 
-#ifdef __linux__
 static int validate_path_component(int fd,
                                    const struct stat *component_stat,
                                    uid_t trusted_owner) {
@@ -444,6 +453,11 @@ static int acquire_at_until(const char *path, uid_t trusted_owner,
         errno = EDEADLK;
         return -1;
     }
+#ifdef HOSTPID_FALLBACK_LOCK_TESTING
+    if (before_flock_hook != NULL) {
+        before_flock_hook();
+    }
+#endif
     for (;;) {
         int expired;
 
@@ -485,6 +499,17 @@ static int acquire_at_until(const char *path, uid_t trusted_owner,
         } else {
             retry_us = HOSTPID_FALLBACK_LOCK_MAX_RETRY_US;
         }
+    }
+
+    if (validate_lock_object(fd, path, trusted_owner, &opened_stat,
+                             require_readonly) != 0 ||
+        deadline_expired(deadline) != 0) {
+        int saved_errno = errno;
+
+        flock(fd, LOCK_UN);
+        discard_active_fd(fd);
+        errno = saved_errno;
+        return -1;
     }
     return 0;
 }

--- a/src/hostpid_fallback_lock.c
+++ b/src/hostpid_fallback_lock.c
@@ -1,0 +1,268 @@
+#include "include/hostpid_fallback_lock.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <linux/magic.h>
+#include <sys/vfs.h>
+#endif
+
+#define HOSTPID_FALLBACK_LOCK_INITIAL_RETRY_US 1000U
+#define HOSTPID_FALLBACK_LOCK_MAX_RETRY_US 100000U
+
+static _Atomic int active_lock_fd = -1;
+
+static int monotonic_now(struct timespec *now) {
+    if (clock_gettime(CLOCK_MONOTONIC, now) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int hostpid_fallback_lock_deadline_after_ms(struct timespec *deadline,
+                                            unsigned int timeout_ms) {
+    if (deadline == NULL || timeout_ms == 0U) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (monotonic_now(deadline) != 0) {
+        return -1;
+    }
+    deadline->tv_sec += timeout_ms / 1000U;
+    deadline->tv_nsec += (int64_t)(timeout_ms % 1000U) * INT64_C(1000000);
+    if (deadline->tv_nsec >= 1000000000L) {
+        deadline->tv_sec++;
+        deadline->tv_nsec -= 1000000000L;
+    }
+    return 0;
+}
+
+static int deadline_expired(const struct timespec *deadline) {
+    struct timespec now;
+
+    if (monotonic_now(&now) != 0) {
+        return -1;
+    }
+    if (now.tv_sec > deadline->tv_sec ||
+        (now.tv_sec == deadline->tv_sec &&
+         now.tv_nsec >= deadline->tv_nsec)) {
+        errno = ETIMEDOUT;
+        return 1;
+    }
+    return 0;
+}
+
+static int deadline_remaining(const struct timespec *deadline,
+                              struct timespec *remaining) {
+    struct timespec now;
+
+    if (monotonic_now(&now) != 0) {
+        return -1;
+    }
+    if (now.tv_sec > deadline->tv_sec ||
+        (now.tv_sec == deadline->tv_sec &&
+         now.tv_nsec >= deadline->tv_nsec)) {
+        errno = ETIMEDOUT;
+        return -1;
+    }
+    remaining->tv_sec = deadline->tv_sec - now.tv_sec;
+    remaining->tv_nsec = deadline->tv_nsec - now.tv_nsec;
+    if (remaining->tv_nsec < 0) {
+        remaining->tv_sec--;
+        remaining->tv_nsec += 1000000000L;
+    }
+    return 0;
+}
+
+static int sleep_before_retry(unsigned int delay_us,
+                              const struct timespec *deadline) {
+    struct timespec delay = {
+        .tv_sec = delay_us / 1000000U,
+        .tv_nsec = (int64_t)(delay_us % 1000000U) * INT64_C(1000),
+    };
+    struct timespec remaining;
+
+    if (deadline_remaining(deadline, &remaining) != 0) {
+        return -1;
+    }
+    if (delay.tv_sec > remaining.tv_sec ||
+        (delay.tv_sec == remaining.tv_sec &&
+         delay.tv_nsec > remaining.tv_nsec)) {
+        delay = remaining;
+    }
+
+    while (nanosleep(&delay, &delay) != 0) {
+        if (errno != EINTR) {
+            return -1;
+        }
+        if (deadline_remaining(deadline, &remaining) != 0) {
+            return -1;
+        }
+        if (delay.tv_sec > remaining.tv_sec ||
+            (delay.tv_sec == remaining.tv_sec &&
+             delay.tv_nsec > remaining.tv_nsec)) {
+            delay = remaining;
+        }
+    }
+    return 0;
+}
+
+static void discard_active_fd(int fd) {
+    int expected = fd;
+
+    atomic_compare_exchange_strong_explicit(&active_lock_fd, &expected, -1,
+                                            memory_order_acq_rel,
+                                            memory_order_acquire);
+    close(fd);
+}
+
+static int acquire_at_until(const char *path, uid_t trusted_owner,
+                            const struct timespec *deadline,
+                            int require_readonly) {
+    unsigned int retry_us = HOSTPID_FALLBACK_LOCK_INITIAL_RETRY_US;
+    int expected = -1;
+    int fd;
+
+    (void)trusted_owner;
+    (void)require_readonly;
+    if (path == NULL || path[0] != '/' || deadline == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (deadline_expired(deadline) != 0) {
+        return -1;
+    }
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd < 0) {
+        return -1;
+    }
+    if (!atomic_compare_exchange_strong_explicit(
+            &active_lock_fd, &expected, fd, memory_order_acq_rel,
+            memory_order_acquire)) {
+        close(fd);
+        errno = EDEADLK;
+        return -1;
+    }
+    for (;;) {
+        int expired;
+
+        expired = deadline_expired(deadline);
+        if (expired != 0) {
+            int saved_errno = errno;
+
+            discard_active_fd(fd);
+            errno = saved_errno;
+            return -1;
+        }
+        if (flock(fd, LOCK_EX | LOCK_NB) == 0) {
+            expired = deadline_expired(deadline);
+            if (expired == 0) {
+                break;
+            }
+            int saved_errno = errno;
+
+            discard_active_fd(fd);
+            errno = saved_errno;
+            return -1;
+        }
+        if (errno != EWOULDBLOCK && errno != EAGAIN && errno != EINTR) {
+            int saved_errno = errno;
+
+            discard_active_fd(fd);
+            errno = saved_errno;
+            return -1;
+        }
+        if (sleep_before_retry(retry_us, deadline) != 0) {
+            int saved_errno = errno;
+
+            discard_active_fd(fd);
+            errno = saved_errno;
+            return -1;
+        }
+        if (retry_us < HOSTPID_FALLBACK_LOCK_MAX_RETRY_US / 2U) {
+            retry_us *= 2U;
+        } else {
+            retry_us = HOSTPID_FALLBACK_LOCK_MAX_RETRY_US;
+        }
+    }
+    return 0;
+}
+
+int hostpid_fallback_lock_acquire_at(const char *path, uid_t trusted_owner,
+                                     unsigned int timeout_ms) {
+    struct timespec deadline;
+
+    if (hostpid_fallback_lock_deadline_after_ms(&deadline, timeout_ms) != 0) {
+        return -1;
+    }
+    return acquire_at_until(path, trusted_owner, &deadline, 0);
+}
+
+int hostpid_fallback_lock_acquire_at_until(
+    const char *path, uid_t trusted_owner, const struct timespec *deadline) {
+    return acquire_at_until(path, trusted_owner, deadline, 0);
+}
+
+int hostpid_fallback_lock_acquire_until(const struct timespec *deadline) {
+    return acquire_at_until(HOSTPID_FALLBACK_LOCK_PATH, 0, deadline, 1);
+}
+
+int hostpid_fallback_lock_acquire(void) {
+    struct timespec deadline;
+
+    if (hostpid_fallback_lock_deadline_after_ms(
+            &deadline, HOSTPID_FALLBACK_LOCK_TIMEOUT_MS) != 0) {
+        return -1;
+    }
+    return hostpid_fallback_lock_acquire_until(&deadline);
+}
+
+int hostpid_fallback_lock_release(void) {
+    int fd = atomic_exchange_explicit(&active_lock_fd, -1,
+                                      memory_order_acq_rel);
+    int result = 0;
+    int saved_errno = 0;
+
+    if (fd < 0) {
+        errno = ENOLCK;
+        return -1;
+    }
+    while (flock(fd, LOCK_UN) != 0) {
+        if (errno != EINTR) {
+            result = -1;
+            saved_errno = errno;
+            break;
+        }
+    }
+    if (close(fd) != 0 && result == 0) {
+        result = -1;
+        saved_errno = errno;
+    }
+    if (result != 0) {
+        errno = saved_errno;
+    }
+    return result;
+}
+
+void hostpid_fallback_lock_after_fork(void) {
+    int fd = atomic_exchange_explicit(&active_lock_fd, -1,
+                                      memory_order_acq_rel);
+
+    if (fd >= 0) {
+        close(fd);
+    }
+}
+
+int hostpid_fallback_lock_active_fd(void) {
+    return atomic_load_explicit(&active_lock_fd, memory_order_acquire);
+}

--- a/src/include/hostpid_fallback_lock.h
+++ b/src/include/hostpid_fallback_lock.h
@@ -9,6 +9,12 @@
 #define HOSTPID_FALLBACK_LOCK_TIMEOUT_MS 30000U
 #endif
 
+#ifdef HOSTPID_FALLBACK_LOCK_TESTING
+typedef void (*hostpid_fallback_lock_test_hook)(void);
+void hostpid_fallback_lock_set_before_flock_hook(
+    hostpid_fallback_lock_test_hook hook);
+#endif
+
 int hostpid_fallback_lock_acquire(void);
 int hostpid_fallback_lock_deadline_after_ms(struct timespec *deadline,
                                             unsigned int timeout_ms);

--- a/src/include/hostpid_fallback_lock.h
+++ b/src/include/hostpid_fallback_lock.h
@@ -1,0 +1,24 @@
+#ifndef SRC_INCLUDE_HOSTPID_FALLBACK_LOCK_H_
+#define SRC_INCLUDE_HOSTPID_FALLBACK_LOCK_H_
+
+#include <sys/types.h>
+#include <time.h>
+
+#define HOSTPID_FALLBACK_LOCK_PATH "/tmp/vgpulock/hostpid"
+#ifndef HOSTPID_FALLBACK_LOCK_TIMEOUT_MS
+#define HOSTPID_FALLBACK_LOCK_TIMEOUT_MS 30000U
+#endif
+
+int hostpid_fallback_lock_acquire(void);
+int hostpid_fallback_lock_deadline_after_ms(struct timespec *deadline,
+                                            unsigned int timeout_ms);
+int hostpid_fallback_lock_acquire_until(const struct timespec *deadline);
+int hostpid_fallback_lock_acquire_at(const char *path, uid_t trusted_owner,
+                                     unsigned int timeout_ms);
+int hostpid_fallback_lock_acquire_at_until(
+    const char *path, uid_t trusted_owner, const struct timespec *deadline);
+int hostpid_fallback_lock_release(void);
+void hostpid_fallback_lock_after_fork(void);
+int hostpid_fallback_lock_active_fd(void);
+
+#endif  // SRC_INCLUDE_HOSTPID_FALLBACK_LOCK_H_

--- a/src/include/hostpid_fallback_lock.h
+++ b/src/include/hostpid_fallback_lock.h
@@ -13,16 +13,16 @@
 typedef void (*hostpid_fallback_lock_test_hook)(void);
 void hostpid_fallback_lock_set_before_flock_hook(
     hostpid_fallback_lock_test_hook hook);
+int hostpid_fallback_lock_acquire_at(const char *path, uid_t trusted_owner,
+                                     unsigned int timeout_ms);
+int hostpid_fallback_lock_acquire_at_until(
+    const char *path, uid_t trusted_owner, const struct timespec *deadline);
 #endif
 
 int hostpid_fallback_lock_acquire(void);
 int hostpid_fallback_lock_deadline_after_ms(struct timespec *deadline,
                                             unsigned int timeout_ms);
 int hostpid_fallback_lock_acquire_until(const struct timespec *deadline);
-int hostpid_fallback_lock_acquire_at(const char *path, uid_t trusted_owner,
-                                     unsigned int timeout_ms);
-int hostpid_fallback_lock_acquire_at_until(
-    const char *path, uid_t trusted_owner, const struct timespec *deadline);
 int hostpid_fallback_lock_release(void);
 void hostpid_fallback_lock_after_fork(void);
 int hostpid_fallback_lock_active_fd(void);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,11 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
             -ffunction-sections -fdata-sections)
         set_target_properties(${TEST_TARGET_NAME} PROPERTIES
             LINK_FLAGS "-Wl,--gc-sections")
+    elseif (TEST_TARGET_NAME STREQUAL "test_hostpid_fallback_lock")
+        # GPU-free: builds the production lock into the test.
+        add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT}
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/hostpid_fallback_lock.c)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE _GNU_SOURCE)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT})
     elseif (TEST_SCRIPT MATCHES ".*cu")
@@ -61,6 +66,7 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
     list(APPEND TEST_TARGET_NAMES_LIST ${TEST_TARGET_NAME})
     if (TEST_TARGET_NAME STREQUAL "test_postinit_owner_death"
             OR TEST_TARGET_NAME STREQUAL "test_fork_child_exit_cleanup"
+            OR TEST_TARGET_NAME STREQUAL "test_hostpid_fallback_lock"
             OR TEST_TARGET_NAME STREQUAL "test_pid_discovery")
         target_link_libraries(${TEST_TARGET_NAME} -lrt -lpthread)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
@@ -103,6 +109,10 @@ set_tests_properties(nvml_v2_signatures PROPERTIES
 add_test(NAME pid_discovery
     COMMAND test_pid_discovery)
 set_tests_properties(pid_discovery PROPERTIES TIMEOUT 10)
+
+add_test(NAME hostpid_fallback_lock
+    COMMAND test_hostpid_fallback_lock)
+set_tests_properties(hostpid_fallback_lock PROPERTIES TIMEOUT 30)
 if (TARGET vgpu)
     add_test(NAME dlsym_rtld_next_preloaded
         COMMAND test_dlsym_rtld_next)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,7 +54,8 @@ foreach(TEST_SCRIPT ${TEST_SCRIPTS})
         # GPU-free: builds the production lock into the test.
         add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT}
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/hostpid_fallback_lock.c)
-        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE _GNU_SOURCE)
+        target_compile_definitions(${TEST_TARGET_NAME} PRIVATE
+            _GNU_SOURCE HOSTPID_FALLBACK_LOCK_TESTING)
     elseif (TEST_TARGET_NAME STREQUAL "test_dlsym_rtld_next")
         add_executable(${TEST_TARGET_NAME} ${TEST_SCRIPT})
     elseif (TEST_SCRIPT MATCHES ".*cu")

--- a/test/test_hostpid_fallback_lock.c
+++ b/test/test_hostpid_fallback_lock.c
@@ -545,6 +545,104 @@ static void test_exec_cleanup(const char *path, const char *program) {
     check(hostpid_fallback_lock_release() == 0, "exec holder release");
 }
 
+static void test_path_trust(const char *path) {
+    char file_path[] = "/tmp/hami-hostpid-lock-file.XXXXXX";
+    char link_path[] = "/tmp/hami-hostpid-lock-link.XXXXXX";
+    char ancestor_directory[] = "/tmp/hami-hostpid-lock-ancestor.XXXXXX";
+    char ancestor_link[PATH_MAX];
+    char ancestor_nested_target[PATH_MAX];
+    char ancestor_target[PATH_MAX];
+    char missing_path[] = "/tmp/hami-hostpid-lock-missing.XXXXXX";
+    char nested_path[PATH_MAX];
+    int file_fd;
+
+    errno = 0;
+    check(hostpid_fallback_lock_acquire_at("relative", getuid(), 50) == -1 &&
+              errno == EINVAL,
+          "relative path is rejected");
+
+    file_fd = mkstemp(missing_path);
+    check(file_fd >= 0, "missing path fixture name");
+    if (file_fd >= 0) {
+        close(file_fd);
+        unlink(missing_path);
+        errno = 0;
+        check(hostpid_fallback_lock_acquire_at(missing_path, getuid(), 50) ==
+                  -1 && errno == ENOENT,
+              "missing path is rejected");
+    }
+
+    file_fd = mkstemp(file_path);
+    check(file_fd >= 0, "regular file fixture");
+    if (file_fd >= 0) {
+        close(file_fd);
+        check(hostpid_fallback_lock_acquire_at(file_path, getuid(), 50) == -1,
+              "regular file is rejected");
+        unlink(file_path);
+    }
+
+    file_fd = mkstemp(link_path);
+    check(file_fd >= 0, "symlink fixture name");
+    if (file_fd >= 0) {
+        close(file_fd);
+        unlink(link_path);
+        check(symlink(path, link_path) == 0, "symlink fixture");
+        check(hostpid_fallback_lock_acquire_at(link_path, getuid(), 50) == -1,
+              "symlink is rejected");
+        unlink(link_path);
+    }
+
+    errno = 0;
+    check(hostpid_fallback_lock_acquire_at(path, getuid() + 1U, 50) == -1 &&
+              errno == EACCES,
+          "unexpected owner is rejected");
+
+#ifdef __linux__
+    check(mkdtemp(ancestor_directory) != NULL,
+          "symlink ancestor fixture directory");
+    check(join_path(ancestor_target, sizeof(ancestor_target),
+                    ancestor_directory, "/target") == 0,
+          "symlink ancestor target path");
+    check(join_path(ancestor_link, sizeof(ancestor_link),
+                    ancestor_directory, "/link") == 0,
+          "symlink ancestor link path");
+    check(join_path(ancestor_nested_target,
+                    sizeof(ancestor_nested_target), ancestor_target,
+                    "/nested") == 0,
+          "symlink ancestor nested target path");
+    check(join_path(nested_path, sizeof(nested_path), ancestor_link,
+                    "/nested") == 0,
+          "symlink ancestor nested path");
+    check(mkdir(ancestor_target, 0700) == 0,
+          "symlink ancestor target directory");
+    check(mkdir(ancestor_nested_target, 0700) == 0,
+          "symlink ancestor nested directory");
+    check(symlink(ancestor_target, ancestor_link) == 0,
+          "symlink ancestor fixture");
+    errno = 0;
+    check(hostpid_fallback_lock_acquire_at(nested_path, getuid(), 50) == -1,
+          "symlink ancestor is rejected");
+    unlink(ancestor_link);
+    rmdir(ancestor_nested_target);
+    rmdir(ancestor_target);
+    rmdir(ancestor_directory);
+
+    snprintf(nested_path, sizeof(nested_path), "/tmp/../tmp/%s",
+             strrchr(path, '/') + 1);
+    errno = 0;
+    check(hostpid_fallback_lock_acquire_at(nested_path, getuid(), 50) == -1 &&
+              errno == EINVAL,
+          "parent traversal is rejected");
+#else
+    (void)ancestor_directory;
+    (void)ancestor_link;
+    (void)ancestor_nested_target;
+    (void)ancestor_target;
+    (void)nested_path;
+    puts("ancestor path tests skipped: Linux required");
+#endif
+}
+
 int main(int argc, char **argv) {
     char directory[] = "/tmp/hami-hostpid-global-lock.XXXXXX";
     char *path;
@@ -577,6 +675,7 @@ int main(int argc, char **argv) {
 
     test_absolute_deadline_api(path);
     test_basic_contract(path);
+    test_path_trust(path);
     test_live_holder_timeout(path);
     test_deadline_not_renewed(path);
     test_waiter_cancellation(path);

--- a/test/test_hostpid_fallback_lock.c
+++ b/test/test_hostpid_fallback_lock.c
@@ -1,0 +1,601 @@
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../src/include/hostpid_fallback_lock.h"
+
+static int failures;
+static int waiter_ready_fd = -1;
+
+static void signal_waiter_ready(void) {
+    if (waiter_ready_fd >= 0) {
+        char byte = '1';
+
+        if (write(waiter_ready_fd, &byte, 1) != 1) {
+            _exit(4);
+        }
+        waiter_ready_fd = -1;
+    }
+}
+
+static int parse_unsigned(const char *value, uintmax_t *parsed) {
+    char *end = NULL;
+
+    errno = 0;
+    *parsed = strtoumax(value, &end, 10);
+    return errno == 0 && end != value && *end == '\0' ? 0 : -1;
+}
+
+static int probe_lock(const char *path, const char *owner_value,
+                      const char *timeout_value, const char *hold_value,
+                      int expect_timeout) {
+    struct timespec hold;
+    uintmax_t owner;
+    uintmax_t timeout_ms;
+    uintmax_t hold_ms;
+
+    if (parse_unsigned(owner_value, &owner) != 0 ||
+        parse_unsigned(timeout_value, &timeout_ms) != 0 ||
+        parse_unsigned(hold_value, &hold_ms) != 0 ||
+        owner > (uintmax_t)(uid_t)-1 || timeout_ms > UINT_MAX ||
+        hold_ms > UINT_MAX) {
+        return 2;
+    }
+    if (hostpid_fallback_lock_acquire_at(path, (uid_t)owner,
+                                         (unsigned int)timeout_ms) != 0) {
+        if (expect_timeout && errno == ETIMEDOUT) {
+            puts("timed_out");
+            return 0;
+        }
+        perror("hostpid_fallback_lock_acquire_at");
+        return 3;
+    }
+    if (expect_timeout) {
+        hostpid_fallback_lock_release();
+        fputs("unexpected_acquire\n", stderr);
+        return 4;
+    }
+    puts("acquired");
+    fflush(stdout);
+    hold.tv_sec = (time_t)(hold_ms / UINTMAX_C(1000));
+    hold.tv_nsec = (int64_t)(hold_ms % UINTMAX_C(1000)) * INT64_C(1000000);
+    while (nanosleep(&hold, &hold) != 0 && errno == EINTR) {
+    }
+    if (hostpid_fallback_lock_release() != 0) {
+        perror("hostpid_fallback_lock_release");
+        return 5;
+    }
+    return 0;
+}
+
+static int probe_default_lock(const char *hold_value) {
+    struct timespec hold;
+    uintmax_t hold_ms;
+
+    if (parse_unsigned(hold_value, &hold_ms) != 0 || hold_ms > UINT_MAX) {
+        return 2;
+    }
+    if (hostpid_fallback_lock_acquire() != 0) {
+        fprintf(stderr, "rejected_errno=%d\n", errno);
+        perror("hostpid_fallback_lock_acquire");
+        return 3;
+    }
+    puts("acquired");
+    fflush(stdout);
+    hold.tv_sec = (time_t)(hold_ms / UINTMAX_C(1000));
+    hold.tv_nsec = (int64_t)(hold_ms % UINTMAX_C(1000)) * INT64_C(1000000);
+    while (nanosleep(&hold, &hold) != 0 && errno == EINTR) {
+    }
+    if (hostpid_fallback_lock_release() != 0) {
+        perror("hostpid_fallback_lock_release");
+        return 4;
+    }
+    return 0;
+}
+
+static void check(int condition, const char *message) {
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s (errno=%d: %s)\n", message, errno,
+                strerror(errno));
+        failures++;
+    }
+}
+
+static int join_path(char *destination, size_t destination_size,
+                     const char *parent, const char *suffix) {
+    size_t parent_length = strlen(parent);
+    size_t suffix_length = strlen(suffix);
+
+    if (parent_length >= destination_size ||
+        suffix_length >= destination_size - parent_length) {
+        if (destination_size > 0) {
+            destination[0] = '\0';
+        }
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    memcpy(destination, parent, parent_length);
+    memcpy(destination + parent_length, suffix, suffix_length + 1);
+    return 0;
+}
+
+static int wait_for_child(pid_t child, int expected_status) {
+    int status;
+
+    if (waitpid(child, &status, 0) != child) {
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != expected_status) {
+        return -1;
+    }
+    return 0;
+}
+
+static double monotonic_milliseconds(void) {
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return -1.0;
+    }
+    return (double)now.tv_sec * 1000.0 +
+           (double)now.tv_nsec / 1000000.0;
+}
+
+static int child_timeout(const char *path, unsigned int timeout_ms) {
+    double started = monotonic_milliseconds();
+    double elapsed;
+
+    if (started < 0.0) {
+        return 4;
+    }
+    hostpid_fallback_lock_after_fork();
+    if (hostpid_fallback_lock_acquire_at(path, getuid(), timeout_ms) == 0) {
+        hostpid_fallback_lock_release();
+        return 2;
+    }
+    if (errno != ETIMEDOUT) {
+        return 3;
+    }
+    elapsed = monotonic_milliseconds() - started;
+    dprintf(STDOUT_FILENO, "timeout_elapsed_ms=%.3f\n", elapsed);
+    if (elapsed < (double)timeout_ms / 2.0 ||
+        elapsed > (double)timeout_ms + 500.0) {
+        return 5;
+    }
+    return 0;
+}
+
+static int child_acquire(const char *path, unsigned int timeout_ms) {
+    hostpid_fallback_lock_after_fork();
+    if (hostpid_fallback_lock_acquire_at(path, getuid(), timeout_ms) != 0) {
+        return 2;
+    }
+    if (hostpid_fallback_lock_release() != 0) {
+        return 3;
+    }
+    return 0;
+}
+
+static int wait_until_child_opened(pid_t child, const char *path) {
+    char fd_directory[64];
+    struct timespec delay = {.tv_sec = 0, .tv_nsec = 1000000L};
+    int attempt;
+
+    snprintf(fd_directory, sizeof(fd_directory), "/proc/%" PRIdMAX "/fd",
+             (intmax_t)child);
+    for (attempt = 0; attempt < 2000; attempt++) {
+        DIR *directory = opendir(fd_directory);
+
+        if (directory != NULL) {
+            struct dirent *entry;
+
+            while ((entry = readdir(directory)) != NULL) {
+                char fd_path[PATH_MAX];
+                char target[4096];
+                int path_length;
+                ssize_t length;
+
+                if (entry->d_name[0] == '.') {
+                    continue;
+                }
+                path_length = snprintf(fd_path, sizeof(fd_path), "%s/%s",
+                                       fd_directory, entry->d_name);
+                if (path_length < 0 ||
+                    (size_t)path_length >= sizeof(fd_path)) {
+                    continue;
+                }
+                length = readlink(fd_path, target, sizeof(target) - 1U);
+                if (length < 0) {
+                    continue;
+                }
+                target[length] = '\0';
+                if (strcmp(target, path) == 0) {
+                    closedir(directory);
+                    return 0;
+                }
+            }
+            closedir(directory);
+        }
+        nanosleep(&delay, NULL);
+    }
+    return -1;
+}
+
+static void test_absolute_deadline_api(const char *path) {
+    struct timespec deadline;
+    struct timespec delay = {.tv_sec = 0, .tv_nsec = 5000000L};
+
+    errno = 0;
+    check(hostpid_fallback_lock_deadline_after_ms(NULL, 50U) == -1 &&
+              errno == EINVAL,
+          "null deadline output is rejected");
+    errno = 0;
+    check(hostpid_fallback_lock_deadline_after_ms(&deadline, 0U) == -1 &&
+              errno == EINVAL,
+          "zero deadline duration is rejected");
+    errno = 0;
+    check(hostpid_fallback_lock_acquire_at_until(path, getuid(), NULL) == -1 &&
+              errno == EINVAL,
+          "null absolute deadline is rejected");
+
+    check(hostpid_fallback_lock_deadline_after_ms(&deadline, 500U) == 0,
+          "future absolute deadline is created");
+    check(hostpid_fallback_lock_acquire_at_until(path, getuid(),
+                                                 &deadline) == 0,
+          "absolute deadline acquire succeeds");
+    check(hostpid_fallback_lock_release() == 0,
+          "absolute deadline acquire releases");
+
+    check(hostpid_fallback_lock_deadline_after_ms(&deadline, 1U) == 0,
+          "short absolute deadline is created");
+    while (nanosleep(&delay, &delay) != 0 && errno == EINTR) {
+    }
+    errno = 0;
+    check(hostpid_fallback_lock_acquire_at_until(path, getuid(),
+                                                 &deadline) == -1 &&
+              errno == ETIMEDOUT,
+          "expired absolute deadline is rejected");
+}
+
+static void test_basic_contract(const char *path) {
+    int fd;
+
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+          "basic acquire");
+    fd = hostpid_fallback_lock_active_fd();
+    check(fd >= 0, "active descriptor is recorded");
+    if (fd >= 0) {
+        int flags = fcntl(fd, F_GETFD);
+
+        check(flags >= 0 && (flags & FD_CLOEXEC) != 0,
+              "descriptor is close on exec");
+    }
+    errno = 0;
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 50) == -1 &&
+              errno == EDEADLK,
+          "recursive acquire fails");
+    check(hostpid_fallback_lock_release() == 0, "basic release");
+    errno = 0;
+    check(hostpid_fallback_lock_release() == -1 && errno == ENOLCK,
+          "release without owner fails");
+}
+
+static void test_live_holder_timeout(const char *path) {
+    pid_t child;
+
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+          "timeout holder acquire");
+    child = fork();
+    check(child >= 0, "timeout contender fork");
+    if (child == 0) {
+        _exit(child_timeout(path, 80));
+    }
+    if (child > 0) {
+        check(wait_for_child(child, 0) == 0, "live holder times out waiter");
+    }
+    check(hostpid_fallback_lock_release() == 0, "timeout holder release");
+}
+
+static void test_deadline_not_renewed(const char *path) {
+    int begin_release[2];
+    int ready[2];
+    pid_t holder;
+    pid_t waiter;
+    char byte;
+
+    if (access("/proc/self/fd", R_OK) != 0) {
+        puts("deadline renewal test skipped: /proc/self/fd unavailable");
+        return;
+    }
+    if (pipe(ready) != 0) {
+        check(0, "deadline holder pipes");
+        return;
+    }
+    if (pipe(begin_release) != 0) {
+        check(0, "deadline holder pipes");
+        close(ready[0]);
+        close(ready[1]);
+        return;
+    }
+    holder = fork();
+    check(holder >= 0, "deadline holder fork");
+    if (holder < 0) {
+        close(ready[0]);
+        close(ready[1]);
+        close(begin_release[0]);
+        close(begin_release[1]);
+        return;
+    }
+    if (holder == 0) {
+        struct timespec hold = {.tv_sec = 0, .tv_nsec = 400000000L};
+
+        close(ready[0]);
+        close(begin_release[1]);
+        hostpid_fallback_lock_after_fork();
+        if (hostpid_fallback_lock_acquire_at(path, getuid(), 500) != 0 ||
+            write(ready[1], "1", 1) != 1) {
+            _exit(2);
+        }
+        close(ready[1]);
+        if (read(begin_release[0], &byte, 1) != 1) {
+            _exit(3);
+        }
+        close(begin_release[0]);
+        while (nanosleep(&hold, &hold) != 0 && errno == EINTR) {
+        }
+        _exit(hostpid_fallback_lock_release() == 0 ? 0 : 4);
+    }
+    close(ready[1]);
+    close(begin_release[0]);
+    if (read(ready[0], &byte, 1) != 1) {
+        check(0, "deadline holder acquired");
+        close(ready[0]);
+        close(begin_release[1]);
+        kill(holder, SIGKILL);
+        waitpid(holder, NULL, 0);
+        return;
+    }
+    close(ready[0]);
+
+    waiter = fork();
+    check(waiter >= 0, "deadline waiter fork");
+    if (waiter == 0) {
+        _exit(child_timeout(path, 80));
+    }
+    if (waiter > 0) {
+        check(wait_until_child_opened(waiter, path) == 0,
+              "deadline waiter opened the lock object");
+        check(write(begin_release[1], "1", 1) == 1,
+              "deadline holder release timer started");
+        close(begin_release[1]);
+        check(wait_for_child(waiter, 0) == 0,
+              "deadline is not renewed by owner release");
+    } else {
+        close(begin_release[1]);
+    }
+    check(wait_for_child(holder, 0) == 0,
+          "deadline holder release");
+}
+
+static void test_waiter_cancellation(const char *path) {
+    int started[2];
+    pid_t child;
+    char byte;
+    int status;
+
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+          "cancellation holder acquire");
+    if (pipe(started) != 0) {
+        check(0, "cancellation start pipe");
+        hostpid_fallback_lock_release();
+        return;
+    }
+    child = fork();
+    check(child >= 0, "cancellation waiter fork");
+    if (child < 0) {
+        close(started[0]);
+        close(started[1]);
+        hostpid_fallback_lock_release();
+        return;
+    }
+    if (child == 0) {
+        close(started[0]);
+        hostpid_fallback_lock_after_fork();
+        if (write(started[1], "1", 1) != 1) {
+            _exit(3);
+        }
+        close(started[1]);
+        if (hostpid_fallback_lock_acquire_at(path, getuid(), 5000) == 0) {
+            hostpid_fallback_lock_release();
+            _exit(4);
+        }
+        _exit(5);
+    }
+    if (child > 0) {
+        close(started[1]);
+        check(read(started[0], &byte, 1) == 1,
+              "cancellation waiter started");
+        close(started[0]);
+        if (access("/proc/self/fd", R_OK) == 0) {
+            check(wait_until_child_opened(child, path) == 0,
+                  "cancellation waiter opened the lock object");
+        }
+        check(kill(child, SIGKILL) == 0,
+              "cancellation waiter killed");
+        check(waitpid(child, &status, 0) == child &&
+                  WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL,
+              "cancellation waiter reaped");
+    }
+    check(hostpid_fallback_lock_release() == 0,
+          "cancellation holder release");
+    child = fork();
+    check(child >= 0, "post cancellation contender fork");
+    if (child == 0) {
+        _exit(child_acquire(path, 500));
+    }
+    if (child > 0) {
+        check(wait_for_child(child, 0) == 0,
+              "lock recovers after waiter cancellation");
+    }
+}
+
+static void test_owner_death(const char *path) {
+    int ready[2] = {-1, -1};
+    pid_t child;
+    char byte;
+
+    if (pipe(ready) != 0) {
+        check(0, "owner death pipe");
+        return;
+    }
+    child = fork();
+    check(child >= 0, "owner death fork");
+    if (child == 0) {
+        close(ready[0]);
+        hostpid_fallback_lock_after_fork();
+        if (hostpid_fallback_lock_acquire_at(path, getuid(), 500) != 0) {
+            _exit(2);
+        }
+        if (write(ready[1], "1", 1) != 1) {
+            _exit(3);
+        }
+        pause();
+        _exit(4);
+    }
+    if (child > 0) {
+        close(ready[1]);
+        check(read(ready[0], &byte, 1) == 1, "owner acquired before death");
+        kill(child, SIGKILL);
+        check(waitpid(child, NULL, 0) == child, "dead owner reaped");
+        check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+              "lock recovers after owner death");
+        check(hostpid_fallback_lock_release() == 0,
+              "owner death recovery release");
+        close(ready[0]);
+    }
+}
+
+static void test_fork_cleanup(const char *path) {
+    pid_t child;
+
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+          "fork holder acquire");
+    child = fork();
+    check(child >= 0, "fork cleanup child");
+    if (child == 0) {
+        hostpid_fallback_lock_after_fork();
+        _exit(hostpid_fallback_lock_active_fd() == -1 ? 0 : 2);
+    }
+    if (child > 0) {
+        check(wait_for_child(child, 0) == 0, "child drops inherited state");
+    }
+
+    child = fork();
+    check(child >= 0, "fork cleanup contender");
+    if (child == 0) {
+        _exit(child_timeout(path, 80));
+    }
+    if (child > 0) {
+        check(wait_for_child(child, 0) == 0,
+              "parent keeps lock after child cleanup");
+    }
+    check(hostpid_fallback_lock_release() == 0, "fork holder release");
+
+    child = fork();
+    check(child >= 0, "post fork contender");
+    if (child == 0) {
+        _exit(child_acquire(path, 500));
+    }
+    if (child > 0) {
+        check(wait_for_child(child, 0) == 0,
+              "new process acquires after release");
+    }
+}
+
+static void test_exec_cleanup(const char *path, const char *program) {
+    char descriptor[32];
+    pid_t child;
+    int fd;
+
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+          "exec holder acquire");
+    fd = hostpid_fallback_lock_active_fd();
+    snprintf(descriptor, sizeof(descriptor), "%d", fd);
+    child = fork();
+    check(child >= 0, "exec cleanup fork");
+    if (child == 0) {
+        execl(program, program, "--check-closed", descriptor, NULL);
+        _exit(3);
+    }
+    if (child > 0) {
+        check(wait_for_child(child, 0) == 0,
+              "exec closes inherited descriptor");
+    }
+    check(hostpid_fallback_lock_release() == 0, "exec holder release");
+}
+
+int main(int argc, char **argv) {
+    char directory[] = "/tmp/hami-hostpid-global-lock.XXXXXX";
+    char *path;
+
+    if (argc == 3 && strcmp(argv[1], "--check-closed") == 0) {
+        int fd = atoi(argv[2]);
+
+        errno = 0;
+        return fcntl(fd, F_GETFD) == -1 && errno == EBADF ? 0 : 2;
+    }
+    if (argc == 6 && strcmp(argv[1], "--probe") == 0) {
+        return probe_lock(argv[2], argv[3], argv[4], argv[5], 0);
+    }
+    if (argc == 6 && strcmp(argv[1], "--expect-timeout") == 0) {
+        return probe_lock(argv[2], argv[3], argv[4], argv[5], 1);
+    }
+    if (argc == 3 && strcmp(argv[1], "--probe-default") == 0) {
+        return probe_default_lock(argv[2]);
+    }
+
+    path = mkdtemp(directory);
+    if (path == NULL) {
+        perror("mkdtemp");
+        return 1;
+    }
+
+    check(strcmp(HOSTPID_FALLBACK_LOCK_PATH,
+                 "/tmp/vgpulock/hostpid") == 0,
+          "default lock uses the trusted broker mount");
+
+    test_absolute_deadline_api(path);
+    test_basic_contract(path);
+    test_live_holder_timeout(path);
+    test_deadline_not_renewed(path);
+    test_waiter_cancellation(path);
+    test_owner_death(path);
+    test_fork_cleanup(path);
+    test_exec_cleanup(path, argv[0]);
+
+    if (hostpid_fallback_lock_active_fd() >= 0) {
+        hostpid_fallback_lock_release();
+    }
+    if (rmdir(path) != 0) {
+        perror("rmdir");
+        failures++;
+    }
+    if (failures != 0) {
+        fprintf(stderr, "%d host PID fallback lock test(s) failed\n",
+                failures);
+        return 1;
+    }
+    puts("host PID fallback lock tests passed");
+    return 0;
+}

--- a/test/test_hostpid_fallback_lock.c
+++ b/test/test_hostpid_fallback_lock.c
@@ -643,6 +643,195 @@ static void test_path_trust(const char *path) {
 #endif
 }
 
+static void test_permission_change_while_waiting(const char *path) {
+    int failures_before = failures;
+    int ready[2];
+    pid_t child;
+    char byte;
+
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+          "permission change holder acquire");
+    if (pipe(ready) != 0) {
+        check(0, "permission change ready pipe");
+        hostpid_fallback_lock_release();
+        return;
+    }
+    waiter_ready_fd = ready[1];
+    hostpid_fallback_lock_set_before_flock_hook(
+        signal_waiter_ready);
+    child = fork();
+    check(child >= 0, "permission change waiter fork");
+    if (child == 0) {
+        close(ready[0]);
+        hostpid_fallback_lock_after_fork();
+        if (hostpid_fallback_lock_acquire_at(path, getuid(), 1000) == 0) {
+            hostpid_fallback_lock_release();
+            _exit(2);
+        }
+        _exit(errno == EACCES ? 0 : 3);
+    }
+    if (child > 0) {
+        close(ready[1]);
+        check(read(ready[0], &byte, 1) == 1,
+              "permission change waiter passed initial validation");
+        close(ready[0]);
+        hostpid_fallback_lock_set_before_flock_hook(NULL);
+        check(chmod(path, 0777) == 0,
+              "permission change makes lock object untrusted");
+        check(hostpid_fallback_lock_release() == 0,
+              "permission change holder release");
+        check(wait_for_child(child, 0) == 0,
+              "permission change is rejected after lock acquisition");
+        check(chmod(path, 0700) == 0,
+              "permission change restores lock object");
+    } else {
+        close(ready[0]);
+        close(ready[1]);
+        hostpid_fallback_lock_set_before_flock_hook(NULL);
+        hostpid_fallback_lock_release();
+    }
+    if (failures == failures_before) {
+        puts("permission_change_rejected=passed");
+    }
+}
+
+static void test_path_replacement(const char *path) {
+    char old_path[4096];
+    int failures_before = failures;
+    int reset_ready[2];
+    pid_t child;
+    char byte;
+
+    snprintf(old_path, sizeof(old_path), "%s.old", path);
+    check(hostpid_fallback_lock_acquire_at(path, getuid(), 500) == 0,
+          "replacement holder acquire");
+    if (pipe(reset_ready) != 0) {
+        check(0, "replacement reset pipe");
+        hostpid_fallback_lock_release();
+        return;
+    }
+    waiter_ready_fd = reset_ready[1];
+    hostpid_fallback_lock_set_before_flock_hook(signal_waiter_ready);
+    child = fork();
+    check(child >= 0, "replacement contender fork");
+    if (child == 0) {
+        close(reset_ready[0]);
+        hostpid_fallback_lock_after_fork();
+        if (hostpid_fallback_lock_acquire_at(path, getuid(), 1000) == 0) {
+            hostpid_fallback_lock_release();
+            _exit(2);
+        }
+        _exit(errno == ESTALE ? 0 : 3);
+    }
+    if (child > 0) {
+        close(reset_ready[1]);
+        check(read(reset_ready[0], &byte, 1) == 1,
+              "replacement waiter passed initial validation");
+        close(reset_ready[0]);
+        hostpid_fallback_lock_set_before_flock_hook(NULL);
+        check(rename(path, old_path) == 0, "replace original path");
+        check(mkdir(path, 0700) == 0, "create replacement path");
+        check(hostpid_fallback_lock_release() == 0,
+              "release replaced original object");
+        check(wait_for_child(child, 0) == 0,
+              "replacement is detected after acquisition");
+        rmdir(path);
+        check(rename(old_path, path) == 0, "restore original path");
+    } else {
+        close(reset_ready[0]);
+        close(reset_ready[1]);
+        hostpid_fallback_lock_set_before_flock_hook(NULL);
+        hostpid_fallback_lock_release();
+    }
+    if (failures == failures_before) {
+        puts("path_replacement_rejected=passed");
+    }
+}
+
+static void test_ancestor_change_while_waiting(void) {
+#ifdef __linux__
+    char fixture[] = "/tmp/hami-hostpid-ancestor-change.XXXXXX";
+    char lock_path[PATH_MAX];
+    char original_parent[PATH_MAX];
+    char parent[PATH_MAX];
+    int failures_before = failures;
+    int ready[2];
+    pid_t child;
+    char byte;
+    char *fixture_root;
+
+    fixture_root = mkdtemp(fixture);
+    check(fixture_root != NULL, "ancestor change fixture root");
+    if (fixture_root == NULL) {
+        return;
+    }
+    check(join_path(parent, sizeof(parent), fixture_root, "/parent") == 0,
+          "ancestor change parent path");
+    check(join_path(original_parent, sizeof(original_parent), fixture_root,
+                    "/parent-original") == 0,
+          "ancestor change original parent path");
+    check(join_path(lock_path, sizeof(lock_path), parent, "/lock") == 0,
+          "ancestor change lock path");
+    check(mkdir(parent, 0700) == 0, "ancestor change parent");
+    check(mkdir(lock_path, 0700) == 0, "ancestor change lock object");
+    check(hostpid_fallback_lock_acquire_at(lock_path, getuid(), 500) == 0,
+          "ancestor change holder acquire");
+    if (pipe(ready) != 0) {
+        check(0, "ancestor change ready pipe");
+        hostpid_fallback_lock_release();
+        rmdir(lock_path);
+        rmdir(parent);
+        rmdir(fixture_root);
+        return;
+    }
+    waiter_ready_fd = ready[1];
+    hostpid_fallback_lock_set_before_flock_hook(signal_waiter_ready);
+    child = fork();
+    check(child >= 0, "ancestor change waiter fork");
+    if (child == 0) {
+        close(ready[0]);
+        hostpid_fallback_lock_after_fork();
+        if (hostpid_fallback_lock_acquire_at(lock_path, getuid(), 1000) ==
+            0) {
+            hostpid_fallback_lock_release();
+            _exit(2);
+        }
+        _exit(errno == ELOOP || errno == ENOTDIR ? 0 : 3);
+    }
+    if (child > 0) {
+        close(ready[1]);
+        check(read(ready[0], &byte, 1) == 1,
+              "ancestor change waiter passed initial validation");
+        close(ready[0]);
+        hostpid_fallback_lock_set_before_flock_hook(NULL);
+        check(rename(parent, original_parent) == 0,
+              "ancestor change moves trusted parent");
+        check(symlink(original_parent, parent) == 0,
+              "ancestor change installs symlink parent");
+        check(hostpid_fallback_lock_release() == 0,
+              "ancestor change holder release");
+        check(wait_for_child(child, 0) == 0,
+              "ancestor change is rejected after lock acquisition");
+        check(unlink(parent) == 0, "ancestor change removes symlink parent");
+        check(rename(original_parent, parent) == 0,
+              "ancestor change restores trusted parent");
+    } else {
+        close(ready[0]);
+        close(ready[1]);
+        hostpid_fallback_lock_set_before_flock_hook(NULL);
+        hostpid_fallback_lock_release();
+    }
+    rmdir(lock_path);
+    rmdir(parent);
+    rmdir(fixture_root);
+    if (failures == failures_before) {
+        puts("ancestor_change_rejected=passed");
+    }
+#else
+    puts("ancestor change test skipped: Linux required");
+#endif
+}
+
 int main(int argc, char **argv) {
     char directory[] = "/tmp/hami-hostpid-global-lock.XXXXXX";
     char *path;
@@ -682,6 +871,9 @@ int main(int argc, char **argv) {
     test_owner_death(path);
     test_fork_cleanup(path);
     test_exec_cleanup(path, argv[0]);
+    test_permission_change_while_waiting(path);
+    test_path_replacement(path);
+    test_ancestor_change_while_waiting();
 
     if (hostpid_fallback_lock_active_fd() >= 0) {
         hostpid_fallback_lock_release();


### PR DESCRIPTION
Split out of #251 at @maverick-woo's request. Just the lock here. Broker client and the integration follow.

## Problem

`postInit` serializes host PID discovery with `lock_postinit()`, a record lock on the cache file. That only covers processes sharing one cache. The NVML snapshot it guards is node wide, so two processes with separate caches can probe at once and each can pick up the other's PID. @maverick-woo said the same on Project-HAMi/HAMi#2244.

The fix is a lock every container agrees on, but the only path they agree on is `/tmp/vgpulock`, which anyone on the node can write.

## Change

`flock` on a directory, so a killed owner doesn't strand waiters.

The wait takes an absolute deadline instead of a timeout, so a caller can spend one budget across this lock and the cache lock rather than give each a fresh 30s. Backoff goes 1ms to 100ms and the deadline is never renewed.

The path isn't trusted. Opening walks it a component at a time with `O_NOFOLLOW`, checks owner and mode at each level, and rejects filesystems where the lock wouldn't behave. It checks again after `flock` returns, since the path can be swapped while you're blocked.

One lock per process, `FD_CLOEXEC` so it doesn't cross an `exec`, and `after_fork()` drops the inherited descriptor so a child can't release a lock it never took.

An operation guard protects descriptor ownership during acquire and release. Overlapping calls return `EBUSY`; acquiring an already held lock returns `EDEADLK`. Once acquire returns, another thread in the same process may release it. This prevents an older acquisition's cleanup from closing a descriptor reused by a newer acquisition.

Operations defer thread cancellation until temporary descriptors have been closed or the acquired descriptor is owned by a cleanup handler. A cancelled acquisition releases its descriptor and clears the guard. The fork child clears the inherited guard along with its descriptor. Asynchronous cancellation is unsupported.

Nothing calls it yet. The call site needs `lock_postinit_deadline()`, which isn't on main, so it goes in with the integration.

## Test

CTest, no GPU and no driver. Covers acquire and release, the deadline API, a deadline that must not be renewed, a live holder timing out, a cancelled waiter, owner death, fork and exec cleanup, an untrusted path, and the path or an ancestor changing while a waiter is blocked. Cases that need `/proc` or Linux mount behaviour skip themselves and say so.

`test_hostpid_fallback_lock_threads` covers overlapping acquire/release, cancellation cleanup and a fork child inheriting a busy guard. It uses real threads and file locks with the production implementation. The Docker build runs both fallback tests with CTest.

```
cmake --build build --target test_hostpid_fallback_lock test_hostpid_fallback_lock_threads
ctest --test-dir build -R hostpid_fallback_lock
```

---
I used AI assistance (deepseek v4 flash) for the original split and Codex for these fixes. The lock design comes from #251.
