### PR TITLE
fix: make SM limiter step linear in SM count

### DIFF
--- a/src/multiprocess/multiprocess_utilization_watcher.c
+++ b/src/multiprocess/multiprocess_utilization_watcher.c
@@ -87,7 +87,7 @@ static int64_t delta(int up_limit, int user_current, int64_t share, int device_i
   int utilization_diff =
       abs(up_limit - user_current) < 5 ? 5 : abs(up_limit - user_current);
   int64_t increment =
-      (int64_t)g_sm_num[device_id] * (int64_t)g_sm_num[device_id] *
+      (int64_t)g_sm_num[device_id] *
       (int64_t)g_max_thread_per_sm[device_id] * (int64_t)utilization_diff / 2560;
 
   /* Accelerate cuda cores allocation when utilization vary widely */


### PR DESCRIPTION
First, English is not my native language, so I used AI to help with the translation. 

Fixes #314

Removes one `sm_num` factor from the correction step in `delta()`.
The token pool is:
```
sm_num * max_thread_per_sm * FACTOR
```
The correction step previously contained:
```
sm_num * sm_num * max_thread_per_sm * diff / 2560
```
This caused the step-to-pool ratio to increase with the SM count. The ratio is now diff / 81920 regardless of device size.
This PR does not change g_total_cuda_cores in setspec(). Its int64_t conversion is covered by #303, and the two changes can be merged in either order.

On a 188-SM GPU, the previous correction step could refill the entire pool in a single 120 ms tick. This caused the limiter to alternate between saturation and throttling instead of settling at the configured cap. See #314 for logs and further analysis.

Test environment:
- RTX PRO 6000 Blackwell Server Edition (188 SMs)
- Driver 580.173.02
- CUDA 13.3
- Standalone LD_PRELOAD
- GPU_CORE_UTILIZATION_POLICY=FORCE
- Separate shared cache per process
Two processes shared one GPU with caps of 30 and 70, running 4096 FP32 matrix multiplication for 240 seconds:

| build | A(30) it/s | B(70) it/s | total | device util |
|---|---|---|---|---|
| no cap | 23.1 | 23.1 | 46.2 | 98% |
| main | 21.4 | 25.2 | 46.6 | 98% |
| this change | 13.2 | 34.9 | 48.1 | 98% |

With one process capped at 10, main averaged 26.9% device utilization while userutil oscillated between 0 and 83. With this change, userutil converged within approximately 20 seconds and remained between 9 and 13, averaging 10.9%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CUDA utilization calculations to prevent overestimating core activity on devices with multiple streaming multiprocessors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->